### PR TITLE
Add Nexus 9 maintainer and fix typo

### DIFF
--- a/res/values/resurrection_device_maintainers_strings.xml
+++ b/res/values/resurrection_device_maintainers_strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-   resurrection_device_maintainers_strings.xml
-   
-   Copyright 2015 Resurrection Remix ROM
+   Copyright 2016 Resurrection Remix ROM
    
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -18,334 +16,333 @@
    along with this program; if not, write to the Free Software
    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
    MA 02110-1301, USA.
-   
-   
 -->
+
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-
-    
-    <string name="device_maintainers_title">Devices and Maintainers</string>
-    <string name="device_maintainers_title_summary">List of devices and their Resurrection ROM maintainers</string>
-
-    <string name="device_category_samsung_title">SAMSUNG</string>
-    <string name="device_category_sony_title">SONY</string>
-    <string name="device_category_lg_title">LG</string>
-    <string name="device_category_htc_title">HTC</string>
-    <string name="device_category_motorola_title">MOTOROLA</string>
-    <string name="device_category_google_title">GOOGLE</string>
-    <string name="device_category_oneplus_title">ONEPLUS</string>
-    <string name="device_category_yureka_title">YU</string>
-    <string name="device_category_xiaomi_title">XIAOMI</string>
-    <string name="device_category_huawei_title">Huawei</string>	
-    <string name="device_category_asus_title">Asus</string>
-    <string name="device_category_wfx_title">WileyFox</string>
-    
-    <string name="maintainers_note_title">Note</string>
-    <string name="maintainers_note_title_summary">Send a PM to \'Varun Date\' at Hangouts containing the link to your ROM thread if you want your name to be added in Device Maintainers list.</string>
-
-    <string name="device_moto_x">Moto X 2013 </string>
-    <string name="device_moto_x_summary">Ghost \nMaintainer - </string>
-    
-    <string name="device_moto_x14">Moto X 2014</string>
-    <string name="device_moto_x14_summary">Victara \nMaintainer - Megatron007</string>
-
-    <string name="device_lux_x">Moto X Play</string>
-    <string name="device_lux_x_summary">Lux \nMaintainer - </string>
-
-    <string name="device_peregrine">Moto G LTE</string>
-    <string name="device_peregrine_summary">Peregrine \nMaintainer - </string>
-
-    <string name="device_condor">Moto E </string>
-    <string name="device_condor_summary">Condor \nMaintainer - Vatsal</string>
-
-    <string name="device_otus">Moto E 3G </string>
-    <string name="device_otus_summary">Otus \nMaintainer - Vatsal</string>
-        
-    <string name="device_oneplus">OnePlus One</string>
-    <string name="device_oneplus_summary">Bacon \nMaintainer - varund7726</string>
-
-    <string name="device_oneplus2">OnePlus Two</string>
-    <string name="device_oneplus2_summary">OnePlus 2 \nMaintainer - regalstreak</string>
-    
-    <string name="device_klte">Galaxy S5 KLTE</string>
-    <string name="device_klte_summary">KLTE \nMaintainer - </string>
-    
-    <string name="device_n9">Nexus 9</string>   
-    <string name="device_n9_summary">Flounder \nMaintainer - </string>
-         
-    <string name="device_og">LG Optimus G</string>   
-    <string name="device_og_summary">Int \nMaintainer - mordesku</string>  
-    
-    <string name="device_o4x">Optimus 4X HD</string>   
-    <string name="device_o4x_summary">Int \nMaintainer - </string>    
-
-    <string name="device_l9">Optimus L9</string>   
-    <string name="device_l9_summary">P760-P765-P768 \nMaintainer - </string>
-        
-    <string name="device_i9082">Galaxy Grand Duos</string>   
-    <string name="device_i9082_summary">GT-I9082 \nMaintainer - </string>
-        
-    <string name="device_n7000">Galaxy Note int</string>
-    <string name="device_n7000_summary">N7000 \nMaintainer - </string>
-    
-    <string name="device_n7100">Galaxy Note II int</string>
-    <string name="device_n7100_summary">N7100 \nMaintainer - </string>
-    
-    <string name="device_hlte">Galaxy Note III Qcom</string>
-    <string name="device_hlte_summary">hlte \nMaintainer - Lord Eko</string>
- 
-    <string name="device_ha3g">Galaxy Note 3 Exynos</string>
-    <string name="device_ha3g_summary">SM-N900 \nMaintainer - varund7726</string>
 	
