### PR TITLE
remove RedMi3 (ido) maintainer

### DIFF
--- a/res/values/resurrection_device_maintainers_strings.xml
+++ b/res/values/resurrection_device_maintainers_strings.xml
@@ -590,7 +590,7 @@
   <string name="device_redmi2_summary">wt88047\nMaintainer - nicknitewolf </string>
 
   <string name="device_redmi3">Xiaomi Redmi 3</string>
-  <string name="device_redmi3_summary">ido\nMaintainer - kmahyyg </string>
+  <string name="device_redmi3_summary">ido\nMaintainer - </string>
 
   <string name="device_land">Xiaomi Redmi 3s</string>
   <string name="device_land_summary">land\nMaintainer - Saicharan </string>


### PR DESCRIPTION
Because of free-falling, my ido is dead. The factory won't repair it and
needs a lot of money. Sorry for all of them!

Revert "Add maintainer for Xiaomi RedMi 3 (#817)"

This reverts commit 809857c5b5618b791d2a34b165e1d7cd3c19e386.