### PR TITLE
Mark a few Strings as untranslatable

### DIFF
--- a/res/values/rr_strings.xml
+++ b/res/values/rr_strings.xml
@@ -35,17 +35,17 @@
     <!-- About RR -->
     <string name="about_rr_settings">About</string>
     <string name="about_rr">About</string>
-    <string name="about_rr_summary">@null</string>
+    <string name="about_rr_summary"  translatable="false">@null</string>
     <string name="about_r0m_summary">Everything about the Resurrection Remix OS</string>
     <string name="rr_donate">Donate to development</string>
     <string name="rr_donate_summary">Show your support to Resurrection Remix OS</string>
     <string name="app_name">Resurrection Remix OS</string>
     <string name="devs">Dev Tag</string>
-    <string name="github_westcrip">https://github.com/westcripp</string>
-    <string name="github_varund7726">https://github.com/varund7726</string>
-    <string name="github_akhilnarang">https://github.com/akhilnarang</string>
-    <string name="github_bdogg718k">https://github.com/bdogg718k</string>
-    <string name="github_apascual89">https://github.com/apascual89</string> 
+    <string name="github_westcrip"  translatable="false">https://github.com/westcripp</string>
+    <string name="github_varund7726"  translatable="false">https://github.com/varund7726</string>
+    <string name="github_akhilnarang"  translatable="false">https://github.com/akhilnarang</string>
+    <string name="github_bdogg718k"  translatable="false">https://github.com/bdogg718k</string>
+    <string name="github_apascual89"  translatable="false">https://github.com/apascual89</string> 
     <string name="rr">Links</string>
     <string name="rr_website_title">Website</string>
     <string name="rr_website_summary">Get more information about Resurrection Remix OS</string>
@@ -465,10 +465,10 @@
     <!-- Color Picker -->
     <string name="dialog_color_picker">Color Picker</string>
     <string name="press_color_to_apply">Press on color below to apply</string>
-    <string name="arrow_right">→</string>
-    <string name="arrow_down">↓</string>
+    <string name="arrow_right" translatable="false">→</string>
+    <string name="arrow_down"  translatable="false">↓</string>
     <string name="hex">Hex:</string>
-    <string name="hex_hint">#ff000000</string>
+    <string name="hex_hint"  translatable="false">#ff000000</string>
     <string name="set">Set</string>
     <string name="color_default">Default</string>
 


### PR DESCRIPTION
It doesn't make sense to translate `@null`, URLs, color codes or arrow signs. This prevents mistakes by translators and reduces the sizes of the localized resource files