-    <string name="device_tblte">Galaxy Note Edge</string>
-    <string name="device_tblte_summary">NoteEdge \nMaintainer - </string>
-    
-    <string name="device_trltexx">Galaxy Note 4 int Snapdragon</string>
-    <string name="device_trltexx_summary">N910F \nMaintainer - </string>
+	<string name="device_maintainers_title">Devices and Maintainers</string>
+	<string name="device_maintainers_title_summary">List of devices and their Resurrection ROM maintainers</string>
 
-    <string name="device_i9100">Galaxy S II</string>
-    <string name="device_i9100_summary">GT-I9100 \nMaintainer - varund7726</string>
-    
-    <string name="device_i9001">Galaxy S Plus</string>
-    <string name="device_i9001_summary">GT-I9001 \nMaintainer - </string> 
+	<string name="device_category_samsung_title">SAMSUNG</string>
+	<string name="device_category_sony_title">SONY</string>
+	<string name="device_category_lg_title">LG</string>
+	<string name="device_category_htc_title">HTC</string>
+	<string name="device_category_motorola_title">MOTOROLA</string>
+	<string name="device_category_google_title">GOOGLE</string>
+	<string name="device_category_oneplus_title">ONEPLUS</string>
+	<string name="device_category_yureka_title">YU</string>
+	<string name="device_category_xiaomi_title">XIAOMI</string>
+	<string name="device_category_huawei_title">Huawei</string>	
+	<string name="device_category_asus_title">Asus</string>
+	<string name="device_category_wfx_title">WileyFox</string>
+	
+	<string name="maintainers_note_title">Note</string>
+	<string name="maintainers_note_title_summary">Send a PM to \'Varun Date\' at Hangouts containing the link to your ROM thread if you want your name to be added in Device Maintainers list.</string>
 
-    <string name="device_w">Samsung Galaxy W I8150</string>
-    <string name="device_w_summary">Ancora \nMaintainer - </string> 
-           
-    <string name="device_m7">HTC One M7</string>
-    <string name="device_m7_summary">m7 \nMaintainer - </string>
+	<string name="device_moto_x">Moto X 2013</string>
+	<string name="device_moto_x_summary">Ghost \nMaintainer - </string>
+	
+	<string name="device_moto_x14">Moto X 2014</string>
+	<string name="device_moto_x14_summary">Victara \nMaintainer - Megatron007</string>
 
-    <string name="device_m8">HTC One M8</string>
-    <string name="device_m8_summary">m8 \nMaintainer - BDogg718</string>
-    
-    <string name="device_i9300">Galaxy S III</string>
-    <string name="device_i9300_summary">GT-I9300 \nMaintainer - varund7726</string>
-    
-    <string name="device_i9305">Galaxy S III LTE</string>
-    <string name="device_i9305_summary">GT-I9305 \nMaintainer - </string>
+	<string name="device_lux_x">Moto X Play</string>
+	<string name="device_lux_x_summary">Lux \nMaintainer - </string>
 
-    <string name="device_I897">Captivate</string>
-    <string name="device_I897_summary">I897 \nMaintainer - </string>
-    
-    <string name="device_i9000">Galaxy S</string>
-    <string name="device_i9000_summary">GT-I9000 \nMaintainer - rodman01</string>
-    
-    <string name="device_t959">Vibrant</string>
-    <string name="device_t959_summary">T959 \nMaintainer - </string>
-    
-    <string name="device_i9105p">Galaxy S II Plus</string>
-    <string name="device_i9105p_summary">GT-I9105P \nMaintainer - </string>
-    
-    <string name="device_att">Galaxy S II AT&amp;T</string>
-    <string name="device_att_summary">SGH-I777 \nMaintainer -</string>
-    
-    <string name="device_s3tm">Galaxy S III T-Mobile</string>
-    <string name="device_s3tm_summary">D2LTE \nMaintainer - </string>
-    
-    <string name="device_s3att">Galaxy S III AT&amp;T</string>
-    <string name="device_s3att_summary">D2LTE \nMaintainer - </string>
-    
-    <string name="device_d2spr">Galaxy S III Sprint</string>
-    <string name="device_d2spr_summary">D2SPR \nMaintainer - </string>
-    
-    <string name="device_i9305">Galaxy S III LTE</string>
-    <string name="device_i9305_summary">i9305 \nMaintainer - rodman01</string>
-    
-    <string name="device_g2">LG G2</string>
-    <string name="device_g2_summary">All variants \nMaintainer - varund7726</string> 
-    
-    <string name="device_n4">Nexus 4</string>
-    <string name="device_n4_summary">Mako \nMaintainer - rodman01</string> 
-    
-    <string name="device_n5">Nexus 5</string>
-    <string name="device_n5_summary">Hammerhead \nMaintainer - westcrip</string>
-    
-    <string name="device_n6">Nexus 6</string>
-    <string name="device_n6_summary">Shamu \nMaintainer - andrewwright</string>
-        
-    <string name="device_spyder">Droid RAZR</string>
-    <string name="device_spyder_summary">spyder GSM-CDMA \nMaintainer - </string>
-    
-    <string name="device_neov">Xperia Neo V</string>
-    <string name="device_neov_summary">Haida \nMaintainer - </string>
+	<string name="device_peregrine">Moto G LTE</string>
+	<string name="device_peregrine_summary">Peregrine \nMaintainer - </string>
 
