### PR TITLE
Fix "Batteryu" typo

### DIFF
--- a/res/values/rr_strings.xml
+++ b/res/values/rr_strings.xml
@@ -1836,7 +1836,7 @@
 	<string name="hide_panel_ampm_summary_off">Am/Pm Hidden</string>
 	
 	<string name="hide_battery_summary_on">Battery Visible</string>	
-	<string name="hide_battery_summary_off">Batteryu Hidden</string>
+	<string name="hide_battery_summary_off">Battery Hidden</string>
 	<string name="hide_icons_summary_on">System Icons Visible</string>	
 	<string name="hide_icons_summary_off">System Icons Hidden</string>
 


### PR DESCRIPTION
Fixed a typo under Notification drawer > Notification header > Header items
