### PR TITLE
fix: Apostrophe not preceded by \

### DIFF
--- a/res/values-it/rr_strings.xml
+++ b/res/values-it/rr_strings.xml
@@ -574,7 +574,7 @@
     <!-- Label, prompt asking the user to enter the name of the gesture -->
     <string name="ga_prompt_gesture_name">Nome</string>
     <!-- Error message, informs the user he needs to enter a name before saving a gesture -->
-    <string name="ga_error_missing_name">E' necessario inserire un nome</string>
+    <string name="ga_error_missing_name">E\' necessario inserire un nome</string>
     <!-- success message, tells the user where the gesture was saved -->
     <string name="ga_save_success">Gesto salvato in %s</string>
     <!-- Buttons in Rename gesture dialog box -->
@@ -1561,7 +1561,7 @@
 	<string name="notification_bg_guts_color_title">Sfondo delle notifiche su una pressione prolungata</string>
 	<string name="notification_app_icon_bg_color_title">Sfondo icona App</string>
 	<string name="notification_color_mode_never_title">Mai</string>
-	<string name="notification_icon_color_mode_greyscale_title">Se l\'icona è un'icona in scala di grigi</string>
+	<string name="notification_icon_color_mode_greyscale_title">Se l\'icona è un\'icona in scala di grigi</string>
 	<string name="notification_bg_color_mode_no_color_title">Se la notifica non include un proprio colore</string>
 	<string name="notification_color_mode_always_title">Sempre</string>
 	<string name="notif_color_switch">Colori Notifiche</string>
@@ -2083,7 +2083,7 @@
       <string name="floating_master_switch">Interruttore principale</string>
       <string name="floating_additional_options">Opzioni aggiuntive Float</string>
       <string name="floating_windows">Finestra fluttuante</string>
-      <string name="floating_windows_switch">Se consente l'uso globale della modalità fluttuante, se questo è fuori nessuna delle opzioni di seguito funzionerà DUH!!!</string>
+      <string name="floating_windows_switch">Se consente l\'uso globale della modalità fluttuante, se questo è fuori nessuna delle opzioni di seguito funzionerà DUH!!!</string>
       <string name="slim_action_floats">Azioni Slim &amp; Pie</string>
       <string name="slim_action_floats_summary">Lanciare Slim &amp; azioni Pie in modalità mobile</string>
       <string name="gesture_anywhere_floating">Gesti ovunque</string>


### PR DESCRIPTION
**not having this caused build error as below...**

packages/apps/Settings/res/values-it/rr_strings.xml:577: error: Apostrophe not preceded by \ (in E' necessario inserire un nome)

packages/apps/Settings/res/values-it/rr_strings.xml:1564: error: Apostrophe not preceded by \ (in Se l\'icona è un'icona in scala di grigi)

packages/apps/Settings/res/values-it/rr_strings.xml:2086: error: Apostrophe not preceded by \ (in Se consente l'uso globale della modalità fluttuante, se questo è fuori nessuna delle opzioni di seguito funzionerà DUH!!!)

nothing matches overlay file activities_icon.png, for flavor 
make: **\* [/home/ashish/WORK_RR/out/target/common/obj/APPS/Settings_intermediates/src/R.stamp] Error 1