-    <string name="device_arc">Xperia Arc</string>
-    <string name="device_arc_summary">Anzu \nMaintainer - </string>  
+	<string name="device_condor">Moto E</string>
+	<string name="device_condor_summary">Condor \nMaintainer - Vatsal</string>
 
-    <string name="device_xperial">Xperia L</string>
-    <string name="device_xperial_summary">Taoshan \nMaintainer - CodeZero</string>  
+	<string name="device_otus">Moto E 3G</string>
+	<string name="device_otus_summary">Otus \nMaintainer - Vatsal</string>
 
-    <string name="device_xperiam">Xperia M</string>
-    <string name="device_xperiam_summary">Nicki \nMaintainer - CodeZero</string>
+	<string name="device_oneplus">OnePlus One</string>
+	<string name="device_oneplus_summary">Bacon \nMaintainer - varund7726</string>
 
-    <string name="device_xperiav">Xperia V</string>
-    <string name="device_xperiav_summary">Tsubasa \nMaintainer - </string> 
+	<string name="device_oneplus2">OnePlus Two</string>
+	<string name="device_oneplus2_summary">OnePlus 2 \nMaintainer - regalstreak</string>
+	
+	<string name="device_klte">Galaxy S5 KLTE</string>
+	<string name="device_klte_summary">KLTE \nMaintainer - </string>
+	
+	<string name="device_n9">Nexus 9</string>
+	<string name="device_n9_summary">Flounder \nMaintainer - MoNTE48</string>
+ 
+	<string name="device_og">LG Optimus G</string>
+	<string name="device_og_summary">Int \nMaintainer - mordesku</string>
+	
+	<string name="device_o4x">Optimus 4X HD</string>
+	<string name="device_o4x_summary">Int \nMaintainer - </string>
 
-    <string name="device_z3c">Xperia Z3 Compact</string>
-    <string name="device_z3c_summary">Z3C \nMaintainer - </string>  
-    
-    <string name="device_maguro">Galaxy Nexus</string>
-    <string name="device_maguro_summary">Maguro \nMaintainer - </string> 
-    
-    <string name="device_toro">Galaxy Nexus CDMA</string>
-    <string name="device_toro_summary">toro \nMaintainer - </string>
-    
-    <string name="device_mega">Galaxy Mega</string>
-    <string name="device_mega_summary">GT-I9152 / GT-I9152 \nMaintainer - </string> 
-    
-    <string name="device_i9200">Galaxy Mega 6.3</string>
-    <string name="device_i9200_summary">GT-I9200  \nMaintainer - </string> 
+	<string name="device_l9">Optimus L9</string>
+	<string name="device_l9_summary">P760-P765-P768 \nMaintainer - </string>
 
-    <string name="device_s4mini">Galaxy S4 Mini</string>
-    <string name="device_s4mini_summary">GT-I9195 / GT-I9190 \nMaintainer - </string> 
-    
-    <string name="device_4x">LG Optimus 4X HD</string>
-    <string name="device_4x_summary">LG Optimus \nMaintainer - </string>
+	<string name="device_i9082">Galaxy Grand Duos</string>
+	<string name="device_i9082_summary">GT-I9082 \nMaintainer - </string>
 
