### PR TITLE
Add Maintainer for Nexus 9, Nexus 10, Moto X Pure, LG G2, Galaxy S3 (all variants), and Touchpad to the mix

### DIFF
--- a/res/values/resurrection_device_maintainers_strings.xml
+++ b/res/values/resurrection_device_maintainers_strings.xml
@@ -184,9 +184,6 @@
 	<string name="device_i9300">Galaxy S III</string>
 	<string name="device_i9300_summary">GT-I9300 \nMaintainer - Varun Date</string>
 	
-	<string name="device_i9300">Galaxy S III</string>
-        <string name="device_i9300_summary">All d2lte variants \nMaintainer - sixohtew</string>
-	
 	<string name="device_a7">Galaxy A7 2014</string>
 	<string name="device_a7_summary">SM-A700FD\nMaintainer -</string>
 
@@ -204,9 +201,6 @@
 	
 	<string name="device_att">Galaxy S II AT&amp;T</string>
 	<string name="device_att_summary">SGH-I777 \nMaintainer - </string>
-  
-	<string name="device_i9300">Galaxy S III LTE</string>
-  <string name="device_i9300_summary">GT-i9300 \nMaintainer - sixohtew</string>
 
   <string name="device_i9305">Galaxy S III LTE</string>
   <string name="device_i9305_summary">GT-I9305 \nMaintainer - rodman01</string>

--- a/res/values/resurrection_device_maintainers_strings.xml
+++ b/res/values/resurrection_device_maintainers_strings.xml
@@ -39,8 +39,9 @@
 	<string name="device_category_bq_title">BQ</string>
 	<string name="device_category_leeco_title">LeEco</string>
 	<string name="device_category_zuk_title">ZUK</string>
-    <string name="device_category_nubia_title">Nubia</string>
-    <string name="device_category_vega_title">Vega</string>
+	<string name="device_category_HP_title">HP</string>
+        <string name="device_category_nubia_title">Nubia</string>
+        <string name="device_category_vega_title">Vega</string>
 	
 	<string name="device_A7010a48">Lenovo Vibe K4 Note</string>
 	<string name="device_A7010a48_summary">A7010a48\nMaintainer - Mohan Cm (mohancm100)</string>
@@ -64,7 +65,7 @@
 	<string name="device_moto_x14_summary">Victara \nMaintainer - Megatron007</string>
 
 	<string name="device_moto_x_clark">Moto X 2015</string>
-	<string name="device_moto_x_clark_summary">Clark \nMaintainer - </string>
+	<string name="device_moto_x_clark_summary">Clark \nMaintainer - sixohtew</string>
 
 	<string name="device_lux_x">Moto X Play</string>
 	<string name="device_lux_x_summary">Lux \nMaintainer - GtrCraft</string>
@@ -109,7 +110,10 @@
 	<string name="device_klte_summary">All klte variants \nMaintainer - ScrawnyB</string>
 	
 	<string name="device_n9">Nexus 9</string>
-	<string name="device_n9_summary">Flounder \nMaintainer -</string>
+	<string name="device_n9_summary">Flounder \nMaintainer - sixohtew</string>
+	
+	<string name="device_n10">Nexus 10</string>
+	<string name="device_n10_summary">Manta \nMaintainer - sixohtew</string>
  
 	<string name="device_og">LG Optimus G</string>
 	<string name="device_og_summary">Int \nMaintainer - </string>
@@ -180,6 +184,9 @@
 	<string name="device_i9300">Galaxy S III</string>
 	<string name="device_i9300_summary">GT-I9300 \nMaintainer - Varun Date</string>
 	
+	<string name="device_i9300">Galaxy S III</string>
+        <string name="device_i9300_summary">All d2lte variants \nMaintainer - sixohtew</string>
+	
 	<string name="device_a7">Galaxy A7 2014</string>
 	<string name="device_a7_summary">SM-A700FD\nMaintainer -</string>
 
@@ -197,15 +204,6 @@
 	
 	<string name="device_att">Galaxy S II AT&amp;T</string>
 	<string name="device_att_summary">SGH-I777 \nMaintainer - </string>
-	
-	<string name="device_s3tm">Galaxy S III T-Mobile</string>
-	<string name="device_s3tm_summary">D2LTE \nMaintainer - </string>
-	
-	<string name="device_s3att">Galaxy S III AT&amp;T</string>
-	<string name="device_s3att_summary">D2LTE \nMaintainer - </string>
-	
-	<string name="device_d2spr">Galaxy S III Sprint</string>
-	<string name="device_d2spr_summary">D2SPR \nMaintainer - </string>
 	
         <string name="device_i9305">Galaxy S III LTE</string>
         <string name="device_i9305_summary">GT-I9305 \nMaintainer - rodman01</string>
