### PR TITLE
rr_arrays: Remove "s" from keyboard rotation timeout entries

### DIFF
--- a/res/values/rr_arrays.xml
+++ b/res/values/rr_arrays.xml
@@ -917,12 +917,12 @@
 
     <!-- Auto keyboard rotation -->
     <string-array name="keyboard_rotation_timeout_entries" translatable="false">
-        <item>2s</item>
-        <item>5s</item>
-        <item>10s</item>
-        <item>20s</item>
-        <item>30s</item>
-        <item>60s</item>
+        <item>2</item>
+        <item>5</item>
+        <item>10</item>
+        <item>20</item>
+        <item>30</item>
+        <item>60</item>
     </string-array>
 
     <string-array name="keyboard_rotation_timeout_values" translatable="false">


### PR DESCRIPTION
because: https://github.com/ResurrectionRemix/Resurrection_packages_apps_Settings/blob/1a74d43ee1387b179fca5c4570c3cc1de103b80c/res/values/rr_strings.xml#L1273

```
Disables auto-rotate sensor <xliff:g id="rotate_timeout">%1$s</xliff:g> seconds after keyboard is hidden
```

You can see on your device:

> Disables auto-rotate sensor **5s seconds** after keyboard is hidden

Many `values-{LANG}/rr_strings.xml` include translation of "seconds" , so we must change `values/rr_arrays.xml` side.

This commit will fix this issue.