-    <string name="device_i9505">Samsung Galaxy S4 LTE</string>
-    <string name="device_i9505_summary">i9505 \nMaintainer - TJSteveMX</string>
-    
-    <string name="device_jfltetmo">Samsung Galaxy S4 LTE T-Mobile</string>
-    <string name="device_jfltetmo_summary">SGH-M919 \nMaintainer - TJSteveMX</string>
-      
-    <string name="device_i9500">Samsung Galaxy S4</string>
-    <string name="device_i9500_summary">i9500 \nMaintainer - </string>
-      
-    <string name="device_n7">Nexus 7 2013</string>
-    <string name="device_n7_summary">Flo \nMaintainer - Ming3r</string>
-    
-    <string name="device_deb">Nexus 7 LTE 2013</string>
-    <string name="device_deb_summary">Deb \nMaintainer - Ming3r</string>
-    
-    <string name="device_falcon">Moto G</string>
-    <string name="device_falcon_summary">Falcon \nMaintainer - varund7726</string>
-    
-    <string name="device_titan">Moto G 2014</string>
-    <string name="device_titan_summary">Titan \nMaintainer - mrunalkaran</string>
+	<string name="device_n7000">Galaxy Note int</string>
+	<string name="device_n7000_summary">N7000 \nMaintainer - </string>
+	
+	<string name="device_n7100">Galaxy Note II int</string>
+	<string name="device_n7100_summary">N7100 \nMaintainer - </string>
+	
+	<string name="device_hlte">Galaxy Note III Qcom</string>
+	<string name="device_hlte_summary">hlte \nMaintainer - Lord Eko</string>
+ 
+	<string name="device_ha3g">Galaxy Note 3 Exynos</string>
+	<string name="device_ha3g_summary">SM-N900 \nMaintainer - varund7726</string>
+	
+	<string name="device_tblte">Galaxy Note Edge</string>
+	<string name="device_tblte_summary">NoteEdge \nMaintainer - </string>
+	
+	<string name="device_trltexx">Galaxy Note 4 int Snapdragon</string>
+	<string name="device_trltexx_summary">N910F \nMaintainer - </string>
 
-    <string name="device_osprey">Moto G 2015</string>
-    <string name="device_osprey_summary">Osprey\nMaintainer - boswelja</string>
-    
-    <string name="device_g3_tmo">LG G3 T-Mobile</string>
-    <string name="device_g3_tmo_summary">D851 \nMaintainer - Aclegg2011</string> 
-       
-    <string name="device_g3">LG G3 Int</string>
-    <string name="device_g3_summary">D855 \nMaintainer - YaDr</string> 
+	<string name="device_i9100">Galaxy S II</string>
+	<string name="device_i9100_summary">GT-I9100 \nMaintainer - varund7726</string>
+	
+	<string name="device_i9001">Galaxy S Plus</string>
+	<string name="device_i9001_summary">GT-I9001 \nMaintainer - </string>
 
-    <string name="device_g3_can">LG G3 Canada</string>
-    <string name="device_g3_can_summary">D852 \nMaintainer - YaDr</string> 
-    
-    <string name="device_att_g3">LG G3 AT&amp;T</string>
-    <string name="device_att_g3_summary">D850 \nMaintainer -  </string> 
-    
-    <string name="device_g3_kr">LG G3 Korea</string>
-    <string name="device_g3_kr_summary">F400 \nMaintainer - </string> 
-    
-    <string name="device_g4">LG G4 Int</string>
-    <string name="device_g4_summary">H815 \nMaintainer - MoNTE48</string> 
+	<string name="device_w">Samsung Galaxy W I8150</string>
+	<string name="device_w_summary">Ancora \nMaintainer - </string>
+   
+	<string name="device_m7">HTC One M7</string>
+	<string name="device_m7_summary">m7 \nMaintainer - </string>
 
-    <string name="device_honami">Xperia Z1</string>
-    <string name="device_honami_summary">Honami \nMaintainer - OmarEinea</string>
-    
-    <string name="device_amami">Xperia Z1 Compact</string>
-    <string name="device_amami_summary">Amiami \nMaintainer - OmarEinea</string>
+	<string name="device_m8">HTC One M8</string>
+	<string name="device_m8_summary">m8 \nMaintainer - BDogg718</string>
+	
+	<string name="device_i9300">Galaxy S III</string>
+	<string name="device_i9300_summary">GT-I9300 \nMaintainer - varund7726</string>
+	
+	<string name="device_i9305">Galaxy S III LTE</string>
+	<string name="device_i9305_summary">GT-I9305 \nMaintainer - </string>
 
