### PR TITLE
DeviceInfoSettings: use "ro.maintainer"

### DIFF
--- a/src/com/android/settings/DeviceInfoSettings.java
+++ b/src/com/android/settings/DeviceInfoSettings.java
@@ -137,7 +137,7 @@ public class DeviceInfoSettings extends SettingsPreferenceFragment implements In
         setValueSummary(KEY_MOD_BUILD_DATE, "ro.build.date");
         findPreference(KEY_BUILD_NUMBER).setEnabled(true);
         setValueSummary(KEY_BUILD_TYPE, "rr.build.type");
-        setValueSummary(KEY_MAINTAINER, "ro.build.user");
+        setValueSummary(KEY_MAINTAINER, "ro.maintainer");
         setValueSummary(KEY_MOD_VERSION, "ro.modversion");
         findPreference(KEY_MOD_VERSION).setEnabled(true);
         findPreference(KEY_BUILD_TYPE).setEnabled(true);


### PR DESCRIPTION
I think it is better to use a new prop such as "ro.maintainer" so maintainers could easily add "PRODUCT_PROPERTY_OVERRIDES += ro.maintainer=blablabla" to system_prop.mk of their device trees.