### PR TITLE
Fix translate

### DIFF
--- a/res/values-ru/rr_strings.xml
+++ b/res/values-ru/rr_strings.xml
@@ -1712,9 +1712,9 @@
   <string name="show_su_indicator_title">Индикатор суперпользователя</string>
   <string name="show_su_indicator_summary">Показывать индикатор суперпользователя, когда сессия активна</string>
   <!-- Pie -->
-  <string name="pie_enable_title">Включить PIE-управление</string>
+  <string name="pa_pie_control_title">PIE управление</string>
   <string name="pie_settings">Настройки PIE</string>
-  <string name="pie_enable_title">Включить PIE-управление</string>
+  <string name="pie_enable_title">Включить PIE управление</string>
   <string name="pie_settings_summary">Настройте PIE как вам нравится</string>
   <string name="pie_theme_mode_title">Тема</string>
   <string name="pie_auto">Автоматически</string>


### PR DESCRIPTION
Hello. Incorrectly displays the translation.
![1](https://user-images.githubusercontent.com/10572914/31318409-a4059ab2-ac5a-11e7-83f8-b72634349660.jpg)


My patch fixes this
![2 2](https://user-images.githubusercontent.com/10572914/31318407-9a9ab958-ac5a-11e7-9147-29f3616bb149.png)