### PR TITLE
remove "Battery fully charged notification" switch from display tab

### DIFF
--- a/res/xml/display.xml
+++ b/res/xml/display.xml
@@ -175,12 +175,6 @@
     <PreferenceCategory
             android:key="lights"
             android:title="@string/category_lights">
-      
-        <!-- Battery fully charged notification -->
-        <com.android.settings.cyanogenmod.SystemSettingSwitchPreference
-        android:key="battery_fully_charged_notification"
-        android:title="@string/battery_fully_charged_notif_title"
-        android:summary="@string/battery_fully_charged_notif_summary" />
 
         <!-- Battery light -->
         <PreferenceScreen


### PR DESCRIPTION
it is already there in notifiactions tab

Signed-off-by: sayeed99 sayeed.afridi2009@gmail.com