-    <string name="device_togari">Xperia Z Ultra</string>
-    <string name="device_togari_summary">Togari \nMaintainer - OmarEinea</string>
-    
-    <string name="device_dogo">Xperia ZR</string>
-    <string name="device_dogo_summary">Dogo \nMaintainer - </string>
-    
-    <string name="device_anzu">Xperia ArC</string>
-    <string name="device_anzu_summary">Anzu\nMaintainer - </string>
+	<string name="device_I897">Captivate</string>
+	<string name="device_I897_summary">I897 \nMaintainer - </string>
+	
+	<string name="device_i9000">Galaxy S</string>
+	<string name="device_i9000_summary">GT-I9000 \nMaintainer - rodman01</string>
+	
+	<string name="device_t959">Vibrant</string>
+	<string name="device_t959_summary">T959 \nMaintainer - </string>
+	
+	<string name="device_i9105p">Galaxy S II Plus</string>
+	<string name="device_i9105p_summary">GT-I9105P \nMaintainer - </string>
+	
+	<string name="device_att">Galaxy S II AT&amp;T</string>
+	<string name="device_att_summary">SGH-I777 \nMaintainer -</string>
+	
+	<string name="device_s3tm">Galaxy S III T-Mobile</string>
+	<string name="device_s3tm_summary">D2LTE \nMaintainer - </string>
+	
+	<string name="device_s3att">Galaxy S III AT&amp;T</string>
+	<string name="device_s3att_summary">D2LTE \nMaintainer - </string>
+	
+	<string name="device_d2spr">Galaxy S III Sprint</string>
+	<string name="device_d2spr_summary">D2SPR \nMaintainer - </string>
+	
+	<string name="device_i9305">Galaxy S III LTE</string>
+	<string name="device_i9305_summary">i9305 \nMaintainer - rodman01</string>
+	
+	<string name="device_g2">LG G2</string>
+	<string name="device_g2_summary">All variants \nMaintainer - varund7726</string>
+	
+	<string name="device_n4">Nexus 4</string>
+	<string name="device_n4_summary">Mako \nMaintainer - rodman01</string>
+	
+	<string name="device_n5">Nexus 5</string>
+	<string name="device_n5_summary">Hammerhead \nMaintainer - westcrip</string>
+	
+	<string name="device_n6">Nexus 6</string>
+	<string name="device_n6_summary">Shamu \nMaintainer - andrewwright</string>
 
-    <string name="device_coconut">Xperia Live</string>
-    <string name="device_coconut_summary">Cocunut\nMaintainer - </string> 
+	<string name="device_spyder">Droid RAZR</string>
+	<string name="device_spyder_summary">spyder GSM-CDMA \nMaintainer - </string>
+	
+	<string name="device_neov">Xperia Neo V</string>
+	<string name="device_neov_summary">Haida \nMaintainer - </string>
 
-    <string name="device_hallon">Xperia Neo</string>
-    <string name="device_hallon_summary">Hallon\nMaintainer - </string> 
+	<string name="device_arc">Xperia Arc</string>
+	<string name="device_arc_summary">Anzu \nMaintainer - </string>
 
-    <string name="device_iyokan">Xperia Pro</string>
-    <string name="device_iyokan_summary">Iyokan\nMaintainer - </string> 
+	<string name="device_xperial">Xperia L</string>
+	<string name="device_xperial_summary">Taoshan \nMaintainer - CodeZero</string>
 
-    <string name="device_mango">Xperia Mini Pro</string>
-    <string name="device_mango_summary">Mango\nMaintainer - </string> 
+	<string name="device_xperiam">Xperia M</string>
+	<string name="device_xperiam_summary">Nicki \nMaintainer - CodeZero</string>
 
-    <string name="device_phoenix">Xperia Neo L</string>
-    <string name="device_phoenix_summary">Phoenix\nMaintainer - </string> 
+	<string name="device_xperiav">Xperia V</string>
+	<string name="device_xperiav_summary">Tsubasa \nMaintainer - </string>
 
