### PR TITLE
Fix tag mismatch in Russian rr_strings.xml file

### DIFF
--- a/res/values-ru/rr_strings.xml
+++ b/res/values-ru/rr_strings.xml
@@ -1936,7 +1936,7 @@
   	
   	<string name="pulse_custom_div">Интервал</string>
   	<string name="default_div">По умолчанию</string>
-  	string name="pulse_custom_dimen_cat">Настроить размеры  блоков спектра. Также настроить расстояние между ними</string>
+  	<string name="pulse_custom_dimen_cat">Настроить размеры  блоков спектра. Также настроить расстояние между ними</string>
   	<string name="pulse_block_category">Блоки панели Пульс</string>
   	<string name="pulse_custom_dimen_category">Расстояние</string>
   	<string name="pulse_block_category_title">Размер</string>


### PR DESCRIPTION
Please take a look at the changes before merging any commits. I wasn't able to compile any builds due to these translation errors. You can check xml files by using Google Chrome - an error appears when there's a tag mismatch. Thanks. :)
