### PR TITLE
Fixes typo in Clock & Date

### DIFF
--- a/res/values/rr_strings.xml
+++ b/res/values/rr_strings.xml
@@ -1723,7 +1723,7 @@
     <string name="clock_date_date_style_lowercase">Lowercase</string>
     <string name="clock_date_date_style_uppercase">Uppercase</string>
     <string name="clock_date_date_size_small_title">Small</string>
-    <string name="clock_date_date_size_small_summary">Enabe to display the date small sized</string>
+    <string name="clock_date_date_size_small_summary">Enable to display the date small sized</string>
     <string name="status_bar_clock_font_size_title">Font size</string>
 
     <!-- Dynamic Navbar -->


### PR DESCRIPTION
This is just a small typo I noticed when digging through the settings.  The "Small" setting in Clock & Date had a description that read "Enabe to display the date small sized."  I simply changed it to read "Enable"