### PR TITLE
Fix typo of string about Kernel Adiutor

### DIFF
--- a/res/values/rr_strings.xml
+++ b/res/values/rr_strings.xml
@@ -450,8 +450,8 @@
 	<string name="clock_font_size_22">22</string>
 	<string name="clock_font_size_23">23</string>
 	
-	<!--Performance/Kernel Aduitor-->
-	<string name="kernel_aduitor">Performance</string>
+	<!--Performance/Kernel Adiutor-->
+	<string name="kernel_adiutor">Performance</string>
 	
 	<!-- Lock screen rotation -->
 	<string name="display_lockscreen_rotation_title">Lock screen</string>

--- a/res/xml/dashboard_categories.xml
+++ b/res/xml/dashboard_categories.xml
@@ -327,7 +327,7 @@
         </dashboard-tile>
     <dashboard-tile
 		android:id="@+id/kernel_adiutor"
-                android:title="@string/kernel_aduitor"
+                android:title="@string/kernel_adiutor"
 		android:icon="@drawable/rr_performance_icon">
  	<intent
                     android:action="android.intent.action.MAIN"


### PR DESCRIPTION
- KenrelAdiutor is Ad **iu** tor, not Ad **ui** tor.
  - https://github.com/Grarak/KernelAdiutor
  - https://play.google.com/store/apps/details?id=com.grarak.kerneladiutor
- This patch will affect **all** translations
