### PR TITLE
Fix for Hardware Buttons

### DIFF
--- a/src/com/android/settings/ButtonSettings.java
+++ b/src/com/android/settings/ButtonSettings.java
@@ -799,7 +799,7 @@ public class ButtonSettings extends SettingsPreferenceFragment implements
         Settings.System.putInt(context.getContentResolver(),
                 Settings.System.ENABLE_HW_KEYS, enabled ? 1 : 0);
         CMHardwareManager hardware = CMHardwareManager.getInstance(context);
-        hardware.set(CMHardwareManager.FEATURE_KEY_DISABLE, enabled);
+        hardware.set(CMHardwareManager.FEATURE_KEY_DISABLE, !enabled);
 
         /* Save/restore button timeouts to disable them in softkey mode */
         if (!enabled) {


### PR DESCRIPTION
The changes from the previous commit to this file is creating Hardware Key issues. The Hardware Keys (except the home button) are not working even it is enabled in the settings. 
I reverted the changes as below and tested. It is working fine.

![screenshot from 2015-08-29 14 30 58](https://cloud.githubusercontent.com/assets/3480365/9561235/a8d8a3e6-4e5a-11e5-9400-1bb8cb152024.png)
