### PR TITLE
Settings: remove duplicate strings

### DIFF
--- a/res/values/rr_strings.xml
+++ b/res/values/rr_strings.xml
@@ -688,10 +688,6 @@
 	<string name="lockscreen_see_through_summary">Blurs and displays the content behind your lockscreen.</string>
 	<string name="lockscreen_blur_radius">Blur effect intensity</string>
 	
-	<!-- Media art -->
-	<string name="media_art_title">Media cover art</string>
-	<string name="media_art_summary">Enable media cover art on the lockscreen</string>
-	
 	<!-- Sound settings -->
 	<string name="advanced_sound_title">Advanced options</string>
 	<string name="sound_title">Sound</string>
@@ -1077,6 +1073,12 @@
 	<string name="status_bar_carrier_size">Carrier label text size</string>	
 	<string name="custom_carrier_label_notset">Custom label currently not set</string>
 	<string name="status_bar_carrier_color">Carrier label color</string>
+
+	<string name="show_carrier_title">Carrier label</string>
+	<string name="show_carrier_disabled">Disabled</string>
+	<string name="show_carrier_keyguard">Keyguard carrier</string>
+	<string name="show_carrier_statusbar">Status bar carrier</string>
+	<string name="show_carrier_enabled">Enabled</string>
 	
 	<!-- Statusbar RR logo -->
 	<string name="status_bar_logo">Resurrection logo</string>
@@ -1102,20 +1104,6 @@
 	<!-- Headphones icon switch -->
 	<string name="show_headset_icon_title">Headset icon</string>
 	<string name="show_headset_icon_summary">Shows icon when headsets are connected.</string>
-	
-	
-	<!-- Carrier Label -->
-	<string name="carrier_options">Carrier Label</string>
-	<string name="custom_carrier_label_title">Custom carrier label</string>
-	<string name="custom_carrier_label_explain">Please enter a new label. Leave blank to revert to stock label.</string>
-	<string name="custom_carrier_label_notset">Custom label currently not set</string>
-	<string name="status_bar_carrier_color">Carrier label color</string>
-	<string name="show_carrier_title">Carrier label</string>
-	<string name="show_carrier_disabled">Disabled</string>
-	<string name="show_carrier_keyguard">Keyguard carrier</string>
-	<string name="show_carrier_statusbar">Status bar carrier</string>
-	<string name="show_carrier_enabled">Enabled</string>
-	
 	
 	<!-- Disabling FC notifications -->
 	<string name="disable_fc_notifications_title">Disable FC Notifications</string>
@@ -1195,15 +1183,6 @@
 	<string name="status_bar_date_format_custom">Custom java format</string>
 	<string name="status_bar_date_string_edittext_title">Must be in DateFormat eg. MM/dd/yy</string>
 	<string name="status_bar_date_string_edittext_summary">Enter string</string>
-	
-	<!-- Sound settings -->
-	<string name="advanced_sound_title">Advanced Sound </string>
-	<string name="sound_title">Sound</string>
-	
-	<!-- Camera sound switch -->
-	<string name="camera_sounds_title">Camera shutter sound</string>
-	<string name="camera_sounds_summary">Enable system camera shutter sound</string>
-	<string name="camera_sound_warning_dialog_text">Disabling the camera shutter sound is illegal in some areas! Please check the applicable law in your country</string>
 	
 	<!-- Slim Recents -->	
 	<string name="slim_recents_panel">Slim Recents</string>


### PR DESCRIPTION
Remove duplicate strings from rr_strings.xml (latest [@b6f2fcf](https://github.com/ResurrectionRemix/Resurrection_packages_apps_Settings/blob/b6f2fcf981648abc2caffe17f0fe2aae7c7ac067/res/values/rr_strings.xml) ).
- media_art_title : L661, ~~L692~~
- media_art_summary : L661, ~~L692~~
- carrier_options : L1072, ~~L1108~~
- custom_carrier_label_title : L1075,  ~~L1109~~
- custom_carrier_label_explain : L1076,  ~~L1110~~
- custom_carrier_label_notset : L1078,  ~~L1111~~
- status_bar_carrier_color : L1079, ~~L1112~~
- advanced_sound_title ~ camera_sound_warning_dialog_text : L691-698, ~~L1199-1206~~
