### PR TITLE
Correct RU translation

### DIFF
--- a/res/values-ru/cm_strings.xml
+++ b/res/values-ru/cm_strings.xml
@@ -333,7 +333,7 @@
   <string name="battery_light_list_title">Цвета</string>
   <string name="battery_light_low_color_title">Батарея разряжена</string>
   <string name="battery_light_medium_color_title">Заряжается</string>
-  <string name="battery_light_full_color_title">Полностью заряжена</string>
+  <string name="battery_light_full_color_title">Заряжена (90%)</string>
   <string name="notification_light_title">Индикатор событий</string>
   <string name="notification_light_general_title">Общие</string>
   <string name="notification_light_applist_title">Приложения</string>


### PR DESCRIPTION
In cyanogenmod package Settings so https://github.com/CyanogenMod/android_packages_apps_Settings/blob/cm-12.1/res/values/cm_strings.xml#L465
In RR - https://github.com/ResurrectionRemix/Resurrection_packages_apps_Settings/blob/lollipop5.1/res/values/cm_strings.xml#L477
Accordingly different translation. Please add the hotfix.
