### PR TITLE
Settings: Set correct default value to In-call DND switch

### DIFF
--- a/res/xml/rr_misc.xml
+++ b/res/xml/rr_misc.xml
@@ -61,7 +61,8 @@
             android:key="dnd_when_call"
             android:title="@string/dnd_when_call_title"
             android:icon="@drawable/rr_dnd_icon"
-            android:summary="@string/dnd_when_call_summary" />
+            android:summary="@string/dnd_when_call_summary"
+            android:defaultValue="true" />
 
         <!-- Weather Settings -->
         <Preference


### PR DESCRIPTION
This comes enabled by default, but the switch will show that it's disable,
making the necessary to enable, then disable to have the disable effect

Signed-off-by: Felipe Leon <fglfgl27@gmail.com>