### PR TITLE
Transfer maintainership of Galaxy S7 series to schwabe93

### DIFF
--- a/res/values/resurrection_device_maintainers_strings.xml
+++ b/res/values/resurrection_device_maintainers_strings.xml
@@ -200,10 +200,10 @@
   <string name="device_i9100_summary">GT-I9100 \nMaintainer - GreekDragon </string>
 
   <string name="device_herolte">Galaxy S7</string>
-  <string name="device_herolte_summary">SM-G930F/FD/W8/S/K/L \nMaintainer - Jesse Chan </string>
+  <string name="device_herolte_summary">SM-G930F/FD/W8/S/K/L \nMaintainer - schwabe93 </string>
 
   <string name="device_hero2lte">Galaxy S7 edge</string>
-  <string name="device_hero2lte_summary">SM-G935F/FD/W8/S/K/L \nMaintainer - Sascha Nesterovic </string>
+  <string name="device_hero2lte_summary">SM-G935F/FD/W8/S/K/L \nMaintainer - schwabe93 </string>
 
   <string name="device_fortuna3g">Galaxy Grand Prime</string>
   <string name="device_fortuna3g_summary">SM-G530H \nMaintainer - Hassan Sardar</string>


### PR DESCRIPTION
s/"Jesse Chan"/"schwabe93"/

As I am too busy to properly and actively maintain Galaxy S7 series
at this moment, maintainership will be transferred to schwabe93.

This transfer could be either temporarily or permanently, depends on
my later *real-life* schedule.