@@ -302,6 +300,9 @@
 	
 	<string name="device_harpia">Moto G4 Play</string>
 	<string name="device_harpia_summary">Harpia \nMaintainer - SubhrajyotiSen</string>
+	
+	<string name="device_g2">LG G2 Verizon</string>
+	<string name="device_g2_summary">vs980 \nMaintainer - sixohtew</string>
 	
 	<string name="device_g3_tmo">LG G3 T-Mobile</string>
 	<string name="device_g3_tmo_summary">D851 \nMaintainer - Aclegg2011 </string>
@@ -477,7 +478,8 @@
 	<string name="device_T00F">Asus Zenfone 5</string>
 	<string name="device_T00F_summary">T00F\nMaintainer - Roman "tank0412" Buhtiarov</string>
 	
-	
+	<string name="device_tenderloin">HP Touchpad</string>
+        <string name="device_tenderloin_summary">Tenderloin\nMaintainer - sixohtew</string>
 
 	<string name="device_ferrari">Xiaomi MI 4i</string>
 	<string name="device_ferrari_summary">ferrari\nMaintainer - haikalizz</string>

--- a/res/values/resurrection_device_maintainers_strings.xml
+++ b/res/values/resurrection_device_maintainers_strings.xml
@@ -64,7 +64,7 @@
 	<string name="device_moto_x14">Moto X 2014</string>
 	<string name="device_moto_x14_summary">Victara \nMaintainer - Megatron007</string>
 
-	<string name="device_moto_x_clark">Moto X 2015</string>
+	<string name="device_moto_x_clark">Moto X Pure/Style 2015</string>
 	<string name="device_moto_x_clark_summary">Clark \nMaintainer - sixohtew</string>
 
 	<string name="device_lux_x">Moto X Play</string>

--- a/res/xml/device_maintainers_fragment.xml
+++ b/res/xml/device_maintainers_fragment.xml
@@ -39,6 +39,13 @@
         android:summary="@string/device_g4_summary"
         android:selectable="false" 
         android:title="@string/device_g4" />
+	   
+    <Preference
+        android:id="@+id/device_g2"
+        android:icon="@drawable/phone_tint"
+        android:summary="@string/device_g2_summary"
+        android:selectable="false" 
+        android:title="@string/device_g2" />
     
     <Preference
         android:id="@+id/device_g3"
@@ -300,6 +307,20 @@
     <PreferenceCategory
         android:id="@+id/device_category_samsung"
         android:title="@string/device_category_samsung_title" >
+	    
+     <Preference
+        android:id="@+id/device_manta"
+        android:icon="@drawable/phone_tint"
+        android:summary="@string/device_manta_summary"
+        android:selectable="false" 
+        android:title="@string/device_manta" />
+	    
+     <Preference
+        android:id="@+id/device_d2lte"
+        android:icon="@drawable/phone_tint"
+        android:summary="@string/device_d2lte_summary"
+        android:selectable="false" 
+        android:title="@string/device_d2lte" />
 
      <Preference
         android:id="@+id/device_herolte"
@@ -331,12 +352,6 @@
         android:summary="@string/device_i9305_summary"
         android:selectable="false" 
         android:title="@string/device_i9305" />
-   <Preference
-        android:id="@+id/device_d2spr"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_d2spr_summary"
-        android:selectable="false" 
-        android:title="@string/device_d2spr" />
     <Preference
         android:id="@+id/device_jf"
         android:icon="@drawable/phone_tint"
@@ -507,6 +522,7 @@
         android:summary="@string/device_flounder_summary"
         android:selectable="false" 
         android:title="@string/device_flounder" />
+	     
   <Preference
         android:id="@+id/device_m9"
         android:icon="@drawable/phone_tint"
@@ -537,6 +553,19 @@
         android:summary="@string/device_google_marlin_summary"
         android:selectable="false" 
         android:title="@string/device_google_marlin" />
+   
+     </PreferenceCategory>
+	
+     <PreferenceCategory
+        android:id="@+id/device_category_hp"
+        android:title="@string/device_category_hp_title" >
+		     
+     <Preference
+	android:id="@+id/device_tenderloin"
+	android:icon="@drawable/phone_tint"
+	android:summary="@string/device_tenderloin_summary"
+	android:selectable="false"
+	android:title="@string/device_tenderloin" />
               
      </PreferenceCategory>
               


### PR DESCRIPTION
Flounder, Manta, Clark, VS980, D2LTE, and Tenderloin need maintainer updates