### PR TITLE
Add maintainers for Redmi 3S/3X/Prime

### DIFF
--- a/res/values/resurrection_device_maintainers_strings.xml
+++ b/res/values/resurrection_device_maintainers_strings.xml
@@ -416,6 +416,9 @@
     <string name="device_redmi3">Xiaomi Redmi 3</string>
 	<string name="device_redmi3_summary">ido\nMaintainer - WinKarbik</string>
 
+        <string name="device_land">Xiaomi Redmi 3S/3X/Prime</string>
+	<string name="device_land_summary">land\nMaintainer - Hriday Sharma(HridayHS), Sai Vishal(DroidThug)</string>
+
 	<string name="device_wfxs">WilleyFox Swift</string>
 	<string name="device_wfxs_summary">crackling\nMaintainer - </string>
 

--- a/res/xml/device_maintainers_fragment.xml
+++ b/res/xml/device_maintainers_fragment.xml
@@ -676,6 +676,12 @@
        android:summary="@string/device_redmi3_summary"
        android:selectable="false" 
        android:title="@string/device_redmi3" />
+    <Preference
+       android:id="@+id/device_land"
+       android:icon="@drawable/phone_tint"
+       android:summary="@string/device_land_summary"
+       android:selectable="false" 
+       android:title="@string/device_land" />
        </PreferenceCategory>
 
 <PreferenceCategory


### PR DESCRIPTION
* Redmi 3S/3X/Prime series have same codename(land).
* RR-MM boots on all of these series.
