### PR TITLE
Fixed NRE when selecting Settings -> More on S3 Neo

### DIFF
--- a/src/com/android/settings/WirelessSettings.java
+++ b/src/com/android/settings/WirelessSettings.java
@@ -333,7 +333,7 @@ public class WirelessSettings extends SettingsPreferenceFragment
 
         // Remove NFC if not available
         mNfcAdapter = NfcAdapter.getDefaultAdapter(activity);
-        if (mNfcAdapter == null) {
+        if (mNfcAdapter == null && nfcCategory != null) {
             getPreferenceScreen().removePreference(nfcCategory);
             mNfcEnabler = null;
         }


### PR DESCRIPTION
This fixes a crash of the Settings app when selecting the "More" button in the wireless category.
