### PR TITLE
Update Maintainers For Nexus 6, Moto G 2014, Z2, Galaxy Nexus

### DIFF
--- a/res/values/resurrection_device_maintainers_strings.xml
+++ b/res/values/resurrection_device_maintainers_strings.xml
@@ -129,7 +129,7 @@
     <string name="device_n5_summary">Hammerhead \nMaintainer - westcrip</string>
     
     <string name="device_n6">Nexus 6</string>
-    <string name="device_n6_summary">Shamu \nMaintainer - asianflavor</string>
+    <string name="device_n6_summary">Shamu \nMaintainer - varund7726</string>
         
     <string name="device_spyder">Droid RAZR</string>
     <string name="device_spyder_summary">spyder GSM-CDMA \nMaintainer - n205des</string>
@@ -175,6 +175,9 @@
     
     <string name="device_falcon">Moto G</string>
     <string name="device_falcon_summary">Falcon \nMaintainer - varund7726</string>
+    
+    <string name="device_yitan">Moto G 2014</string>
+    <string name="device_yitan_summary">Falcon \nMaintainer - varund7726</string>
  
     <string name="device_g3_tmo">LG G3 T-Mobile</string>
     <string name="device_g3_tmo_summary">D851 \nMaintainer - aclegg2011</string> 
@@ -189,5 +192,14 @@
     <string name="device_amiami_summary">Amiami \nMaintainer - OmarEinea</string>
     
     <string name="device_togari">Xperia Z Ultra</string>
-    <string name="device_togari_summary">Togari \nMaintainer - OmarEinea</string>      
-</resources>
+    <string name="device_togari_summary">Togari \nMaintainer - OmarEinea</string>
+    
+    <string name="device_sirius">Xperia Z2</string>
+    <string name="device_sirius_summary">sirius\nMaintainer - varund7726</string>  
+    
+    <string name="device_maguro">Galaxy Nexus</string>
+    <string name="device_sirius_summary">Maguro\nMaintainer - varund7726</string>
+    
+    
+    
+   </resources>

--- a/res/values/resurrection_device_maintainers_strings.xml
+++ b/res/values/resurrection_device_maintainers_strings.xml
@@ -198,7 +198,7 @@
     <string name="device_sirius_summary">sirius\nMaintainer - varund7726</string>  
     
     <string name="device_maguro">Galaxy Nexus</string>
-    <string name="device_sirius_summary">Maguro\nMaintainer - varund7726</string>
+    <string name="device_maguro_summary">Maguro\nMaintainer - varund7726</string>
     
     
     


### PR DESCRIPTION
Add Moto g 2014 Titan ,Xperia Z2 (sirius) and Galaxy Nexus(maguro) Maintainer

Update Nexus 6 Shamu Maintainer