-    <string name="device_satsuma">Xperia Active</string>
-    <string name="device_satsuma_summary">Satsuma\nMaintainer - </string> 
+	<string name="device_z3c">Xperia Z3 Compact</string>
+	<string name="device_z3c_summary">Z3C \nMaintainer - </string>
+	
+	<string name="device_maguro">Galaxy Nexus</string>
+	<string name="device_maguro_summary">Maguro \nMaintainer - </string>
+	
+	<string name="device_toro">Galaxy Nexus CDMA</string>
+	<string name="device_toro_summary">toro \nMaintainer - </string>
+	
+	<string name="device_mega">Galaxy Mega</string>
+	<string name="device_mega_summary">GT-I9152 / GT-I9152 \nMaintainer - </string>
+	
+	<string name="device_i9200">Galaxy Mega 6.3</string>
+	<string name="device_i9200_summary">GT-I9200  \nMaintainer - </string>
 
-    <string name="device_smultron">Xperia Mini</string>
-    <string name="device_smultron_summary">Smultron\nMaintainer - </string> 
+	<string name="device_s4mini">Galaxy S4 Mini</string>
+	<string name="device_s4mini_summary">GT-I9195 / GT-I9190 \nMaintainer - </string>
+	
+	<string name="device_4x">LG Optimus 4X HD</string>
+	<string name="device_4x_summary">LG Optimus \nMaintainer - </string>
 
-    <string name="device_urushi">Xperia Ray</string>
-    <string name="device_urushi_summary">Urushi\nMaintainer - </string> 
+	<string name="device_i9505">Samsung Galaxy S4 LTE</string>
+	<string name="device_i9505_summary">i9505 \nMaintainer - TJSteveMX</string>
+	
+	<string name="device_jfltetmo">Samsung Galaxy S4 LTE T-Mobile</string>
+	<string name="device_jfltetmo_summary">SGH-M919 \nMaintainer - TJSteveMX</string>
+	  
+	<string name="device_i9500">Samsung Galaxy S4</string>
+	<string name="device_i9500_summary">i9500 \nMaintainer - </string>
+	  
+	<string name="device_n7">Nexus 7 2013</string>
+	<string name="device_n7_summary">Flo \nMaintainer - Ming3r</string>
+	
+	<string name="device_deb">Nexus 7 LTE 2013</string>
+	<string name="device_deb_summary">Deb \nMaintainer - Ming3r</string>
+	
+	<string name="device_falcon">Moto G</string>
+	<string name="device_falcon_summary">Falcon \nMaintainer - varund7726</string>
+	
+	<string name="device_titan">Moto G 2014</string>
+	<string name="device_titan_summary">Titan \nMaintainer - mrunalkaran</string>
 
-    <string name="device_sirius">Xperia Z2</string>
-    <string name="device_sirius_summary">sirius\nMaintainer - </string>  
-    
-    <string name="device_maguro">Galaxy Nexus</string>
-    <string name="device_maguro_summary">Maguro\nMaintainer - varund7726</string>
+	<string name="device_osprey">Moto G 2015</string>
+	<string name="device_osprey_summary">Osprey\nMaintainer - boswelja</string>
+	
+	<string name="device_g3_tmo">LG G3 T-Mobile</string>
+	<string name="device_g3_tmo_summary">D851 \nMaintainer - Aclegg2011</string>
+	   
+	<string name="device_g3">LG G3 Int</string>
+	<string name="device_g3_summary">D855 \nMaintainer - YaDr</string>
 
-    <string name="device_tomato">Yu Yureka</string>
-    <string name="device_tomato_summary">Tomato\nMaintainer - DC07 </string>
-    
-    <string name="device_jalebi">Yu Yunique</string>
-    <string name="device_jalebi_summary">Jalebi\nMaintainer - DC07  </string>
+	<string name="device_g3_can">LG G3 Canada</string>
+	<string name="device_g3_can_summary">D852 \nMaintainer - YaDr</string>
+	
+	<string name="device_att_g3">LG G3 AT&amp;T</string>
+	<string name="device_att_g3_summary">D850 \nMaintainer -  </string>
+	
+	<string name="device_g3_kr">LG G3 Korea</string>
+	<string name="device_g3_kr_summary">F400 \nMaintainer - </string>
+	
+	<string name="device_g4">LG G4 Int</string>
+	<string name="device_g4_summary">H815 \nMaintainer - MoNTE48</string>
 
