### PR TITLE
Settings: Set root access options appropriately

### DIFF
--- a/res/values/cm_arrays.xml
+++ b/res/values/cm_arrays.xml
@@ -30,6 +30,16 @@
         <item>3</item>
     </string-array>
 
+    <string-array name="root_access_entries_adb" translatable="false">
+        <item>@string/root_access_none</item>
+        <item>@string/root_access_adb</item>
+    </string-array>
+
+    <string-array name="root_access_values_adb" translatable="false">
+        <item>0</item>
+        <item>2</item>
+    </string-array>
+
     <!-- Names of categories of app ops tabs - extension of AOSP -->
     <string-array name="app_ops_categories_cm" translatable="false">
         <item>@string/app_ops_categories_location</item>

--- a/res/xml/development_prefs.xml
+++ b/res/xml/development_prefs.xml
@@ -114,9 +114,7 @@
     <ListPreference
         android:key="root_access"
         android:title="@string/root_access"
-        android:persistent="false"
-        android:entries="@array/root_access_entries"
-        android:entryValues="@array/root_access_values" />
+        android:persistent="false" />
 
     <Preference
         android:key="root_appops"

--- a/src/com/android/settings/DevelopmentSettings.java
+++ b/src/com/android/settings/DevelopmentSettings.java
@@ -97,6 +97,8 @@ import com.android.settingslib.RestrictedSwitchPreference;
 
 import cyanogenmod.providers.CMSettings;
 
+import org.cyanogenmod.internal.util.FileUtils;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -560,6 +562,13 @@ public class DevelopmentSettings extends RestrictedSettingsFragment
         mRootAppops.setOnPreferenceClickListener(this);
 
         if (!removeRootOptionsIfRequired()) {
+            if (FileUtils.fileExists("/system/xbin/su")) {
+                mRootAccess.setEntries(R.array.root_access_entries);
+                mRootAccess.setEntryValues(R.array.root_access_values);
+            } else {
+                mRootAccess.setEntries(R.array.root_access_entries_adb);
+                mRootAccess.setEntryValues(R.array.root_access_values_adb);
+            }
             mAllPrefs.add(mRootAccess);
             mAllPrefs.add(mRootAppops);
         }


### PR DESCRIPTION
It is possible to be running a user build with a debuggable boot image.
In this case, "su" will not be available.  So only show none/adb.

Issue-Id: BACON-4461
Change-Id: Iaa7df8311b9ea81eabb1566ba6f9159fdc9fab34
Signed-off-by: Pafcholini <nadyaivanova14@gmail.com>