### PR TITLE
Capitalize Smart Pulldown settings

### DIFF
--- a/res/values/rr_strings.xml
+++ b/res/values/rr_strings.xml
@@ -311,10 +311,10 @@
 
     <!-- Smart pulldown-->
     <string name="smart_pulldown_title">Smart pulldown</string>
-    <string name="smart_pulldown_off">off</string>
-    <string name="smart_pulldown_none">no notifications</string>
-    <string name="smart_pulldown_dismissable">no dismissable notifications</string>
-    <string name="smart_pulldown_ongoing">no ongoing notifications</string>
+    <string name="smart_pulldown_off">Off</string>
+    <string name="smart_pulldown_none">No notifications</string>
+    <string name="smart_pulldown_dismissable">No dismissable notifications</string>
+    <string name="smart_pulldown_ongoing">No ongoing notifications</string>
     <string name="smart_pulldown_summary">Open quick settings when there are %1$s</string>
     <string name="smart_pulldown_none_summary">Open quick settings when there are no notifications</string>
     <string name="smart_pulldown_off_summary">is turned off</string>


### PR DESCRIPTION
This just capitalizes the Smart Pulldown settings. The current options looked a little out of place and unfinished being all lowercase.