-    <string name="device_lettuce">Yu Yuphoria</string>
-    <string name="device_lettuce_summary">Lettuce\nMaintainer - DC07 </string>
-    
-    <string name="device_armani">Xiaomi Redmi 1S </string>
-    <string name="device_armani_summary">Armani\nMaintainer - sud.vastav</string>
+	<string name="device_honami">Xperia Z1</string>
+	<string name="device_honami_summary">Honami \nMaintainer - OmarEinea</string>
+	
+	<string name="device_amami">Xperia Z1 Compact</string>
+	<string name="device_amami_summary">Amiami \nMaintainer - OmarEinea</string>
 
-   <string name="device_cancro">Xiaomi MI 3</string>
-    <string name="device_cancro_summary">Cancro\nMaintainer - Matoxxi </string>
-    
-    <string name="device_sprout4">Android One -4GB variants(1st Gen)</string>
-    <string name="device_sprout4_summary">Sprout4\nMaintainer - Bun_Bun</string>   
-    
-    <string name="device_sprout8">Android One -8GB variants(1st Gen)</string>
-    <string name="device_sprout8_summary">Sprout8\nMaintainer - Bun_Bun</string> 
+	<string name="device_togari">Xperia Z Ultra</string>
+	<string name="device_togari_summary">Togari \nMaintainer - OmarEinea</string>
+	
+	<string name="device_dogo">Xperia ZR</string>
+	<string name="device_dogo_summary">Dogo \nMaintainer - </string>
+	
+	<string name="device_anzu">Xperia ArC</string>
+	<string name="device_anzu_summary">Anzu\nMaintainer - </string>
 
-    <string name="device_alpha">Samsung Galaxy Alpha</string>
-    <string name="device_alpha_summary">G850F\nMaintainer - sunsettrack4</string> 
-    
-    <string name="device_t0ltexx">Samsung Galaxy Note II LTE</string>
-    <string name="device_t0ltexx_summary">T0ltexx\nMaintainer-mrhainavn</string>
+	<string name="device_coconut">Xperia Live</string>
+	<string name="device_coconut_summary">Cocunut\nMaintainer - </string>
 
-    <string name="device_u9500">Huawei Ascend D1</string>
-    <string name="device_u9500_summary">U9500\nMaintainer- </string>
+	<string name="device_hallon">Xperia Neo</string>
+	<string name="device_hallon_summary">Hallon\nMaintainer - </string>
 
-    <string name="device_angler">Huawei Nexus 6p</string>
-    <string name="device_angler_summary">Angler\nMaintainer- apascual89</string>
+	<string name="device_iyokan">Xperia Pro</string>
+	<string name="device_iyokan_summary">Iyokan\nMaintainer - </string>
 
-    <string name="device_smp601">Samsung Galaxy Note 10.1 3G</string>
-    <string name="device_smp601_summary">SM-P601\nMaintainer-</string>
+	<string name="device_mango">Xperia Mini Pro</string>
+	<string name="device_mango_summary">Mango\nMaintainer - </string>
 
-    <string name="device_huashan">Sony Xperia SP</string>
-    <string name="device_huashan_summary">Huashan\nMaintainer- </string>
+	<string name="device_phoenix">Xperia Neo L</string>
+	<string name="device_phoenix_summary">Phoenix\nMaintainer - </string>
 
-    <string name="device_z00a">Asus Zenfone 2</string>
-    <string name="device_z00a_summary">Z00a\nMaintainer- Rap_Turkez </string>
+	<string name="device_satsuma">Xperia Active</string>
+	<string name="device_satsuma_summary">Satsuma\nMaintainer - </string>
 
-    <string name="device_Z008">Asus Zenfone 2</string>
-    <string name="device_Z008_summary">Z008\nMaintainer- Rap_Turkez </string>
+	<string name="device_smultron">Xperia Mini</string>
+	<string name="device_smultron_summary">Smultron\nMaintainer - </string>
 
-    <string name="device_ferrari">Xiaomi MI 4i</string>
-    <string name="device_ferrari_summary">ferrari\nMaintainer- swapnilxd</string>
+	<string name="device_urushi">Xperia Ray</string>
+	<string name="device_urushi_summary">Urushi\nMaintainer - </string>
 
