### PR TITLE
Fix TaskManager Running services [2/2]

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1051,6 +1051,24 @@
                 android:value="true" />
         </activity>
 
+        <!-- Provide direct entry into Dev settings - Running Services -->
+        <activity android:name="Settings$DevRunningServicesActivity"
+                android:label="@string/runningservices_settings_title"
+                android:excludeFromRecents="true"
+                android:taskAffinity="com.android.settings"
+                android:parentActivityName="Settings">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.MONKEY" />
+                <category android:name="android.intent.category.VOICE_LAUNCH" />
+            </intent-filter>
+            <meta-data android:name="com.android.settings.FRAGMENT_CLASS"
+                android:value="com.android.settings.applications.RunningServices" />
+            <meta-data android:name="com.android.settings.PRIMARY_PROFILE_CONTROLLED"
+                android:value="true" />
+        </activity>
+
         <activity android:name="Settings$DeviceInfoSettingsActivity"
                 android:theme="@style/Theme.SubSettingsDialogWhenLarge"
                 android:label="@string/device_info_settings"

--- a/src/com/android/settings/Settings.java
+++ b/src/com/android/settings/Settings.java
@@ -179,4 +179,5 @@ public class Settings extends SettingsActivity {
     public static class GestrueAnywhereActivity extends SettingsActivity { /* empty */ }
     public static class AppSidebarActivity extends SettingsActivity { /* empty */ }
     public static class AppCircleBarActivity extends SettingsActivity { /* empty */ }
+    public static class DevRunningServicesActivity extends SettingsActivity { /* empty */ }
 }

--- a/src/com/android/settings/SettingsActivity.java
+++ b/src/com/android/settings/SettingsActivity.java
@@ -71,6 +71,7 @@ import com.android.settings.applications.ManageDomainUrls;
 import com.android.settings.applications.NotificationApps;
 import com.android.settings.applications.ProcessStatsSummary;
 import com.android.settings.applications.ProcessStatsUi;
+import com.android.settings.applications.RunningServices;
 import com.android.settings.applications.UsageAccessDetails;
 import com.android.settings.applications.VrListenerSettings;
 import com.android.settings.applications.WriteSettingsDetails;
@@ -287,6 +288,7 @@ public class SettingsActivity extends SettingsDrawerActivity
             Settings.PrintSettingsActivity.class.getName(),
             Settings.PaymentSettingsActivity.class.getName(),
             Settings.TimerSwitchSettingsActivity.class.getName(),
+            Settings.DevRunningServicesActivity.class.getName(),
     };
 
     private static final String[] ENTRY_FRAGMENTS = {
@@ -395,7 +397,8 @@ public class SettingsActivity extends SettingsDrawerActivity
             MasterClear.class.getName(),
             NightDisplaySettings.class.getName(),
             ManageDomainUrls.class.getName(),
-            AutomaticStorageManagerSettings.class.getName()
+            AutomaticStorageManagerSettings.class.getName(),
+            RunningServices.class.getName(),
     };
 
 


### PR DESCRIPTION
Instead of RunningServicesActivity, we now fetch from DevRunningServicesActivity

Picked up from https://github.com/AICP/packages_apps_Settings/commit/eeedc0114eda47200d3a6b4b2dec907c63c1805b
Credits: @ezio84 for the original piece of code.

[1/2] is in FWB.

Change-Id: I725d0d5ef946a876e1099cc2941bdd0e608678de
Signed-off-by: Ashok Soni <ashok.soni@gmail.com>