-    <string name="device_redmi2">Redmi 2</string>
-    <string name="device_redmi2_summary">WT88047\nMaintainer- </string>
+	<string name="device_sirius">Xperia Z2</string>
+	<string name="device_sirius_summary">sirius\nMaintainer - </string>
+	
+	<string name="device_maguro">Galaxy Nexus</string>
+	<string name="device_maguro_summary">Maguro\nMaintainer - varund7726</string>
 
-    <string name="device_wfxs">WilleyFox Swift</string>
-    <string name="device_wfxs_summary">crackling\nMaintainer- </string>
+	<string name="device_tomato">Yu Yureka</string>
+	<string name="device_tomato_summary">Tomato\nMaintainer - DC07</string>
+	
+	<string name="device_jalebi">Yu Yunique</string>
+	<string name="device_jalebi_summary">Jalebi\nMaintainer - DC07</string>
 
-    <string name="device_quark">Moto Maxx</string>
-    <string name="device_quark_summary">Quark\nMaintainer- </string>
-    
-    <string name="device_bullhead">LGE Nexus 5x</string>
-    <string name="device_bullhead_summary">Bullhead\nMaintainer- Akhil</string>
-   </resources>
+	<string name="device_lettuce">Yu Yuphoria</string>
+	<string name="device_lettuce_summary">Lettuce\nMaintainer - DC07 </string>
+	
+	<string name="device_armani">Xiaomi Redmi 1S </string>
+	<string name="device_armani_summary">Armani\nMaintainer - sud.vastav</string>
+
+	<string name="device_cancro">Xiaomi MI 3</string>
+	<string name="device_cancro_summary">Cancro\nMaintainer - Matoxxi</string>
+	
+	<string name="device_sprout4">Android One - 4GB variants (1st Gen)</string>
+	<string name="device_sprout4_summary">Sprout4\nMaintainer - Bun_Bun</string>
+	
+	<string name="device_sprout8">Android One - 8GB variants (1st Gen)</string>
+	<string name="device_sprout8_summary">Sprout8\nMaintainer - Bun_Bun</string>
+
+	<string name="device_alpha">Samsung Galaxy Alpha</string>
+	<string name="device_alpha_summary">G850F\nMaintainer - sunsettrack4</string>
+	
+	<string name="device_t0ltexx">Samsung Galaxy Note II LTE</string>
+	<string name="device_t0ltexx_summary">T0ltexx\nMaintainer - mrhainavn</string>
+
+	<string name="device_u9500">Huawei Ascend D1</string>
+	<string name="device_u9500_summary">U9500\nMaintainer - </string>
+
+	<string name="device_angler">Huawei Nexus 6p</string>
+	<string name="device_angler_summary">Angler\nMaintainer - apascual89</string>
+
+	<string name="device_smp601">Samsung Galaxy Note 10.1 3G</string>
+	<string name="device_smp601_summary">SM-P601\nMaintainer - </string>
+
+	<string name="device_huashan">Sony Xperia SP</string>
+	<string name="device_huashan_summary">Huashan\nMaintainer - </string>
+
+	<string name="device_z00a">Asus Zenfone 2</string>
+	<string name="device_z00a_summary">Z00a\nMaintainer - Rap_Turkez</string>
+
+	<string name="device_Z008">Asus Zenfone 2</string>
+	<string name="device_Z008_summary">Z008\nMaintainer - Rap_Turkez</string>
+
+	<string name="device_ferrari">Xiaomi MI 4i</string>
+	<string name="device_ferrari_summary">ferrari\nMaintainer - swapnilxd</string>
+
+	<string name="device_redmi2">Redmi 2</string>
+	<string name="device_redmi2_summary">WT88047\nMaintainer - </string>
+
+	<string name="device_wfxs">WilleyFox Swift</string>
+	<string name="device_wfxs_summary">crackling\nMaintainer - </string>
+
+	<string name="device_quark">Moto Maxx</string>
+	<string name="device_quark_summary">Quark\nMaintainer - </string>
+	
+	<string name="device_bullhead">LGE Nexus 5x</string>
+	<string name="device_bullhead_summary">Bullhead\nMaintainer - Akhil</string>
+	
+</resources>


### PR DESCRIPTION
Nexus 9 http://forum.xda-developers.com/nexus-9/development/rom-resurrection-remix-5-6-0-flounder-t3288180
Fix typo
Spaces are replaced with Tab
Added missing gaps.
Removed extra spaces.
Fixed the register in the name of manufacturers
