### PR TITLE
Refactor device maintainer fragment

### DIFF
--- a/res/drawable/tablet_tint.xml
+++ b/res/drawable/tablet_tint.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="@color/rr_config_icon_tint"
+        android:pathData="M21,4L3,4c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h18c1.1,0 1.99,-0.9 1.99,-2L23,6c0,-1.1 -0.9,-2 -2,-2zM19,18L5,18L5,6h14v12z"/>
+</vector>

--- a/res/values/resurrection_device_maintainers_strings.xml
+++ b/res/values/resurrection_device_maintainers_strings.xml
@@ -45,652 +45,868 @@
   <string name="device_category_vega_title">Vega</string>
   <string name="device_category_jiayu_title">Jiayu</string>
   <string name="device_category_nextbit_title">Nextbit</string>
-  
-  <string name="device_a610">ZTE BLADE A610</string>
-  <string name="device_a610_summary">a610\nMaintainer - Roman Yukovsky (mosya234)</string>  
- 
-  <string name="device_nextbit_ether">Nextbit Robin</string>
-  <string name="device_nextbit_ether_summary">Ether\nMaintainer - Røbin</string>
 
-  <string name="device_aio_row">Lenovo A7000-a</string>
-  <string name="device_aio_row_summary">aio_row\nMaintainer - Rohan Taneja (rohantaneja)</string>
+  <string name="device_a610" translatable="false">ZTE BLADE A610</string>
+  <string name="device_a610_codename" translatable="false">a610</string>
+  <string name="device_a610_maintainer" translatable="false">Roman Yukovsky (mosya234)</string>
 
-  <string name="device_aio_otfp">Lenovo K3 Note</string>
-  <string name="device_aio_otfp_summary">aio_otfp\nMaintainer - Ninad Patil (PainKiller3)</string>
+  <string name="device_nextbit_ether" translatable="false">Nextbit Robin</string>
+  <string name="device_nextbit_ether_codename" translatable="false">Ether</string>
+  <string name="device_nextbit_ether_maintainer" translatable="false">Røbin</string>
 
-  <string name="device_A7010a48">Lenovo Vibe K4 Note</string>
-  <string name="device_A7010a48_summary">A7010a48\nMaintainer - Mohan Cm (mohancm100)</string>
+  <string name="device_aio_row" translatable="false">Lenovo A7000-a</string>
+  <string name="device_aio_row_codename" translatable="false">aio_row</string>
+  <string name="device_aio_row_maintainer" translatable="false">Rohan Taneja (rohantaneja)</string>
 
-  <string name="device_K33">Lenovo K6 Power</string>
-  <string name="device_K33_summary">K33\nMaintainer - Techno (mohit sethi)</string>
-   
-  <string name="device_CP8676_I02">Coolpad Note 3</string>
-  <string name="device_CP8676_I02_summary">CP8676_I02\nMaintainer - Mohan Cm (mohancm100)</string>
+  <string name="device_aio_otfp" translatable="false">Lenovo K3 Note</string>
+  <string name="device_aio_otfp_codename" translatable="false">aio_otfp</string>
+  <string name="device_aio_otfp_maintainer" translatable="false">Ninad Patil (PainKiller3)</string>
 
-  <string name="device_CP8298_I00">Coolpad Note 3 Lite</string>
-  <string name="device_CP8298_I00_summary">CP8298_I00\nMaintainer - Sayan Biwas (SamGrande)</string>
+  <string name="device_A7010a48" translatable="false">Lenovo Vibe K4 Note</string>
+  <string name="device_A7010a48_codename" translatable="false">A7010a48</string>
+  <string name="device_A7010a48_maintainer" translatable="false">Mohan Cm (mohancm100)</string>
 
-  <string name="device_s3_h560">Jiayu S3</string>
-  <string name="device_s3_h560_summary">s3_h560\nMaintainer - Evgeniy Mineev (sandstranger)</string>
+  <string name="device_K33" translatable="false">Lenovo K6 Power</string>
+  <string name="device_K33_codename" translatable="false">K33</string>
+  <string name="device_K33_maintainer" translatable="false">Techno (mohit sethi)</string>
 
-  <string name="device_A6020">Vibe K5</string>
-  <string name="device_A6020_summary">A6020\nMaintainer -</string>
+  <string name="device_CP8676_I02" translatable="false">Coolpad Note 3</string>
+  <string name="device_CP8676_I02_codename" translatable="false">CP8676_I02</string>
+  <string name="device_CP8676_I02_maintainer" translatable="false">Mohan Cm (mohancm100)</string>
 
-  <string name="device_a6000">Lenovo A6000</string>
-  <string name="device_a6000_summary">a6000\nMaintainer - Hassan Sardar (Has.007)</string>
+  <string name="device_CP8298_I00" translatable="false">Coolpad Note 3 Lite</string>
+  <string name="device_CP8298_I00_codename" translatable="false">CP8298_I00</string>
+  <string name="device_CP8298_I00_maintainer" translatable="false">Sayan Biwas (SamGrande)</string>
 
-  <string name="device_p2a42">Lenovo P2</string>
-  <string name="device_p2a42_summary">p2a42\nMaintainer - Vedat Ak (Incredible)</string>
+  <string name="device_s3_h560" translatable="false">Jiayu S3</string>
+  <string name="device_s3_h560_codename" translatable="false">s3_h560</string>
+  <string name="device_s3_h560_maintainer" translatable="false">Evgeniy Mineev (sandstranger)</string>
 
-  <string name="device_ms013g">Grand 2 SM-G7102</string>
-  <string name="device_ms013g_summary">ms013g\nMaintainer - </string>
+  <string name="device_A6020" translatable="false">Vibe K5</string>
+  <string name="device_A6020_codename" translatable="false">A6020</string>
+  <string name="device_A6020_maintainer" translatable="false"></string>
 
-  <string name="device_moto_x">Moto X 2013</string>
-  <string name="device_moto_x_summary">Ghost\nMaintainer - </string>
+  <string name="device_a6000" translatable="false">Lenovo A6000</string>
+  <string name="device_a6000_codename" translatable="false">a6000</string>
+  <string name="device_a6000_maintainer" translatable="false">Hassan Sardar (Has.007)</string>
 
-  <string name="device_moto_x14">Moto X 2014</string>
-  <string name="device_moto_x14_summary">Victara\nMaintainer - Megatron007</string>
+  <string name="device_p2a42" translatable="false">Lenovo P2</string>
+  <string name="device_p2a42_codename" translatable="false">p2a42</string>
+  <string name="device_p2a42_maintainer" translatable="false">Vedat Ak (Incredible)</string>
 
-  <string name="device_moto_x_clark">Moto X Pure/Style 2015</string>
-  <string name="device_moto_x_clark_summary">Clark\nMaintainer - sixohtew</string>
+  <string name="device_ms013g" translatable="false">Grand 2 SM-G7102</string>
+  <string name="device_ms013g_codename" translatable="false">ms013g</string>
+  <string name="device_ms013g_maintainer" translatable="false"></string>
 
-  <string name="device_lux_x">Moto X Play</string>
-  <string name="device_lux_x_summary">Lux\nMaintainer - GtrCraft</string>
+  <string name="device_moto_x" translatable="false">Moto X 2013</string>
+  <string name="device_moto_x_codename" translatable="false">Ghost</string>
+  <string name="device_moto_x_maintainer" translatable="false"></string>
 
-  <string name="device_peregrine">Moto G LTE</string>
-  <string name="device_peregrine_summary">Peregrine\nMaintainer - Hasan Okarci</string>
+  <string name="device_moto_x14" translatable="false">Moto X 2014</string>
+  <string name="device_moto_x14_codename" translatable="false">Victara</string>
+  <string name="device_moto_x14_maintainer" translatable="false">Megatron007</string>
 
-  <string name="device_merlin">Moto G Turbo Edition</string>
-  <string name="device_merlin_summary">Merlin\nMaintainer - Abhinai Sanka</string>
+  <string name="device_moto_x_clark" translatable="false">Moto X Pure/Style 2015</string>
+  <string name="device_moto_x_clark_codename" translatable="false">Clark</string>
+  <string name="device_moto_x_clark_maintainer" translatable="false">sixohtew</string>
 
-  <string name="device_condor">Moto E</string>
-  <string name="device_condor_summary">Condor\nMaintainer - Dashaanan</string>
+  <string name="device_lux_x" translatable="false">Moto X Play</string>
+  <string name="device_lux_x_codename" translatable="false">Lux</string>
+  <string name="device_lux_x_maintainer" translatable="false">GtrCraft</string>
 
-  <string name="device_thea">Moto G 2014 LTE</string>
-  <string name="device_thea_summary">Thea\nMaintainer - j144df</string>
+  <string name="device_peregrine" translatable="false">Moto G LTE</string>
+  <string name="device_peregrine_codename" translatable="false">Peregrine</string>
+  <string name="device_peregrine_maintainer" translatable="false">Hasan Okarci</string>
 
-  <string name="device_potter">Moto G5 Plus</string>
-  <string name="device_potter_summary">Potter\nMaintainer - Henrique Silva (jhenrique09)</string>
+  <string name="device_merlin" translatable="false">Moto G Turbo Edition</string>
+  <string name="device_merlin_codename" translatable="false">Merlin</string>
+  <string name="device_merlin_maintainer" translatable="false">Abhinai Sanka</string>
 
-  <string name="device_sanders">Moto G5S Plus</string>
-  <string name="device_sanders_summary">sanders\nMaintainer - Keertesh </string>
+  <string name="device_condor" translatable="false">Moto E</string>
+  <string name="device_condor_codename" translatable="false">Condor</string>
+  <string name="device_condor_maintainer" translatable="false">Dashaanan</string>
 
-  <string name="device_otus">Moto E 2015 3G</string>
-  <string name="device_otus_summary">Otus\nMaintainer - Hamza Badar</string>
+  <string name="device_thea" translatable="false">Moto G 2014 LTE</string>
+  <string name="device_thea_codename" translatable="false">Thea</string>
+  <string name="device_thea_maintainer" translatable="false">j144df</string>
 
-  <string name="device_surnia">Moto E 2015 4G</string>
-  <string name="device_surnia_summary">Surnia\nMaintainer - El Dainosor</string>
+  <string name="device_potter" translatable="false">Moto G5 Plus</string>
+  <string name="device_potter_codename" translatable="false">Potter</string>
+  <string name="device_potter_maintainer" translatable="false">Henrique Silva (jhenrique09)</string>
 
-  <string name="device_taido_row">Moto E3 Power</string>
-  <string name="device_taido_row_summary">Taido_row\nMaintainer - Samar Vispute(SamarV-121)</string>
-   
-  <string name="device_oneplus">OnePlus One</string>
-  <string name="device_oneplus_summary">Bacon\nMaintainer - Varun Date</string>
+  <string name="device_sanders" translatable="false">Moto G5S Plus</string>
+  <string name="device_sanders_codename" translatable="false">sanders</string>
+  <string name="device_sanders_maintainer" translatable="false">Keertesh </string>
 
-  <string name="device_find7">OPPO</string>
-  <string name="device_find7_summary">Find 7\nMaintainer - Opposeeker</string>
+  <string name="device_otus" translatable="false">Moto E 2015 3G</string>
+  <string name="device_otus_codename" translatable="false">Otus</string>
+  <string name="device_otus_maintainer" translatable="false">Hamza Badar</string>
 
-  <string name="device_find7a">OPPO</string>
-  <string name="device_find7a_summary">Find 7a\nMaintainer - Opposeeker</string>
+  <string name="device_surnia" translatable="false">Moto E 2015 4G</string>
+  <string name="device_surnia_codename" translatable="false">Surnia</string>
+  <string name="device_surnia_maintainer" translatable="false">El Dainosor</string>
 
-  <string name="device_r7plus">OPPO</string>
-  <string name="device_r7plus_summary">R7plus\nMaintainer - Pixelfreak2005</string>
+  <string name="device_taido_row" translatable="false">Moto E3 Power</string>
+  <string name="device_taido_row_codename" translatable="false">Taido_row</string>
+  <string name="device_taido_row_maintainer" translatable="false">Samar Vispute(SamarV-121)</string>
 
-  <string name="device_oneplus2">OnePlus Two</string>
-  <string name="device_oneplus2_summary">OnePlus 2\nMaintainer - Shreesha Murthy</string>
+  <string name="device_oneplus" translatable="false">OnePlus One</string>
+  <string name="device_oneplus_codename" translatable="false">Bacon</string>
+  <string name="device_oneplus_maintainer" translatable="false">Varun Date</string>
 
-  <string name="device_oneplus3">OnePlus 3/3t[Unified]</string>
-  <string name="device_oneplus3_summary">oneplus3\nMaintainer Akhil Narang</string>
+  <string name="device_find7" translatable="false">OPPO</string>
+  <string name="device_find7_codename" translatable="false">Find 7</string>
+  <string name="device_find7_maintainer" translatable="false">Opposeeker</string>
 
-  <string name="device_oneplus5t">OnePlus 5T</string>
-  <string name="device_oneplus5t_summary">dumpling\nMaintainer Varun Date</string>
+  <string name="device_find7a" translatable="false">OPPO</string>
+  <string name="device_find7a_codename" translatable="false">Find 7a</string>
+  <string name="device_find7a_maintainer" translatable="false">Opposeeker</string>
 
-  <string name="device_oneplus5">OnePlus 5</string>
-  <string name="device_oneplus5_summary">cheeseburger\nMaintainer Varun Date</string>
+  <string name="device_r7plus" translatable="false">OPPO</string>
+  <string name="device_r7plus_codename" translatable="false">R7plus</string>
+  <string name="device_r7plus_maintainer" translatable="false">Pixelfreak2005</string>
 
-  <string name="device_klte">Galaxy S5</string>
-  <string name="device_klte_summary">All klte variants\nMaintainer - ScrawnyB</string>
-  
-  <string name="device_k3gxx">Galaxy S5</string>
-  <string name="device_k3gxx_summary">K3gxx\nMaintainer - HunnyMadaan</string>
+  <string name="device_oneplus2" translatable="false">OnePlus Two</string>
+  <string name="device_oneplus2_codename" translatable="false">OnePlus 2</string>
+  <string name="device_oneplus2_maintainer" translatable="false">Shreesha Murthy</string>
 
-  <string name="device_n9">Nexus 9</string>
-  <string name="device_n9_summary">Flounder\nMaintainer - sixohtew</string>
+  <string name="device_oneplus3" translatable="false">OnePlus 3/3t[Unified]</string>
+  <string name="device_oneplus3_codename" translatable="false">oneplus3</string>
+  <string name="device_oneplus3_maintainer" translatable="false">Akhil Narang</string>
 
-  <string name="device_n10">Nexus 10</string>
-  <string name="device_n10_summary">Manta\nMaintainer - sixohtew</string>
+  <string name="device_oneplus5t" translatable="false">OnePlus 5T</string>
+  <string name="device_oneplus5t_codename" translatable="false">dumpling</string>
+  <string name="device_oneplus5t_maintainer" translatable="false">Varun Date</string>
 
-  <string name="device_og">LG Optimus G</string>
-  <string name="device_og_summary">Int\nMaintainer - </string>
+  <string name="device_oneplus5" translatable="false">OnePlus 5</string>
+  <string name="device_oneplus5_codename" translatable="false">cheeseburger</string>
+  <string name="device_oneplus5_maintainer" translatable="false">Varun Date</string>
 
-  <string name="device_o4x">Optimus 4X HD</string>
-  <string name="device_o4x_summary">Int\nMaintainer - </string>
+  <string name="device_klte" translatable="false">Galaxy S5</string>
+  <string name="device_klte_codename" translatable="false">All klte variants</string>
+  <string name="device_klte_maintainer" translatable="false">ScrawnyB</string>
 
-  <string name="device_l9">Optimus L9</string>
-  <string name="device_l9_summary">P760-P765-P768\nMaintainer - </string>
+  <string name="device_k3gxx" translatable="false">Galaxy S5</string>
+  <string name="device_k3gxx_codename" translatable="false">K3gxx</string>
+  <string name="device_k3gxx_maintainer" translatable="false">HunnyMadaan</string>
 
-  <string name="device_sltexx">Samsung Galaxy Alpha</string>
-  <string name="device_sltexx_summary">SM-G850F\nMaintainer - Jan-Luca Neumann (sunsettrack4)</string>
+  <string name="device_n9" translatable="false">Nexus 9</string>
+  <string name="device_n9_codename" translatable="false">Flounder</string>
+  <string name="device_n9_maintainer" translatable="false">sixohtew</string>
 
-  <string name="device_serrano3gxx">Galaxy S4 Mini</string>
-  <string name="device_serrano3gxx_summary">GT-I9190\nMaintainer - PRAViN PRAJAPATI (Harvey_Spectar)</string>
+  <string name="device_n10" translatable="false">Nexus 10</string>
+  <string name="device_n10_codename" translatable="false">Manta</string>
+  <string name="device_n10_maintainer" translatable="false">sixohtew</string>
 
-  <string name="device_serranodsdd">Galaxy S4 Mini</string>
-  <string name="device_serranodsdd_summary">GT-I9192\nMaintainer - PRAViN PRAJAPATI (Harvey_Spectar)</string>
+  <string name="device_og" translatable="false">LG Optimus G</string>
+  <string name="device_og_codename" translatable="false">Int</string>
+  <string name="device_og_maintainer" translatable="false"></string>
 
-  <string name="device_serranoltexx">Galaxy S4 Mini</string>
-  <string name="device_serranoltexx_summary">GT-I9195\nMaintainer - PRAViN PRAJAPATI (Harvey_Spectar)</string>
+  <string name="device_o4x" translatable="false">Optimus 4X HD</string>
+  <string name="device_o4x_codename" translatable="false">Int</string>
+  <string name="device_o4x_maintainer" translatable="false"></string>
 
-  <string name="device_i9082">Galaxy Grand Duos</string>
-  <string name="device_i9082_summary">GT-I9082\nMaintainer - </string>
+  <string name="device_l9" translatable="false">Optimus L9</string>
+  <string name="device_l9_codename" translatable="false">P760-P765-P768</string>
+  <string name="device_l9_maintainer" translatable="false"></string>
 
-  <string name="device_n7000">Galaxy Note int</string>
-  <string name="device_n7000_summary">N7000\nMaintainer - Benjamin Bois</string>
+  <string name="device_sltexx" translatable="false">Samsung Galaxy Alpha</string>
+  <string name="device_sltexx_codename" translatable="false">SM-G850F</string>
+  <string name="device_sltexx_maintainer" translatable="false">Jan-Luca Neumann (sunsettrack4)</string>
 
-  <string name="device_n7100">Galaxy Note II int</string>
-  <string name="device_n7100_summary">N7100\nMaintainer - Hibin Maheendran </string>
+  <string name="device_serrano3gxx" translatable="false">Galaxy S4 Mini</string>
+  <string name="device_serrano3gxx_codename" translatable="false">GT-I9190</string>
+  <string name="device_serrano3gxx_maintainer" translatable="false">PRAViN PRAJAPATI (Harvey_Spectar)</string>
 
-  <string name="device_hlte">Galaxy Note III Qcom</string>
-  <string name="device_hlte_summary">hlte\nMaintainer - Jagrav Naik</string>
+  <string name="device_serranodsdd" translatable="false">Galaxy S4 Mini</string>
+  <string name="device_serranodsdd_codename" translatable="false">GT-I9192</string>
+  <string name="device_serranodsdd_maintainer" translatable="false">PRAViN PRAJAPATI (Harvey_Spectar)</string>
 
-  <string name="device_ha3g">Galaxy Note 3 Exynos</string>
-  <string name="device_ha3g_summary">SM-N900\nMaintainer - Mountaser Halak</string>
+  <string name="device_serranoltexx" translatable="false">Galaxy S4 Mini</string>
+  <string name="device_serranoltexx_codename" translatable="false">GT-I9195</string>
+  <string name="device_serranoltexx_maintainer" translatable="false">PRAViN PRAJAPATI (Harvey_Spectar)</string>
 
-  <string name="device_tblte">Galaxy Note Edge</string>
-  <string name="device_tblte_summary">NoteEdge\nMaintainer - micky387</string>
+  <string name="device_i9082" translatable="false">Galaxy Grand Duos</string>
+  <string name="device_i9082_codename" translatable="false">GT-I9082</string>
+  <string name="device_i9082_maintainer" translatable="false"></string>
 
-  <string name="device_trltexx">Galaxy Note 4 int Snapdragon</string>
-  <string name="device_trltexx_summary">N910F\nMaintainer - Mobspyguy</string>
+  <string name="device_n7000" translatable="false">Galaxy Note int</string>
+  <string name="device_n7000_codename" translatable="false">N7000</string>
+  <string name="device_n7000_maintainer" translatable="false">Benjamin Bois</string>
 
-  <string name="device_treltexx">Galaxy Note 4 Exynos</string>
-   <string name="device_treltexx_summary">N910C/H\nMaintainer - </string>
+  <string name="device_n7100" translatable="false">Galaxy Note II int</string>
+  <string name="device_n7100_codename" translatable="false">N7100</string>
+  <string name="device_n7100_maintainer" translatable="false">Hibin Maheendran </string>
 
-  <string name="device_greatlte">Samsung Galaxy Note 8</string>
-  <string name="device_greatlte_summary">greatlte\nMaintainer - Sascha Nesterovic (SaschaNes)</string>
-   
-  <string name="device_i9100">Galaxy S II</string>
-  <string name="device_i9100_summary">GT-I9100\nMaintainer - GreekDragon </string>
+  <string name="device_hlte" translatable="false">Galaxy Note III Qcom</string>
+  <string name="device_hlte_codename" translatable="false">hlte</string>
+  <string name="device_hlte_maintainer" translatable="false">Jagrav Naik</string>
 
-  <string name="device_herolte">Galaxy S7</string>
-  <string name="device_herolte_summary">SM-G930F/FD/W8/S/K/L\nMaintainer - schwabe93 </string>
+  <string name="device_ha3g" translatable="false">Galaxy Note 3 Exynos</string>
+  <string name="device_ha3g_codename" translatable="false">SM-N900</string>
+  <string name="device_ha3g_maintainer" translatable="false">Mountaser Halak</string>
 
-  <string name="device_hero2lte">Galaxy S7 edge</string>
-  <string name="device_hero2lte_summary">SM-G935F/FD/W8/S/K/L\nMaintainer - Ivan Meler</string>
+  <string name="device_tblte" translatable="false">Galaxy Note Edge</string>
+  <string name="device_tblte_codename" translatable="false">NoteEdge</string>
+  <string name="device_tblte_maintainer" translatable="false">micky387</string>
 
-  <string name="device_dreamlte">Galaxy S8</string>
-  <string name="device_dreamlte_summary">SM-G950F/FD/N\nMaintainer - Vaughn</string>
+  <string name="device_trltexx" translatable="false">Galaxy Note 4 int Snapdragon</string>
+  <string name="device_trltexx_codename" translatable="false">N910F</string>
+  <string name="device_trltexx_maintainer" translatable="false">Mobspyguy</string>
 
-  <string name="device_dream2lte">Galaxy S8+</string>
-  <string name="device_dream2lte_summary">SM-G955F/FD/N\nMaintainer - Fevax</string>
+  <string name="device_treltexx" translatable="false">Galaxy Note 4 Exynos</string>
+  <string name="device_treltexx_codename" translatable="false">N910C/H</string>
+  <string name="device_treltexx_maintainer" translatable="false"></string>
 
-  <string name="device_fortuna3g">Galaxy Grand Prime</string>
-  <string name="device_fortuna3g_summary">SM-G530H\nMaintainer - Hassan Sardar</string>
+  <string name="device_greatlte" translatable="false">Samsung Galaxy Note 8</string>
+  <string name="device_greatlte_codename" translatable="false">greatlte</string>
+  <string name="device_greatlte_maintainer" translatable="false">Sascha Nesterovic (SaschaNes)</string>
 
-  <string name="device_fortunave3g">Galaxy Grand Prime</string>
-  <string name="device_fortunave3g_summary">SM-G530H\nMaintainer - Hassan Sardar</string>
+  <string name="device_i9100" translatable="false">Galaxy S II</string>
+  <string name="device_i9100_codename" translatable="false">GT-I9100</string>
+  <string name="device_i9100_maintainer" translatable="false">GreekDragon </string>
 
-  <string name="device_fortunafz">Galaxy Grand Prime</string>
-  <string name="device_fortunafz_summary">SM-G530FZ\nMaintainer - Hassan Sardar</string>
+  <string name="device_herolte" translatable="false">Galaxy S7</string>
+  <string name="device_herolte_codename" translatable="false">SM-G930F/FD/W8/S/K/L</string>
+  <string name="device_herolte_maintainer" translatable="false">schwabe93 </string>
 
-  <string name="device_grandprimeve3g">Galaxy Grand Prime VE</string>
-  <string name="device_grandprimeve3g_summary">SM-G531H\nMaintainer - Hassan Sardar</string>
+  <string name="device_hero2lte" translatable="false">Galaxy S7 edge</string>
+  <string name="device_hero2lte_codename" translatable="false">SM-G935F/FD/W8/S/K/L</string>
+  <string name="device_hero2lte_maintainer" translatable="false">Ivan Meler</string>
 
-  <string name="device_j5ltexx">Galaxy J5</string>
-  <string name="device_j5ltexx_summary">SM-J500F/FN/M/G/Y/H\nMaintainer - Dyneteve </string>
+  <string name="device_dreamlte" translatable="false">Galaxy S8</string>
+  <string name="device_dreamlte_codename" translatable="false">SM-G950F/FD/N</string>
+  <string name="device_dreamlte_maintainer" translatable="false">Vaughn</string>
 
-  <string name="device_i9001">Galaxy S Plus</string>
-  <string name="device_i9001_summary">GT-I9001\nMaintainer - </string>
+  <string name="device_dream2lte" translatable="false">Galaxy S8+</string>
+  <string name="device_dream2lte_codename" translatable="false">SM-G955F/FD/N</string>
+  <string name="device_dream2lte_maintainer" translatable="false">Fevax</string>
 
-  <string name="device_w">Samsung Galaxy W I8150</string>
-  <string name="device_w_summary">Ancora\nMaintainer - </string>
+  <string name="device_fortuna3g" translatable="false">Galaxy Grand Prime</string>
+  <string name="device_fortuna3g_codename" translatable="false">SM-G530H</string>
+  <string name="device_fortuna3g_maintainer" translatable="false">Hassan Sardar</string>
 
-  <string name="device_m7">HTC One M7</string>
-  <string name="device_m7_summary">m7\nMaintainer - </string>
+  <string name="device_fortunave3g" translatable="false">Galaxy Grand Prime</string>
+  <string name="device_fortunave3g_codename" translatable="false">SM-G530H</string>
+  <string name="device_fortunave3g_maintainer" translatable="false">Hassan Sardar</string>
 
-  <string name="device_m8">HTC One M8</string>
-  <string name="device_m8_summary">m8\nMaintainer - BDogg718</string>
+  <string name="device_fortunafz" translatable="false">Galaxy Grand Prime</string>
+  <string name="device_fortunafz_codename" translatable="false">SM-G530FZ</string>
+  <string name="device_fortunafz_maintainer" translatable="false">Hassan Sardar</string>
 
-  <string name="device_m9">HTC One M9</string>
-  <string name="device_m9_summary">M9\nMaintainer - </string>
+  <string name="device_grandprimeve3g" translatable="false">Galaxy Grand Prime VE</string>
+  <string name="device_grandprimeve3g_codename" translatable="false">SM-G531H</string>
+  <string name="device_grandprimeve3g_maintainer" translatable="false">Hassan Sardar</string>
 
-  <string name="device_htc_10">HTC 10</string>
-  <string name="device_htc_10_summary">10\nMaintainer - tabp0le</string>
+  <string name="device_j5ltexx" translatable="false">Galaxy J5</string>
+  <string name="device_j5ltexx_codename" translatable="false">SM-J500F/FN/M/G/Y/H</string>
+  <string name="device_j5ltexx_maintainer" translatable="false">Dyneteve </string>
 
-  <string name="device_google_marlin">Pixel XL</string>
-  <string name="device_google_marlin_summary">marlin\nMaintainer - BDogg718</string>
+  <string name="device_i9001" translatable="false">Galaxy S Plus</string>
+  <string name="device_i9001_codename" translatable="false">GT-I9001</string>
+  <string name="device_i9001_maintainer" translatable="false"></string>
 
-  <string name="device_axon7">ZTE Axon7</string>
-  <string name="device_axon7_summary">Axon7\nMaintainer - Twilighttony</string>
+  <string name="device_w" translatable="false">Samsung Galaxy W I8150</string>
+  <string name="device_w_codename" translatable="false">Ancora</string>
+  <string name="device_w_maintainer" translatable="false"></string>
 
-  <string name="device_i9300">Galaxy S III</string>
-  <string name="device_i9300_summary">GT-I9300\nMaintainer - </string>
+  <string name="device_m7" translatable="false">HTC One M7</string>
+  <string name="device_m7_codename" translatable="false">m7</string>
+  <string name="device_m7_maintainer" translatable="false"></string>
 
-  <string name="device_a7">Galaxy A7 2014</string>
-  <string name="device_a7_summary">SM-A700FD\nMaintainer -</string>
+  <string name="device_m8" translatable="false">HTC One M8</string>
+  <string name="device_m8_codename" translatable="false">m8</string>
+  <string name="device_m8_maintainer" translatable="false">BDogg718</string>
 
-  <string name="device_I897">Captivate</string>
-  <string name="device_I897_summary">I897\nMaintainer - </string>
+  <string name="device_m9" translatable="false">HTC One M9</string>
+  <string name="device_m9_codename" translatable="false">M9</string>
+  <string name="device_m9_maintainer" translatable="false"></string>
 
-  <string name="device_i9000">Galaxy S</string>
-  <string name="device_i9000_summary">GT-I9000\nMaintainer - </string>
+  <string name="device_htc_10" translatable="false">HTC 10</string>
+  <string name="device_htc_10_codename" translatable="false">10</string>
+  <string name="device_htc_10_maintainer" translatable="false">tabp0le</string>
 
-  <string name="device_manta">Samsung Nexus 10</string>
-  <string name="device_manta_summary">Manta\nMaintainer - sixohtew</string>
+  <string name="device_google_marlin" translatable="false">Pixel XL</string>
+  <string name="device_google_marlin_codename" translatable="false">marlin</string>
+  <string name="device_google_marlin_maintainer" translatable="false">BDogg718</string>
 
-  <string name="device_t959">Vibrant</string>
-  <string name="device_t959_summary">T959\nMaintainer - </string>
+  <string name="device_axon7" translatable="false">ZTE Axon7</string>
+  <string name="device_axon7_codename" translatable="false">Axon7</string>
+  <string name="device_axon7_maintainer" translatable="false">Twilighttony</string>
 
-  <string name="device_i9105p">Galaxy S II Plus</string>
-  <string name="device_i9105p_summary">GT-I9105P\nMaintainer - </string>
+  <string name="device_i9300" translatable="false">Galaxy S III</string>
+  <string name="device_i9300_codename" translatable="false">GT-I9300</string>
+  <string name="device_i9300_maintainer" translatable="false"></string>
 
-  <string name="device_att">Galaxy S II AT&amp;T</string>
-  <string name="device_att_summary">SGH-I777\nMaintainer - </string>
+  <string name="device_a7" translatable="false">Galaxy A7 2014</string>
+  <string name="device_a7_codename" translatable="false">SM-A700FD</string>
+  <string name="device_a7_maintainer" translatable="false"></string>
 
-  <string name="device_i9305">Galaxy S III LTE</string>
-  <string name="device_i9305_summary">GT-I9305\nMaintainer - rodman01</string>
+  <string name="device_I897" translatable="false">Captivate</string>
+  <string name="device_I897_codename" translatable="false">I897</string>
+  <string name="device_I897_maintainer" translatable="false"></string>
 
-  <string name="device_s3tm">Galaxy S III T-Mobile</string>
-  <string name="device_s3tm_summary">D2LTE\nMaintainer - sixohtew</string>
+  <string name="device_i9000" translatable="false">Galaxy S</string>
+  <string name="device_i9000_codename" translatable="false">GT-I9000</string>
+  <string name="device_i9000_maintainer" translatable="false"></string>
 
-  <string name="device_s3att">Galaxy S III AT&amp;T</string>
-  <string name="device_s3att_summary">D2LTE\nMaintainer - sixohtew</string>
+  <string name="device_manta" translatable="false">Samsung Nexus 10</string>
+  <string name="device_manta_codename" translatable="false">Manta</string>
+  <string name="device_manta_maintainer" translatable="false">sixohtew</string>
 
-  <string name="device_d2lte">Galaxy S III Sprint</string>
-  <string name="device_d2lte_summary">D2LTE\nMaintainer - sixohtew</string>
+  <string name="device_t959" translatable="false">Vibrant</string>
+  <string name="device_t959_codename" translatable="false">T959</string>
+  <string name="device_t959_maintainer" translatable="false"></string>
 
-  <string name="device_d2vzw">Galaxy S III Verizon</string>
-  <string name="device_d2vzw_summary">D2LTE\nMaintainer - sixohtew</string>
+  <string name="device_i9105p" translatable="false">Galaxy S II Plus</string>
+  <string name="device_i9105p_codename" translatable="false">GT-I9105P</string>
+  <string name="device_i9105p_maintainer" translatable="false"></string>
 
-  <string name="device_sm_t217s">Galaxy Tab 3 7.0</string>
-  <string name="device_sm_t217s_summary">SM-T217S\nMaintainer - DarkFrenzy </string>
+  <string name="device_att" translatable="false">Galaxy S II AT&amp;T</string>
+  <string name="device_att_codename" translatable="false">SGH-I777</string>
+  <string name="device_att_maintainer" translatable="false"></string>
 
-  <string name="device_g2">LG G2 Intl</string>
-  <string name="device_g2_summary">D802\nMaintainer </string>
+  <string name="device_i9305" translatable="false">Galaxy S III LTE</string>
+  <string name="device_i9305_codename" translatable="false">GT-I9305</string>
+  <string name="device_i9305_maintainer" translatable="false">rodman01</string>
 
-  <string name="device_g2_spr">LG G2 Sprint</string>
-  <string name="device_g2_spr_summary">LS980\nMaintainer - Berkehan Kenan Sekban</string>
+  <string name="device_s3tm" translatable="false">Galaxy S III T-Mobile</string>
+  <string name="device_s3tm_codename" translatable="false">D2LTE</string>
+  <string name="device_s3tm_maintainer" translatable="false">sixohtew</string>
 
-  <string name="device_g2m">LG G2 Mini</string>
-  <string name="device_g2m_summary">g2m\nMaintainer - MobiusM </string>
+  <string name="device_s3att" translatable="false">Galaxy S III AT&amp;T</string>
+  <string name="device_s3att_codename" translatable="false">D2LTE</string>
+  <string name="device_s3att_maintainer" translatable="false">sixohtew</string>
 
-  <string name="device_n4">Nexus 4</string>
-  <string name="device_n4_summary">Mako\nMaintainer - </string>
+  <string name="device_d2lte" translatable="false">Galaxy S III Sprint</string>
+  <string name="device_d2lte_codename" translatable="false">D2LTE</string>
+  <string name="device_d2lte_maintainer" translatable="false">sixohtew</string>
 
-  <string name="device_n5">Nexus 5</string>
-  <string name="device_n5_summary">Hammerhead\nMaintainer - westcrip</string>
+  <string name="device_d2vzw" translatable="false">Galaxy S III Verizon</string>
+  <string name="device_d2vzw_codename" translatable="false">D2LTE</string>
+  <string name="device_d2vzw_maintainer" translatable="false">sixohtew</string>
 
-  <string name="device_n6">Nexus 6</string>
-  <string name="device_n6_summary">Shamu\nMaintainer - andrewwright</string>
+  <string name="device_sm_t217s" translatable="false">Galaxy Tab 3 7.0</string>
+  <string name="device_sm_t217s_codename" translatable="false">SM-T217S</string>
+  <string name="device_sm_t217s_maintainer" translatable="false">DarkFrenzy</string>
 
-  <string name="device_spyder">Droid RAZR</string>
-  <string name="device_spyder_summary">spyder GSM-CDMA\nMaintainer - </string>
+  <string name="device_g2" translatable="false">LG G2 Intl</string>
+  <string name="device_g2_codename" translatable="false">D802</string>
+  <string name="device_g2_maintainer" translatable="false"></string>
 
-  <string name="device_neov">Xperia Neo V</string>
-  <string name="device_neov_summary">Haida\nMaintainer - </string>
+  <string name="device_g2_spr" translatable="false">LG G2 Sprint</string>
+  <string name="device_g2_spr_codename" translatable="false">LS980</string>
+  <string name="device_g2_spr_maintainer" translatable="false">Berkehan Kenan Sekban</string>
 
-  <string name="device_arc">Xperia Arc</string>
-  <string name="device_arc_summary">Anzu\nMaintainer - </string>
+  <string name="device_g2m" translatable="false">LG G2 Mini</string>
+  <string name="device_g2m_codename" translatable="false">g2m</string>
+  <string name="device_g2m_maintainer" translatable="false">MobiusM </string>
 
-  <string name="device_taoshan">Xperia L</string>
-  <string name="device_taoshan_summary">Taoshan\nMaintainer - CodeZero</string>
+  <string name="device_n4" translatable="false">Nexus 4</string>
+  <string name="device_n4_codename" translatable="false">Mako</string>
+  <string name="device_n4_maintainer" translatable="false"></string>
 
-  <string name="device_nicki">Xperia M</string>
-  <string name="device_nicki_summary">Nicki\nMaintainer - CodeZero, Adrian DC</string>
+  <string name="device_n5" translatable="false">Nexus 5</string>
+  <string name="device_n5_codename" translatable="false">Hammerhead</string>
+  <string name="device_n5_maintainer" translatable="false">westcrip</string>
 
-  <string name="device_mint">Xperia T</string>
-  <string name="device_mint_summary">Mint\nMaintainer - CodeZero, Adrian DC</string>
+  <string name="device_n6" translatable="false">Nexus 6</string>
+  <string name="device_n6_codename" translatable="false">Shamu</string>
+  <string name="device_n6_maintainer" translatable="false">andrewwright</string>
 
-  <string name="device_hayabusa">Xperia TX</string>
-  <string name="device_hayabusa_summary">Hayabusa\nMaintainer - CodeZero, Adrian DC</string>
+  <string name="device_spyder" translatable="false">Droid RAZR</string>
+  <string name="device_spyder_codename" translatable="false">spyder GSM-CDMA</string>
+  <string name="device_spyder_maintainer" translatable="false"></string>
 
-  <string name="device_tsubasa">Xperia V</string>
-  <string name="device_tsubasa_summary">Tsubasa\nMaintainer - CodeZero, Adrian DC</string>
+  <string name="device_neov" translatable="false">Xperia Neo V</string>
+  <string name="device_neov_codename" translatable="false">Haida</string>
+  <string name="device_neov_maintainer" translatable="false"></string>
 
-  <string name="device_castor">Xperia Z2 Tablet</string>
-  <string name="device_castor_summary">Castor\nMaintainer - opendata</string>
+  <string name="device_arc" translatable="false">Xperia Arc</string>
+  <string name="device_arc_codename" translatable="false">Anzu</string>
+  <string name="device_arc_maintainer" translatable="false"></string>
 
-  <string name="device_z3c">Xperia Z3 Compact</string>
-  <string name="device_z3c_summary">Z3C\nMaintainer - </string>
+  <string name="device_taoshan" translatable="false">Xperia L</string>
+  <string name="device_taoshan_codename" translatable="false">Taoshan</string>
+  <string name="device_taoshan_maintainer" translatable="false">CodeZero</string>
 
-  <string name="device_toro">Galaxy Nexus CDMA</string>
-  <string name="device_toro_summary">toro\nMaintainer - </string>
+  <string name="device_nicki" translatable="false">Xperia M</string>
+  <string name="device_nicki_codename" translatable="false">Nicki</string>
+  <string name="device_nicki_maintainer" translatable="false">CodeZero, Adrian DC</string>
 
-  <string name="device_mega">Galaxy Mega</string>
-  <string name="device_mega_summary">GT-I9152 / GT-I9152\nMaintainer - </string>
+  <string name="device_mint" translatable="false">Xperia T</string>
+  <string name="device_mint_codename" translatable="false">Mint</string>
+  <string name="device_mint_maintainer" translatable="false">CodeZero, Adrian DC</string>
 
-  <string name="device_i9200">Galaxy Mega 6.3</string>
-  <string name="device_i9200_summary">GT-I9200\nMaintainer - </string>
+  <string name="device_hayabusa" translatable="false">Xperia TX</string>
+  <string name="device_hayabusa_codename" translatable="false">Hayabusa</string>
+  <string name="device_hayabusa_maintainer" translatable="false">CodeZero, Adrian DC</string>
 
-  <string name="device_i9205">Galaxy Mega 6.3</string>
-  <string name="device_i9205_summary">GT-I9205\nMaintainer - Silesh.Nair</string>
+  <string name="device_tsubasa" translatable="false">Xperia V</string>
+  <string name="device_tsubasa_codename" translatable="false">Tsubasa</string>
+  <string name="device_tsubasa_maintainer" translatable="false">CodeZero, Adrian DC</string>
 
-  <string name="device_s4mini">Galaxy S4 Mini</string>
-  <string name="device_s4mini_summary">GT-I9195 / GT-I9190\nMaintainer - </string>
+  <string name="device_castor" translatable="false">Xperia Z2 Tablet</string>
+  <string name="device_castor_codename" translatable="false">Castor</string>
+  <string name="device_castor_maintainer" translatable="false">opendata</string>
 
-  <string name="device_4x">LG Optimus 4X HD</string>
-  <string name="device_4x_summary">LG Optimus\nMaintainer - </string>
+  <string name="device_z3c" translatable="false">Xperia Z3 Compact</string>
+  <string name="device_z3c_codename" translatable="false">Z3C</string>
+  <string name="device_z3c_maintainer" translatable="false"></string>
 
-  <string name="device_jf">Samsung Galaxy S4 (jflte series)</string>
-  <string name="device_jf_summary">i9505\nMaintainer - Buff99</string>
+  <string name="device_toro" translatable="false">Galaxy Nexus CDMA</string>
+  <string name="device_toro_codename" translatable="false">toro</string>
+  <string name="device_toro_maintainer" translatable="false"></string>
 
-  <string name="device_ja3gxx">Samsung Galaxy S4</string>
-  <string name="device_ja3gxx_summary">i9500\nMaintainer - kongacute</string>
+  <string name="device_mega" translatable="false">Galaxy Mega</string>
+  <string name="device_mega_codename" translatable="false">GT-I9152 / GT-I9152</string>
+  <string name="device_mega_maintainer" translatable="false"></string>
 
-  <string name="device_falcon">Moto G</string>
-  <string name="device_falcon_summary">Falcon\nMaintainer - SKULSHADY</string>
+  <string name="device_i9200" translatable="false">Galaxy Mega 6.3</string>
+  <string name="device_i9200_codename" translatable="false">GT-I9200</string>
+  <string name="device_i9200_maintainer" translatable="false"></string>
 
-  <string name="device_titan">Moto G 2014</string>
-  <string name="device_titan_summary">Titan\nMaintainer - mrunalkaran</string>
+  <string name="device_i9205" translatable="false">Galaxy Mega 6.3</string>
+  <string name="device_i9205_codename" translatable="false">GT-I9205</string>
+  <string name="device_i9205_maintainer" translatable="false">Silesh.Nair</string>
 
-  <string name="device_osprey">Moto G 2015 </string>
-  <string name="device_osprey_summary">Osprey\nMaintainer - Pavan Jadhaw (Arcade)</string>
+  <string name="device_s4mini" translatable="false">Galaxy S4 Mini</string>
+  <string name="device_s4mini_codename" translatable="false">GT-I9195 / GT-I9190</string>
+  <string name="device_s4mini_maintainer" translatable="false"></string>
 
-  <string name="device_athene">Moto G4 Plus</string>
-  <string name="device_athene_summary">athene\nMaintainer - Joshua Blanchard (Jleeblanch)</string>
+  <string name="device_4x" translatable="false">LG Optimus 4X HD</string>
+  <string name="device_4x_codename" translatable="false">LG Optimus</string>
+  <string name="device_4x_maintainer" translatable="false"></string>
 
-  <string name="device_harpia">Moto G4 Play</string>
-  <string name="device_harpia_summary">Harpia\nMaintainer - SubhrajyotiSen</string>
+  <string name="device_jf" translatable="false">Samsung Galaxy S4 (jflte series)</string>
+  <string name="device_jf_codename" translatable="false">i9505</string>
+  <string name="device_jf_maintainer" translatable="false">Buff99</string>
 
-  <string name="device_g2_vs980">LG G2 Verizon</string>
-  <string name="device_g2_vs980_summary">vs980\nMaintainer - sixohtew</string>
+  <string name="device_ja3gxx" translatable="false">Samsung Galaxy S4</string>
+  <string name="device_ja3gxx_codename" translatable="false">i9500</string>
+  <string name="device_ja3gxx_maintainer" translatable="false">kongacute</string>
 
-  <string name="device_g3_tmo">LG G3 T-Mobile</string>
-  <string name="device_g3_tmo_summary">D851\nMaintainer - Mountaser Halak </string>
+  <string name="device_falcon" translatable="false">Moto G</string>
+  <string name="device_falcon_codename" translatable="false">Falcon</string>
+  <string name="device_falcon_maintainer" translatable="false">SKULSHADY</string>
 
-  <string name="device_g3">LG G3 Int</string>
-  <string name="device_g3_summary">D855\nMaintainer - Mountaser Halak, Rafael Marchetto </string>
+  <string name="device_titan" translatable="false">Moto G 2014</string>
+  <string name="device_titan_codename" translatable="false">Titan</string>
+  <string name="device_titan_maintainer" translatable="false">mrunalkaran</string>
 
-  <string name="device_g3_can">LG G3 Canada</string>
-  <string name="device_g3_can_summary">D852\nMaintainer - </string>
+  <string name="device_osprey" translatable="false">Moto G 2015 </string>
+  <string name="device_osprey_codename" translatable="false">Osprey</string>
+  <string name="device_osprey_maintainer" translatable="false">Pavan Jadhaw (Arcade)</string>
 
-  <string name="device_att_g3">LG G3 AT&amp;T</string>
-  <string name="device_att_g3_summary">D850\nMaintainer - oadam11 </string>
+  <string name="device_athene" translatable="false">Moto G4 Plus</string>
+  <string name="device_athene_codename" translatable="false">athene</string>
+  <string name="device_athene_maintainer" translatable="false">Joshua Blanchard (Jleeblanch)</string>
 
-  <string name="device_g3_kr">LG G3 Korea</string>
-  <string name="device_g3_kr_summary">F400\nMaintainer - oadam11 </string>
+  <string name="device_harpia" translatable="false">Moto G4 Play</string>
+  <string name="device_harpia_codename" translatable="false">Harpia</string>
+  <string name="device_harpia_maintainer" translatable="false">SubhrajyotiSen</string>
 
-  <string name="device_g3_spr">LG G3 Sprint</string>
-  <string name="device_g3_spr_summary">LS990\nMaintainer - oadam11 </string>
+  <string name="device_g2_vs980" translatable="false">LG G2 Verizon</string>
+  <string name="device_g2_vs980_codename" translatable="false">vs980</string>
+  <string name="device_g2_vs980_maintainer" translatable="false">sixohtew</string>
 
-  <string name="device_g3_vzw">LG G3 Verizon</string>
-  <string name="device_g3_vzw_summary">VS985\nMaintainer - oadam11 </string>
+  <string name="device_g3_tmo" translatable="false">LG G3 T-Mobile</string>
+  <string name="device_g3_tmo_codename" translatable="false">D851</string>
+  <string name="device_g3_tmo_maintainer" translatable="false">Mountaser Halak </string>
 
-  <string name="device_g3_beat">LG G3 Beat</string>
-  <string name="device_g3_beat_summary">D722\nMaintainer - MobiusM </string>
+  <string name="device_g3" translatable="false">LG G3 Int</string>
+  <string name="device_g3_codename" translatable="false">D855</string>
+  <string name="device_g3_maintainer" translatable="false">Mountaser Halak, Rafael Marchetto </string>
 
-  <string name="device_g4">LG G4 Int</string>
-  <string name="device_g4_summary">H815\nMaintainer - Erwan Leboucher </string>
+  <string name="device_g3_can" translatable="false">LG G3 Canada</string>
+  <string name="device_g3_can_codename" translatable="false">D852</string>
+  <string name="device_g3_can_maintainer" translatable="false"></string>
 
-  <string name="device_g5">LG G5 Int</string>
-  <string name="device_g5_summary">H850\nMaintainer - Gwolf2u (gwolfu @XDA)</string>
+  <string name="device_att_g3" translatable="false">LG G3 AT&amp;T</string>
+  <string name="device_att_g3_codename" translatable="false">D850</string>
+  <string name="device_att_g3_maintainer" translatable="false">oadam11 </string>
 
-  <string name="device_g5_tmo">LG G5 T-Mobile</string>
-  <string name="device_g5_tmo_summary">H830\nMaintainer - Gwolf2u (gwolfu @XDA)</string>
+  <string name="device_g3_kr" translatable="false">LG G3 Korea</string>
+  <string name="device_g3_kr_codename" translatable="false">F400</string>
+  <string name="device_g3_kr_maintainer" translatable="false">oadam11 </string>
 
-  <string name="device_l70pn">LG L Fino</string>
-  <string name="device_l70pn_summary">H815\nMaintainer - Mountaser Halak </string>
+  <string name="device_g3_spr" translatable="false">LG G3 Sprint</string>
+  <string name="device_g3_spr_codename" translatable="false">LS990</string>
+  <string name="device_g3_spr_maintainer" translatable="false">oadam11 </string>
 
-  <string name="device_v521">LG G Pad X 8.0</string>
-  <string name="device_v521_summary">V521\nMaintainer - highridas (highridas @XDA) </string>
+  <string name="device_g3_vzw" translatable="false">LG G3 Verizon</string>
+  <string name="device_g3_vzw_codename" translatable="false">VS985</string>
+  <string name="device_g3_vzw_maintainer" translatable="false">oadam11 </string>
 
-  <string name="device_honami">Xperia Z1</string>
-  <string name="device_honami_summary">Honami\nMaintainer - CodeZero</string>
+  <string name="device_g3_beat" translatable="false">LG G3 Beat</string>
+  <string name="device_g3_beat_codename" translatable="false">D722</string>
+  <string name="device_g3_beat_maintainer" translatable="false">MobiusM </string>
 
-  <string name="device_amami">Xperia Z1 Compact</string>
-  <string name="device_amami_summary">Amiami\nMaintainer -</string>
+  <string name="device_g4" translatable="false">LG G4 Int</string>
+  <string name="device_g4_codename" translatable="false">H815</string>
+  <string name="device_g4_maintainer" translatable="false">Erwan Leboucher </string>
 
-  <string name="device_togari">Xperia Z Ultra</string>
-  <string name="device_togari_summary">Togari\nMaintainer - Markakash</string>
+  <string name="device_g5" translatable="false">LG G5 Int</string>
+  <string name="device_g5_codename" translatable="false">H850</string>
+  <string name="device_g5_maintainer" translatable="false">Gwolf2u (gwolfu @XDA)</string>
 
-  <string name="device_yuga">Xperia Z</string>
-  <string name="device_yuga_summary">Yuga\nMaintainer - Chippa_a</string>
+  <string name="device_g5_tmo" translatable="false">LG G5 T-Mobile</string>
+  <string name="device_g5_tmo_codename" translatable="false">H830</string>
+  <string name="device_g5_tmo_maintainer" translatable="false">Gwolf2u (gwolfu @XDA)</string>
 
-  <string name="device_odin">Xperia ZL</string>
-  <string name="device_odin_summary">Odin\nMaintainer - Chippa_a</string>
+  <string name="device_l70pn" translatable="false">LG L Fino</string>
+  <string name="device_l70pn_codename" translatable="false">H815</string>
+  <string name="device_l70pn_maintainer" translatable="false">Mountaser Halak </string>
 
-  <string name="device_dogo">Xperia ZR</string>
-  <string name="device_dogo_summary">Dogo\nMaintainer - Chippa_a</string>
+  <string name="device_v521" translatable="false">LG G Pad X 8.0</string>
+  <string name="device_v521_codename" translatable="false">V521</string>
+  <string name="device_v521_maintainer" translatable="false">highridas (highridas @XDA) </string>
 
-  <string name="device_anzu">Xperia ArC</string>
-  <string name="device_anzu_summary">Anzu\nMaintainer - </string>
+  <string name="device_honami" translatable="false">Xperia Z1</string>
+  <string name="device_honami_codename" translatable="false">Honami</string>
+  <string name="device_honami_maintainer" translatable="false">CodeZero</string>
 
-  <string name="device_coconut">Xperia Live</string>
-  <string name="device_coconut_summary">Cocunut\nMaintainer - </string>
+  <string name="device_amami" translatable="false">Xperia Z1 Compact</string>
+  <string name="device_amami_codename" translatable="false">Amiami</string>
+  <string name="device_amami_maintainer" translatable="false"></string>
 
-  <string name="device_hallon">Xperia Neo</string>
-  <string name="device_hallon_summary">Hallon\nMaintainer - </string>
+  <string name="device_togari" translatable="false">Xperia Z Ultra</string>
+  <string name="device_togari_codename" translatable="false">Togari</string>
+  <string name="device_togari_maintainer" translatable="false">Markakash</string>
 
-  <string name="device_iyokan">Xperia Pro</string>
-  <string name="device_iyokan_summary">Iyokan\nMaintainer - </string>
+  <string name="device_yuga" translatable="false">Xperia Z</string>
+  <string name="device_yuga_codename" translatable="false">Yuga</string>
+  <string name="device_yuga_maintainer" translatable="false">Chippa_a</string>
 
-  <string name="device_mango">Xperia Mini Pro</string>
-  <string name="device_mango_summary">Mango\nMaintainer - </string>
+  <string name="device_odin" translatable="false">Xperia ZL</string>
+  <string name="device_odin_codename" translatable="false">Odin</string>
+  <string name="device_odin_maintainer" translatable="false">Chippa_a</string>
 
-  <string name="device_phoenix">Xperia Neo L</string>
-  <string name="device_phoenix_summary">Phoenix\nMaintainer - </string>
+  <string name="device_dogo" translatable="false">Xperia ZR</string>
+  <string name="device_dogo_codename" translatable="false">Dogo</string>
+  <string name="device_dogo_maintainer" translatable="false">Chippa_a</string>
 
-  <string name="device_satsuma">Xperia Active</string>
-  <string name="device_satsuma_summary">Satsuma\nMaintainer - </string>
+  <string name="device_anzu" translatable="false">Xperia ArC</string>
+  <string name="device_anzu_codename" translatable="false">Anzu</string>
+  <string name="device_anzu_maintainer" translatable="false"></string>
 
-  <string name="device_smultron">Xperia Mini</string>
-  <string name="device_smultron_summary">Smultron\nMaintainer - </string>
+  <string name="device_coconut" translatable="false">Xperia Live</string>
+  <string name="device_coconut_codename" translatable="false">Cocunut</string>
+  <string name="device_coconut_maintainer" translatable="false"></string>
 
-  <string name="device_urushi">Xperia Ray</string>
-  <string name="device_urushi_summary">Urushi\nMaintainer - </string>
+  <string name="device_hallon" translatable="false">Xperia Neo</string>
+  <string name="device_hallon_codename" translatable="false">Hallon</string>
+  <string name="device_hallon_maintainer" translatable="false"></string>
 
-  <string name="device_sirius">Xperia Z2</string>
-  <string name="device_sirius_summary">sirius\nMaintainer - opendata</string>
+  <string name="device_iyokan" translatable="false">Xperia Pro</string>
+  <string name="device_iyokan_codename" translatable="false">Iyokan</string>
+  <string name="device_iyokan_maintainer" translatable="false"></string>
 
-  <string name="device_maguro">Galaxy Nexus</string>
-  <string name="device_maguro_summary">Maguro\nMaintainer - </string>
+  <string name="device_mango" translatable="false">Xperia Mini Pro</string>
+  <string name="device_mango_codename" translatable="false">Mango</string>
+  <string name="device_mango_maintainer" translatable="false"></string>
 
-  <string name="device_garlic">Yu Yureka Black</string>
-  <string name="device_garlic_summary">Garlic\nMaintainer- Vjs Pranav</string>
+  <string name="device_phoenix" translatable="false">Xperia Neo L</string>
+  <string name="device_phoenix_codename" translatable="false">Phoenix</string>
+  <string name="device_phoenix_maintainer" translatable="false"></string>
 
-  <string name="device_tomato">Yu Yureka</string>
-  <string name="device_tomato_summary">Tomato\nMaintainer - Sanchit Rohilla</string>
+  <string name="device_satsuma" translatable="false">Xperia Active</string>
+  <string name="device_satsuma_codename" translatable="false">Satsuma</string>
+  <string name="device_satsuma_maintainer" translatable="false"></string>
 
-  <string name="device_jalebi">Yu Yunique</string>
-  <string name="device_jalebi_summary">Jalebi\nMaintainer - Sai Charan, Shaik Jaleel (iamsj7)</string>
+  <string name="device_smultron" translatable="false">Xperia Mini</string>
+  <string name="device_smultron_codename" translatable="false">Smultron</string>
+  <string name="device_smultron_maintainer" translatable="false"></string>
 
-  <string name="device_lettuce">Yu Yuphoria</string>
-  <string name="device_lettuce_summary">Lettuce\nMaintainer - Aashish Toshniwal</string>
+  <string name="device_urushi" translatable="false">Xperia Ray</string>
+  <string name="device_urushi_codename" translatable="false">Urushi</string>
+  <string name="device_urushi_maintainer" translatable="false"></string>
 
-  <string name="device_sambar">Yu Yutopia</string>
-  <string name="device_sambar_summary">Sambar\nMaintainer - Darshan M. (darshan1205)</string>
+  <string name="device_sirius" translatable="false">Xperia Z2</string>
+  <string name="device_sirius_codename" translatable="false">sirius</string>
+  <string name="device_sirius_maintainer" translatable="false">opendata</string>
 
-  <string name="device_armani">Xiaomi Redmi 1S </string>
-  <string name="device_armani_summary">Armani\nMaintainer - </string>
+  <string name="device_maguro" translatable="false">Galaxy Nexus</string>
+  <string name="device_maguro_codename" translatable="false">Maguro</string>
+  <string name="device_maguro_maintainer" translatable="false"></string>
 
-  <string name="device_cancro">Xiaomi MI 3</string>
-  <string name="device_cancro_summary">Cancro\nMaintainer - Nihar Deshpande</string>
+  <string name="device_garlic" translatable="false">Yu Yureka Black</string>
+  <string name="device_garlic_codename" translatable="false">Garlic</string>
+  <string name="device_garlic_maintainer" translatable="false">Vjs Pranav</string>
 
-  <string name="device_gemini">Xiaomi MI 5</string>
-  <string name="device_gemini_summary">Gemini\nMaintainer - Fabian Leutenegger</string>
+  <string name="device_tomato" translatable="false">Yu Yureka</string>
+  <string name="device_tomato_codename" translatable="false">Tomato</string>
+  <string name="device_tomato_maintainer" translatable="false">Sanchit Rohilla</string>
 
-  <string name="device_capricorn">Xiaomi MI 5s</string>
-  <string name="device_capricorn_summary">Capricorn\nMaintainer - Ali İhsan Hatun (Asderdd)</string>
+  <string name="device_jalebi" translatable="false">Yu Yunique</string>
+  <string name="device_jalebi_codename" translatable="false">Jalebi</string>
+  <string name="device_jalebi_maintainer" translatable="false">Sai Charan, Shaik Jaleel (iamsj7)</string>
 
-  <string name="device_natrium">Xiaomi MI 5s Plus</string>
-  <string name="device_natrium_summary">Natrium\nMaintainer - Ali İhsan Hatun (Asderdd)</string>
+  <string name="device_lettuce" translatable="false">Yu Yuphoria</string>
+  <string name="device_lettuce_codename" translatable="false">Lettuce</string>
+  <string name="device_lettuce_maintainer" translatable="false">Aashish Toshniwal</string>
 
-  <string name="device_sagit">Xiaomi MI 6</string>
-  <string name="device_sagit_summary">Sagit\nMaintainer - Ali İhsan Hatun (Asderdd)</string>
- 
-  <string name="device_scorpio">Xiaomi MI Note 2</string>
-  <string name="device_scorpio_summary">Scorpio\nMaintainer - StoneTrapper</string>
+  <string name="device_sambar" translatable="false">Yu Yutopia</string>
+  <string name="device_sambar_codename" translatable="false">Sambar</string>
+  <string name="device_sambar_maintainer" translatable="false">Darshan M. (darshan1205)</string>
 
-  <string name="device_lithium">Xiaomi MI Mix</string>
-  <string name="device_lithium_summary">Lithium\nMaintainer - pappschlumpf</string>
+  <string name="device_armani" translatable="false">Xiaomi Redmi 1S </string>
+  <string name="device_armani_codename" translatable="false">Armani</string>
+  <string name="device_armani_maintainer" translatable="false"></string>
 
-  <string name="device_dior">Xiaomi Redmi Note 4G</string>
-  <string name="device_dior_summary">dior\nMaintainer - Ashish Kotnala</string>
+  <string name="device_cancro" translatable="false">Xiaomi MI 3</string>
+  <string name="device_cancro_codename" translatable="false">Cancro</string>
+  <string name="device_cancro_maintainer" translatable="false">Nihar Deshpande</string>
 
-  <string name="device_kenzo">Xiaomi Redmi Note 3</string>
-  <string name="device_kenzo_summary">Kenzo\nMaintainer - Akhil, Abhishek</string>
+  <string name="device_gemini" translatable="false">Xiaomi MI 5</string>
+  <string name="device_gemini_codename" translatable="false">Gemini</string>
+  <string name="device_gemini_maintainer" translatable="false">Fabian Leutenegger</string>
 
-  <string name="device_mido">Xiaomi Redmi Note 4</string>
-  <string name="device_mido_summary">mido\nMaintainer - Adesh (Adesh15)</string>
+  <string name="device_capricorn" translatable="false">Xiaomi MI 5s</string>
+  <string name="device_capricorn_codename" translatable="false">Capricorn</string>
+  <string name="device_capricorn_maintainer" translatable="false">Ali İhsan Hatun (Asderdd)</string>
 
-  <string name="device_hydrogen">Xiaomi Mi Max</string>
-  <string name="device_hydrogen_summary">Hydrogen\nMaintainer - ROMFACTORY(SARTHAKMALLA)</string>
+  <string name="device_natrium" translatable="false">Xiaomi MI 5s Plus</string>
+  <string name="device_natrium_codename" translatable="false">Natrium</string>
+  <string name="device_natrium_maintainer" translatable="false">Ali İhsan Hatun (Asderdd)</string>
 
-  <string name="device_sprout4">Android One - 4GB variants (1st Gen)</string>
-  <string name="device_sprout4_summary">Sprout4\nMaintainer - Samar Vispute (SamarV-121)</string>
+  <string name="device_sagit" translatable="false">Xiaomi MI 6</string>
+  <string name="device_sagit_codename" translatable="false">Sagit</string>
+  <string name="device_sagit_maintainer" translatable="false">Ali İhsan Hatun (Asderdd)</string>
 
-  <string name="device_sprout8">Android One - 8GB variants (1st Gen)</string>
-  <string name="device_sprout8_summary">Sprout8\nMaintainer - Samar Vispute (SamarV-121)</string>
+  <string name="device_scorpio" translatable="false">Xiaomi MI Note 2</string>
+  <string name="device_scorpio_codename" translatable="false">Scorpio</string>
+  <string name="device_scorpio_maintainer" translatable="false">StoneTrapper</string>
 
-  <string name="device_seed">Android One - 2nd Gen</string>
-  <string name="device_seed_summary">Seed\nMaintainer - Kaan Külahlı (Rygebin), Kerem Erkaplan (HD)</string>
+  <string name="device_lithium" translatable="false">Xiaomi MI Mix</string>
+  <string name="device_lithium_codename" translatable="false">Lithium</string>
+  <string name="device_lithium_maintainer" translatable="false">pappschlumpf</string>
 
-  <string name="device_shamrock">Android One - GM 5 Plus (3rd Gen)</string>
-  <string name="device_shamrock_summary">Shamrock\nMaintainer - Ali İhsan Hatun (Asderdd)</string>
+  <string name="device_dior" translatable="false">Xiaomi Redmi Note 4G</string>
+  <string name="device_dior_codename" translatable="false">dior</string>
+  <string name="device_dior_maintainer" translatable="false">Ashish Kotnala</string>
 
-  <string name="device_s2">LeEco Le 2</string>
-  <string name="device_s2_summary">s2\nMaintainer - Rishabh Rao (rishabhrao)</string>
+  <string name="device_kenzo" translatable="false">Xiaomi Redmi Note 3</string>
+  <string name="device_kenzo_codename" translatable="false">Kenzo</string>
+  <string name="device_kenzo_maintainer" translatable="false">Akhil, Abhishek</string>
 
-  <string name="device_X3">LeEco Le 1s</string>
-  <string name="device_X3_summary">X3\nMaintainer - Łukasz Wiśniewski (WisniaPL)</string>
+  <string name="device_mido" translatable="false">Xiaomi Redmi Note 4</string>
+  <string name="device_mido_codename" translatable="false">mido</string>
+  <string name="device_mido_maintainer" translatable="false">Adesh (Adesh15)</string>
 
-  <string name="device_x2">LeEco LeMax 2</string>
-  <string name="device_x2_summary">x2\nMaintainer - Andrey Shidakov (andr68rus)</string>
+  <string name="device_hydrogen" translatable="false">Xiaomi Mi Max</string>
+  <string name="device_hydrogen_codename" translatable="false">Hydrogen</string>
+  <string name="device_hydrogen_maintainer" translatable="false">ROMFACTORY(SARTHAKMALLA)</string>
 
-  <string name="device_zl1">LeEco LePro 3</string>
-  <string name="device_zl1_summary">zl1\nMaintainer - Santiago Villar (VillarLeg)</string>
+  <string name="device_sprout4" translatable="false">Android One - 4GB variants (1st Gen)</string>
+  <string name="device_sprout4_codename" translatable="false">Sprout4</string>
+  <string name="device_sprout4_maintainer" translatable="false">Samar Vispute (SamarV-121)</string>
 
-  <string name="device_t0ltexx">Samsung Galaxy Note II LTE</string>
-  <string name="device_t0ltexx_summary">T0ltexx\nMaintainer - </string>
+  <string name="device_sprout8" translatable="false">Android One - 8GB variants (1st Gen)</string>
+  <string name="device_sprout8_codename" translatable="false">Sprout8</string>
+  <string name="device_sprout8_maintainer" translatable="false">Samar Vispute (SamarV-121)</string>
 
-  <string name="device_u9500">Huawei Ascend D1</string>
-  <string name="device_u9500_summary">U9500\nMaintainer - </string>
+  <string name="device_seed" translatable="false">Android One - 2nd Gen</string>
+  <string name="device_seed_codename" translatable="false">Seed</string>
+  <string name="device_seed_maintainer" translatable="false">Kaan Külahlı (Rygebin), Kerem Erkaplan (HD)</string>
 
-  <string name="device_kiwi">Huawei Honor 5x</string>
-  <string name="device_kiwi_summary">kiwi\nMaintainer - jsbeyond(KAOKAO)</string>
+  <string name="device_shamrock" translatable="false">Android One - GM 5 Plus (3rd Gen)</string>
+  <string name="device_shamrock_codename" translatable="false">Shamrock</string>
+  <string name="device_shamrock_maintainer" translatable="false">Ali İhsan Hatun (Asderdd)</string>
 
-  <string name="device_angler">Huawei Nexus 6P</string>
-  <string name="device_angler_summary">Angler\nMaintainer - </string>
+  <string name="device_s2" translatable="false">LeEco Le 2</string>
+  <string name="device_s2_codename" translatable="false">s2</string>
+  <string name="device_s2_maintainer" translatable="false">Rishabh Rao (rishabhrao)</string>
 
-  <string name="device_smp601">Samsung Galaxy Note 10.1 3G</string>
-  <string name="device_smp601_summary">SM-P601\nMaintainer - </string>
+  <string name="device_X3" translatable="false">LeEco Le 1s</string>
+  <string name="device_X3_codename" translatable="false">X3</string>
+  <string name="device_X3_maintainer" translatable="false">Łukasz Wiśniewski (WisniaPL)</string>
 
-  <string name="device_huashan">Sony Xperia SP</string>
-  <string name="device_huashan_summary">Huashan\nMaintainer - CodeZero, Adrian DC</string>
-  
-  <string name="device_z012d">Asus Zenfone 3</string>
-  <string name="device_z012d_summary">Z012D\nMaintainer - Ezio (TurkDevs)</string>
+  <string name="device_x2" translatable="false">LeEco LeMax 2</string>
+  <string name="device_x2_codename" translatable="false">x2</string>
+  <string name="device_x2_maintainer" translatable="false">Andrey Shidakov (andr68rus)</string>
 
-  <string name="device_z00a">Asus Zenfone 2</string>
-  <string name="device_z00a_summary">Z00A\nMaintainer - sayeed99</string>
+  <string name="device_zl1" translatable="false">LeEco LePro 3</string>
+  <string name="device_zl1_codename" translatable="false">zl1</string>
+  <string name="device_zl1_maintainer" translatable="false">Santiago Villar (VillarLeg)</string>
 
-  <string name="device_z008">Asus Zenfone 2</string>
-  <string name="device_z008_summary">Z008\nMaintainer - sayeed99</string>
+  <string name="device_t0ltexx" translatable="false">Samsung Galaxy Note II LTE</string>
+  <string name="device_t0ltexx_codename" translatable="false">T0ltexx</string>
+  <string name="device_t0ltexx_maintainer" translatable="false"></string>
 
-  <string name="device_T00F">Asus Zenfone 5</string>
-  <string name="device_T00F_summary">T00F\nMaintainer - Roman "tank0412" Buhtiarov</string>
+  <string name="device_u9500" translatable="false">Huawei Ascend D1</string>
+  <string name="device_u9500_codename" translatable="false">U9500</string>
+  <string name="device_u9500_maintainer" translatable="false"></string>
 
-  <string name="device_tenderloin">HP Touchpad</string>
-  <string name="device_tenderloin_summary">Tenderloin\nMaintainer - sixohtew</string>
+  <string name="device_kiwi" translatable="false">Huawei Honor 5x</string>
+  <string name="device_kiwi_codename" translatable="false">kiwi</string>
+  <string name="device_kiwi_maintainer" translatable="false">jsbeyond(KAOKAO)</string>
 
-  <string name="device_ferrari">Xiaomi MI 4i</string>
-  <string name="device_ferrari_summary">ferrari\nMaintainer - haikalizz</string>
+  <string name="device_angler" translatable="false">Huawei Nexus 6P</string>
+  <string name="device_angler_codename" translatable="false">Angler</string>
+  <string name="device_angler_maintainer" translatable="false"></string>
 
-  <string name="device_libra">Xiaomi MI 4c</string>
-  <string name="device_libra_summary">libra\nMaintainer - AndropaX </string>
+  <string name="device_smp601" translatable="false">Samsung Galaxy Note 10.1 3G</string>
+  <string name="device_smp601_codename" translatable="false">SM-P601</string>
+  <string name="device_smp601_maintainer" translatable="false"></string>
 
-  <string name="device_redmi2">Xiaomi Redmi 2</string>
-  <string name="device_redmi2_summary">wt88047\nMaintainer - nicknitewolf </string>
+  <string name="device_huashan" translatable="false">Sony Xperia SP</string>
+  <string name="device_huashan_codename" translatable="false">Huashan</string>
+  <string name="device_huashan_maintainer" translatable="false">CodeZero, Adrian DC</string>
 
-  <string name="device_redmi3">Xiaomi Redmi 3</string>
-  <string name="device_redmi3_summary">ido\nMaintainer - kmahyyg </string>
+  <string name="device_z012d" translatable="false">Asus Zenfone 3</string>
+  <string name="device_z012d_codename" translatable="false">Z012D</string>
+  <string name="device_z012d_maintainer" translatable="false">Ezio (TurkDevs)</string>
 
-  <string name="device_land">Xiaomi Redmi 3s</string>
-  <string name="device_land_summary">land\nMaintainer - Saicharan </string>
+  <string name="device_z00a" translatable="false">Asus Zenfone 2</string>
+  <string name="device_z00a_codename" translatable="false">Z00A</string>
+  <string name="device_z00a_maintainer" translatable="false">sayeed99</string>
 
-  <string name="device_santoni">Xiaomi Redmi 4X</string>
-  <string name="device_santoni_summary">santoni\nMaintainer - Nikesh Kataria</string>
+  <string name="device_z008" translatable="false">Asus Zenfone 2</string>
+  <string name="device_z008_codename" translatable="false">Z008</string>
+  <string name="device_z008_maintainer" translatable="false">sayeed99</string>
 
-  <string name="device_wfxs">WilleyFox Swift</string>
-  <string name="device_wfxs_summary">crackling\nMaintainer - Semih ÇELİK (Wes)</string>
+  <string name="device_T00F" translatable="false">Asus Zenfone 5</string>
+  <string name="device_T00F_codename" translatable="false">T00F</string>
+  <string name="device_T00F_maintainer" translatable="false">Roman "tank0412" Buhtiarov</string>
 
-  <string name="device_wfxk">WilleyFox Storm</string>
-  <string name="device_wfxk_summary">kipper\nMaintainer - </string>
+  <string name="device_tenderloin" translatable="false">HP Touchpad</string>
+  <string name="device_tenderloin_codename" translatable="false">Tenderloin</string>
+  <string name="device_tenderloin_maintainer" translatable="false">sixohtew</string>
 
-  <string name="device_Z00D">Asus Zenfone 2 </string>
-  <string name="device_Z00D_summary">Z00D\nMaintainer - Nguyenhung9x </string>
+  <string name="device_ferrari" translatable="false">Xiaomi MI 4i</string>
+  <string name="device_ferrari_codename" translatable="false">ferrari</string>
+  <string name="device_ferrari_maintainer" translatable="false">haikalizz</string>
 
-  <string name="device_quark">Moto Maxx-Turbo, Droid Turbo </string>
-  <string name="device_quark_summary">Quark\nMaintainer - bhb27 - Felipe Leon</string>
+  <string name="device_libra" translatable="false">Xiaomi MI 4c</string>
+  <string name="device_libra_codename" translatable="false">libra</string>
+  <string name="device_libra_maintainer" translatable="false">AndropaX </string>
 
-  <string name="device_bullhead">LGE Nexus 5X</string>
-  <string name="device_bullhead_summary">Bullhead\nMaintainer - Akash Srivastava(Markakash)</string>
+  <string name="device_redmi2" translatable="false">Xiaomi Redmi 2</string>
+  <string name="device_redmi2_codename" translatable="false">wt88047</string>
+  <string name="device_redmi2_maintainer" translatable="false">nicknitewolf </string>
 
-  <string name="device_shieldtablet">Nvidia Shield Tablet/K1</string>
-  <string name="device_shieldtablet_summary">shieldtablet\nMaintainer - Trafalgar Square</string>
+  <string name="device_redmi3" translatable="false">Xiaomi Redmi 3</string>
+  <string name="device_redmi3_codename" translatable="false">ido</string>
+  <string name="device_redmi3_maintainer" translatable="false">kmahyyg </string>
 
-  <string name="device_nexus7">Asus Nexus 7 2013</string>
-  <string name="device_nexus7_summary">flo/deb\nMaintainer - apascual89</string>
+  <string name="device_land" translatable="false">Xiaomi Redmi 3s</string>
+  <string name="device_land_codename" translatable="false">land</string>
+  <string name="device_land_maintainer" translatable="false">Saicharan </string>
 
-  <string name="device_google_dragon">Pixel C</string>
-  <string name="device_google_dragon_summary">dragon\nMaintainer - apascual89</string>
+  <string name="device_santoni" translatable="false">Xiaomi Redmi 4X</string>
+  <string name="device_santoni_codename" translatable="false">santoni</string>
+  <string name="device_santoni_maintainer" translatable="false">Nikesh Kataria</string>
 
-  <string name="device_z00t">Asus Zenfone 2 Laser/Selfie (1080p)</string>
-  <string name="device_z00t_summary">Z00T\nMaintainer - Fabb2303</string>
+  <string name="device_wfxs" translatable="false">WilleyFox Swift</string>
+  <string name="device_wfxs_codename" translatable="false">crackling</string>
+  <string name="device_wfxs_maintainer" translatable="false">Semih ÇELİK (Wes)</string>
 
-  <string name="device_z00l">Asus Zenfone 2 Laser (720p)</string>
-  <string name="device_z00l_summary">Z00L\nMaintainer - Fabb2303</string>
+  <string name="device_wfxk" translatable="false">WilleyFox Storm</string>
+  <string name="device_wfxk_codename" translatable="false">kipper</string>
+  <string name="device_wfxk_maintainer" translatable="false"></string>
 
-  <string name="device_n5100">Note 8.0 3g</string>
-  <string name="device_n5100_summary">n5100\nMaintainer - Buff99</string>
+  <string name="device_Z00D" translatable="false">Asus Zenfone 2 </string>
+  <string name="device_Z00D_codename" translatable="false">Z00D</string>
+  <string name="device_Z00D_maintainer" translatable="false">Nguyenhung9x </string>
 
-  <string name="device_n5110">Note 8.0 wifi</string>
-  <string name="device_n5110_summary">n5110\nMaintainer - Buff99</string>
+  <string name="device_quark" translatable="false">Moto Maxx-Turbo, Droid Turbo </string>
+  <string name="device_quark_codename" translatable="false">Quark</string>
+  <string name="device_quark_maintainer" translatable="false">bhb27 - Felipe Leon</string>
 
-  <string name="device_n5120">Note 8.0 4g</string>
-  <string name="device_n5120_summary">n5120\nMaintainer - Buff99</string>
+  <string name="device_bullhead" translatable="false">LGE Nexus 5X</string>
+  <string name="device_bullhead_codename" translatable="false">Bullhead</string>
+  <string name="device_bullhead_maintainer" translatable="false">Akash Srivastava(Markakash)</string>
 
-  <string name="device_paella">BQ Aquaris X5</string>
-  <string name="device_paella_summary">Paella\nMaintainer - Darkmet98</string>
+  <string name="device_shieldtablet" translatable="false">Nvidia Shield Tablet/K1</string>
+  <string name="device_shieldtablet_codename" translatable="false">shieldtablet</string>
+  <string name="device_shieldtablet_maintainer" translatable="false">Trafalgar Square</string>
 
-  <string name="device_piccolo">BQ Aquaris M5</string>
-  <string name="device_piccolo_summary">Piccolo\nMaintainer - Juanan557</string>
+  <string name="device_nexus7" translatable="false">Asus Nexus 7 2013</string>
+  <string name="device_nexus7_codename" translatable="false">flo/deb</string>
+  <string name="device_nexus7_maintainer" translatable="false">apascual89</string>
 
-  <string name="device_onyx">OnePlus X</string>
-  <string name="device_onyx_summary">Onyx\nMaintainer - Sanjay Varun</string>
+  <string name="device_google_dragon" translatable="false">Pixel C</string>
+  <string name="device_google_dragon_codename" translatable="false">dragon</string>
+  <string name="device_google_dragon_maintainer" translatable="false">apascual89</string>
 
-  <string name="device_flounder">HTC Nexus 9</string>
-  <string name="device_flounder_summary">Flounder\nMaintainer - Jithu Mathew Joseph</string>
-  
-  <string name="device_i9515">Samsung Galaxy S4 GT-I9515</string>
-  <string name="device_i9515_summary">GT-I9515\nMaintainer - Jalgoczy Alexandru (mitomanu)</string>
-   
-  <string name="device_ham">ZUK Z1</string>
-  <string name="device_ham_summary">Ham\nMaintainer - Ankur Pandey(ankurpandeyvns)</string>
+  <string name="device_z00t" translatable="false">Asus Zenfone 2 Laser/Selfie (1080p)</string>
+  <string name="device_z00t_codename" translatable="false">Z00T</string>
+  <string name="device_z00t_maintainer" translatable="false">Fabb2303</string>
 
-  <string name="device_nubia_nx531j">Nubia Z11</string>
-  <string name="device_nubia_nx531j_summary">nx531j\nMaintainer - ZhangXueZe</string>
+  <string name="device_z00l" translatable="false">Asus Zenfone 2 Laser (720p)</string>
+  <string name="device_z00l_codename" translatable="false">Z00L</string>
+  <string name="device_z00l_maintainer" translatable="false">Fabb2303</string>
 
-  <string name="device_vega_A910">Vega Sky A910</string>
-  <string name="device_vega_A910_summary">A910\nMaintainer - XDAVN</string>
+  <string name="device_n5100" translatable="false">Note 8.0 3g</string>
+  <string name="device_n5100_codename" translatable="false">n5100</string>
+  <string name="device_n5100_maintainer" translatable="false">Buff99</string>
 
-  <string name="device_vega_A900">Vega Sky A900</string>
-  <string name="device_vega_A900_summary">A900\nMaintainer - XDAVN</string>
+  <string name="device_n5110" translatable="false">Note 8.0 wifi</string>
+  <string name="device_n5110_codename" translatable="false">n5110</string>
+  <string name="device_n5110_maintainer" translatable="false">Buff99</string>
 
-  <string name="device_vega_A890">Vega Sky A890</string>
-  <string name="device_vega_A890_summary">A890\nMaintainer - XDAVN</string>
+  <string name="device_n5120" translatable="false">Note 8.0 4g</string>
+  <string name="device_n5120_codename" translatable="false">n5120</string>
+  <string name="device_n5120_maintainer" translatable="false">Buff99</string>
 
-  <string name="device_lenovo_P1a42">Lenovo Vibe P1 Turbo</string>
-  <string name="device_lenovo_P1a42_summary">P1a42\nMaintainer - Subham (DerkLord)</string>
+  <string name="device_paella" translatable="false">BQ Aquaris X5</string>
+  <string name="device_paella_codename" translatable="false">Paella</string>
+  <string name="device_paella_maintainer" translatable="false">Darkmet98</string>
 
-  <string name="device_Zuk_Z2">Zuk_Z2</string>
-  <string name="device_Zuk_Z2_summary"> Zuk_Z2\nMaintainer - Keerten </string>
+  <string name="device_piccolo" translatable="false">BQ Aquaris M5</string>
+  <string name="device_piccolo_codename" translatable="false">Piccolo</string>
+  <string name="device_piccolo_maintainer" translatable="false">Juanan557</string>
 
-  <string name="device_ville">HTC One S</string>
-  <string name="device_ville_summary">Ville\nMaintainer - Moozon</string>
-  
-  <string name="device_nubia_nx512j">Nubia Z9 Max</string>
-  <string name="device_nubia_nx512j_summary">nx512j\nMaintainer - Atul Bansode</string>   
-  
-  <string name="device_helium">Xiaomi Mi Max Prime</string>
-  <string name="device_helium_summary">Helium\nMaintainer - ROMFACTORY(SARTHAKMALLA)</string>
+  <string name="device_onyx" translatable="false">OnePlus X</string>
+  <string name="device_onyx_codename" translatable="false">Onyx</string>
+  <string name="device_onyx_maintainer" translatable="false">Sanjay Varun</string>
+
+  <string name="device_flounder" translatable="false">HTC Nexus 9</string>
+  <string name="device_flounder_codename" translatable="false">Flounder</string>
+  <string name="device_flounder_maintainer" translatable="false">Jithu Mathew Joseph</string>
+
+  <string name="device_i9515" translatable="false">Samsung Galaxy S4 GT-I9515</string>
+  <string name="device_i9515_codename" translatable="false">GT-I9515</string>
+  <string name="device_i9515_maintainer" translatable="false">Jalgoczy Alexandru (mitomanu)</string>
+
+  <string name="device_ham" translatable="false">ZUK Z1</string>
+  <string name="device_ham_codename" translatable="false">Ham</string>
+  <string name="device_ham_maintainer" translatable="false">Ankur Pandey(ankurpandeyvns)</string>
+
+  <string name="device_nubia_nx531j" translatable="false">Nubia Z11</string>
+  <string name="device_nubia_nx531j_codename" translatable="false">nx531j</string>
+  <string name="device_nubia_nx531j_maintainer" translatable="false">ZhangXueZe</string>
+
+  <string name="device_vega_A910" translatable="false">Vega Sky A910</string>
+  <string name="device_vega_A910_codename" translatable="false">A910</string>
+  <string name="device_vega_A910_maintainer" translatable="false">XDAVN</string>
+
+  <string name="device_vega_A900" translatable="false">Vega Sky A900</string>
+  <string name="device_vega_A900_codename" translatable="false">A900</string>
+  <string name="device_vega_A900_maintainer" translatable="false">XDAVN</string>
+
+  <string name="device_vega_A890" translatable="false">Vega Sky A890</string>
+  <string name="device_vega_A890_codename" translatable="false">A890</string>
+  <string name="device_vega_A890_maintainer" translatable="false">XDAVN</string>
+
+  <string name="device_lenovo_P1a42" translatable="false">Lenovo Vibe P1 Turbo</string>
+  <string name="device_lenovo_P1a42_codename" translatable="false">P1a42</string>
+  <string name="device_lenovo_P1a42_maintainer" translatable="false">Subham (DerkLord)</string>
+
+  <string name="device_Zuk_Z2" translatable="false">Zuk_Z2</string>
+  <string name="device_Zuk_Z2_codename" translatable="false"> Zuk_Z2</string>
+  <string name="device_Zuk_Z2_maintainer" translatable="false">Keerten </string>
+
+  <string name="device_ville" translatable="false">HTC One S</string>
+  <string name="device_ville_codename" translatable="false">Ville</string>
+  <string name="device_ville_maintainer" translatable="false">Moozon</string>
+
+  <string name="device_nubia_nx512j" translatable="false">Nubia Z9 Max</string>
+  <string name="device_nubia_nx512j_codename" translatable="false">nx512j</string>
+  <string name="device_nubia_nx512j_maintainer" translatable="false">Atul Bansode</string>
+
+  <string name="device_helium" translatable="false">Xiaomi Mi Max Prime</string>
+  <string name="device_helium_codename" translatable="false">Helium</string>
+  <string name="device_helium_maintainer" translatable="false">ROMFACTORY(SARTHAKMALLA)</string>
 </resources>

--- a/res/values/rr_attrs.xml
+++ b/res/values/rr_attrs.xml
@@ -176,4 +176,15 @@
     <attr name="changelog_color_commit_message" format="color" />
     <attr name="changelog_color_commit_bg" format="color" />
 
+    <!-- DevicePreference -->
+    <declare-styleable name="DevicePreference">
+        <attr name="codename" format="string" />
+        <attr name="maintainer" format="string" />
+        <attr name="type" format="integer">
+            <enum name="phone" value="0" />
+            <enum name="tablet" value="1" />
+            <enum name="other" value="2" />
+        </attr>
+    </declare-styleable>
+
 </resources>

--- a/res/values/rr_strings.xml
+++ b/res/values/rr_strings.xml
@@ -82,7 +82,8 @@
     <string name="device_maintainers_title_summary">List of devices and their official RR-OS maintainers</string>
     <string name="maintainers_note_title">Note</string>
     <string name="maintainers_note_title_summary">Make a pull request on Settings app with your name against your device if you want to apply to be a maintainer for a certain device</string>
- 
+    <string name="device_summary"><xliff:g example="goldfish" id="codename">%1$s</xliff:g>\nMaintainer - <xliff:g example="deletescape" id="maintainer">%2$s</xliff:g></string>
+
     <!-- The Drill -->
     <string name="rr_drill_title">The drill</string>
     <string name="drill_summary">Logcat or GTFO</string>

--- a/res/xml/device_maintainers_fragment.xml
+++ b/res/xml/device_maintainers_fragment.xml
@@ -1,1422 +1,1423 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-        android:title="@string/device_maintainers_title">
-   <Preference
-        style="?android:preferenceInformationStyle"
-        android:title="@string/maintainers_note_title"
-        android:summary="@string/maintainers_note_title_summary"
-        android:selectable="false" />
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:title="Tmp">
+    <Preference
+         style="?android:preferenceInformationStyle"
+         android:title="@string/maintainers_note_title"
+         android:summary="@string/maintainers_note_title_summary"
+         android:selectable="false" />
 
-   <PreferenceCategory
+    <PreferenceCategory
         android:id="@+id/device_category_lg"
-        android:title="@string/device_category_lg_title" >
+        android:title="@string/device_category_lg_title">
 
-    <Preference
-        android:id="@+id/device_bullhead"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_bullhead_summary"
-        android:selectable="false"
-        android:title="@string/device_bullhead" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_bullhead"
+            android:title="@string/device_bullhead"
+            app:codename="@string/device_bullhead_codename"
+            app:maintainer="@string/device_bullhead_maintainer"
+            app:type="phone" />
 
-    <Preference
-        android:id="@+id/device_g5"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_g5_summary"
-        android:selectable="false"
-        android:title="@string/device_g5" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_g5"
+            android:title="@string/device_g5"
+            app:codename="@string/device_g5_codename"
+            app:maintainer="@string/device_g5_maintainer"
+            app:type="phone" />
 
-    <Preference
-        android:id="@+id/device_g5_tmo"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_g5_tmo_summary"
-        android:selectable="false"
-        android:title="@string/device_g5_tmo" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_g5_tmo"
+            android:title="@string/device_g5_tmo"
+            app:codename="@string/device_g5_tmo_codename"
+            app:maintainer="@string/device_g5_tmo_maintainer"
+            app:type="phone" />
 
-    <Preference
-        android:id="@+id/device_g4"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_g4_summary"
-        android:selectable="false"
-        android:title="@string/device_g4" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_g4"
+            android:title="@string/device_g4"
+            app:codename="@string/device_g4_codename"
+            app:maintainer="@string/device_g4_maintainer"
+            app:type="phone" />
 
-    <Preference
-        android:id="@+id/device_g2_vs980"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_g2_vs980_summary"
-        android:selectable="false" 
-        android:title="@string/device_g2_vs980" />
-    
-    <Preference
-        android:id="@+id/device_g3"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_g3_summary"
-        android:selectable="false"
-        android:title="@string/device_g3" />
-    <Preference
-        android:id="@+id/device_g3_tmo"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_g3_tmo_summary"
-        android:selectable="false"
-        android:title="@string/device_g3_tmo" />
-    <Preference
-        android:id="@+id/device_att_g3"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_att_g3_summary"
-        android:selectable="false"
-        android:title="@string/device_att_g3" />
-    <Preference
-        android:id="@+id/device_g3_kr"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_g3_kr_summary"
-        android:selectable="false"
-        android:title="@string/device_g3_kr" />
-    <Preference
-        android:id="@+id/device_g3_spr"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_g3_spr_summary"
-        android:selectable="false"
-        android:title="@string/device_g3_spr" />
-    <Preference
-        android:id="@+id/device_g3_vzw"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_g3_vzw_summary"
-        android:selectable="false"
-        android:title="@string/device_g3_vzw" />
-    <Preference
-        android:id="@+id/device_g3_beat"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_g3_beat_summary"
-        android:selectable="false"
-        android:title="@string/device_g3_beat" />
-    <Preference
-        android:id="@+id/device_g2"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_g2_summary"
-        android:selectable="false"
-        android:title="@string/device_g2" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_g2_vs980"
+            android:title="@string/device_g2_vs980"
+            app:codename="@string/device_g2_vs980_codename"
+            app:maintainer="@string/device_g2_vs980_maintainer"
+            app:type="phone" />
 
-   <Preference
-        android:id="@+id/device_g2_spr"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_g2_spr_summary"
-        android:selectable="false" 
-        android:title="@string/device_g2_spr" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_g3"
+            android:title="@string/device_g3"
+            app:codename="@string/device_g3_codename"
+            app:maintainer="@string/device_g3_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_g3_tmo"
+            android:title="@string/device_g3_tmo"
+            app:codename="@string/device_g3_tmo_codename"
+            app:maintainer="@string/device_g3_tmo_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_att_g3"
+            android:title="@string/device_att_g3"
+            app:codename="@string/device_att_g3_codename"
+            app:maintainer="@string/device_att_g3_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_g3_kr"
+            android:title="@string/device_g3_kr"
+            app:codename="@string/device_g3_kr_codename"
+            app:maintainer="@string/device_g3_kr_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_g3_spr"
+            android:title="@string/device_g3_spr"
+            app:codename="@string/device_g3_spr_codename"
+            app:maintainer="@string/device_g3_spr_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_g3_vzw"
+            android:title="@string/device_g3_vzw"
+            app:codename="@string/device_g3_vzw_codename"
+            app:maintainer="@string/device_g3_vzw_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_g3_beat"
+            android:title="@string/device_g3_beat"
+            app:codename="@string/device_g3_beat_codename"
+            app:maintainer="@string/device_g3_beat_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_g2"
+            android:title="@string/device_g2"
+            app:codename="@string/device_g2_codename"
+            app:maintainer="@string/device_g2_maintainer"
+            app:type="phone" />
 
-    <Preference
-        android:id="@+id/device_g2m"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_g2m_summary"
-        android:selectable="false"
-        android:title="@string/device_g2m" />
-    <Preference
-        android:id="@+id/device_n5"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_n5_summary"
-        android:selectable="false"
-        android:title="@string/device_n5" />
-    <Preference
-        android:id="@+id/device_n4"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_n4_summary"
-        android:selectable="false"
-        android:title="@string/device_n4" />
-    <Preference
-        android:id="@+id/device_l9"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_l9_summary"
-        android:selectable="false"
-        android:title="@string/device_l9" />
-    <Preference
-        android:id="@+id/device_og"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_og_summary"
-        android:selectable="false"
-        android:title="@string/device_og" />
-    <Preference
-        android:id="@+id/device_o4x"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_o4x_summary"
-        android:selectable="false"
-        android:title="@string/device_o4x" />
-    <Preference
-        android:id="@+id/device_v521"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_v521_summary"
-        android:selectable="false"
-        android:title="@string/device_v521" />
-    <Preference
-        android:id="@+id/device_l70pn"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_l70pn_summary"
-        android:selectable="false"
-        android:title="@string/device_l70pn" />
-  </PreferenceCategory>
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_g2_spr"
+            android:title="@string/device_g2_spr"
+            app:codename="@string/device_g2_spr_codename"
+            app:maintainer="@string/device_g2_spr_maintainer"
+            app:type="phone" />
+
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_g2m"
+            android:title="@string/device_g2m"
+            app:codename="@string/device_g2m_codename"
+            app:maintainer="@string/device_g2m_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_n5"
+            android:title="@string/device_n5"
+            app:codename="@string/device_n5_codename"
+            app:maintainer="@string/device_n5_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_n4"
+            android:title="@string/device_n4"
+            app:codename="@string/device_n4_codename"
+            app:maintainer="@string/device_n4_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_l9"
+            android:title="@string/device_l9"
+            app:codename="@string/device_l9_codename"
+            app:maintainer="@string/device_l9_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_og"
+            android:title="@string/device_og"
+            app:codename="@string/device_og_codename"
+            app:maintainer="@string/device_og_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_o4x"
+            android:title="@string/device_o4x"
+            app:codename="@string/device_o4x_codename"
+            app:maintainer="@string/device_o4x_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_v521"
+            android:title="@string/device_v521"
+            app:codename="@string/device_v521_codename"
+            app:maintainer="@string/device_v521_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_l70pn"
+            android:title="@string/device_l70pn"
+            app:codename="@string/device_l70pn_codename"
+            app:maintainer="@string/device_l70pn_maintainer"
+            app:type="phone" />
+    </PreferenceCategory>
 
     <PreferenceCategory
         android:id="@+id/device_category_motorola"
-        android:title="@string/device_category_motorola_title" >
+        android:title="@string/device_category_motorola_title">
 
-    <Preference
-        android:id="@+id/device_n6"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_n6_summary"
-        android:selectable="false"
-        android:title="@string/device_n6" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_n6"
+            android:title="@string/device_n6"
+            app:codename="@string/device_n6_codename"
+            app:maintainer="@string/device_n6_maintainer"
+            app:type="phone" />
 
-    <Preference
-        android:id="@+id/device_falcon"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_falcon_summary"
-        android:selectable="false"
-        android:title="@string/device_falcon" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_falcon"
+            android:title="@string/device_falcon"
+            app:codename="@string/device_falcon_codename"
+            app:maintainer="@string/device_falcon_maintainer"
+            app:type="phone" />
 
-    <Preference
-        android:id="@+id/device_condor"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_condor_summary"
-        android:selectable="false"
-        android:title="@string/device_condor" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_condor"
+            android:title="@string/device_condor"
+            app:codename="@string/device_condor_codename"
+            app:maintainer="@string/device_condor_maintainer"
+            app:type="phone" />
 
-    <Preference
-        android:id="@+id/device_otus"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_otus_summary"
-        android:selectable="false"
-        android:title="@string/device_otus" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_otus"
+            android:title="@string/device_otus"
+            app:codename="@string/device_otus_codename"
+            app:maintainer="@string/device_otus_maintainer"
+            app:type="phone" />
 
-    <Preference
-        android:id="@+id/device_surnia"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_surnia_summary"
-        android:selectable="false"
-        android:title="@string/device_surnia" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_surnia"
+            android:title="@string/device_surnia"
+            app:codename="@string/device_surnia_codename"
+            app:maintainer="@string/device_surnia_maintainer"
+            app:type="phone" />
 
-    <Preference
-        android:id="@+id/device_peregrine"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_peregrine_summary"
-        android:selectable="false"
-        android:title="@string/device_peregrine" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_peregrine"
+            android:title="@string/device_peregrine"
+            app:codename="@string/device_peregrine_codename"
+            app:maintainer="@string/device_peregrine_maintainer"
+            app:type="phone" />
 
-    <Preference
-        android:id="@+id/device_merlin"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_merlin_summary"
-        android:selectable="false"
-        android:title="@string/device_merlin" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_merlin"
+            android:title="@string/device_merlin"
+            app:codename="@string/device_merlin_codename"
+            app:maintainer="@string/device_merlin_maintainer"
+            app:type="phone" />
 
-    <Preference
-        android:id="@+id/device_moto_x14"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_moto_x14_summary"
-        android:selectable="false"
-        android:title="@string/device_moto_x14" />
-    <Preference
-        android:id="@+id/device_moto_x"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_moto_x_summary"
-        android:selectable="false"
-        android:title="@string/device_moto_x" />
-    <Preference
-        android:id="@+id/device_moto_x_clark"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_moto_x_clark_summary"
-        android:selectable="false"
-        android:title="@string/device_moto_x_clark" />
-    <Preference
-        android:id="@+id/device_titan"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_titan_summary"
-        android:selectable="false"
-        android:title="@string/device_titan" />
-    <Preference
-        android:id="@+id/device_thea"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_thea_summary"
-        android:selectable="false"
-        android:title="@string/device_thea" />
-    <Preference
-        android:id="@+id/device_osprey"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_osprey_summary"
-        android:selectable="false"
-        android:title="@string/device_osprey" />
-    <Preference
-        android:id="@+id/device_athene"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_athene_summary"
-        android:selectable="false"
-        android:title="@string/device_athene" />
-    <Preference
-        android:id="@+id/device_potter"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_potter_summary"
-        android:selectable="false"
-        android:title="@string/device_potter" />
-    <Preference
-        android:id="@+id/device_sanders"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_sanders_summary"
-        android:selectable="false"
-        android:title="@string/device_sanders" />
-    <Preference
-        android:id="@+id/device_lux_x"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_lux_x_summary"
-        android:selectable="false"
-        android:title="@string/device_lux_x" />
-    <Preference
-        android:id="@+id/device_quark"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_quark_summary"
-        android:selectable="false"
-        android:title="@string/device_quark" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_moto_x14"
+            android:title="@string/device_moto_x14"
+            app:codename="@string/device_moto_x14_codename"
+            app:maintainer="@string/device_moto_x14_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_moto_x"
+            android:title="@string/device_moto_x"
+            app:codename="@string/device_moto_x_codename"
+            app:maintainer="@string/device_moto_x_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_moto_x_clark"
+            android:title="@string/device_moto_x_clark"
+            app:codename="@string/device_moto_x_clark_codename"
+            app:maintainer="@string/device_moto_x_clark_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_titan"
+            android:title="@string/device_titan"
+            app:codename="@string/device_titan_codename"
+            app:maintainer="@string/device_titan_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_thea"
+            android:title="@string/device_thea"
+            app:codename="@string/device_thea_codename"
+            app:maintainer="@string/device_thea_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_osprey"
+            android:title="@string/device_osprey"
+            app:codename="@string/device_osprey_codename"
+            app:maintainer="@string/device_osprey_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_athene"
+            android:title="@string/device_athene"
+            app:codename="@string/device_athene_codename"
+            app:maintainer="@string/device_athene_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_potter"
+            android:title="@string/device_potter"
+            app:codename="@string/device_potter_codename"
+            app:maintainer="@string/device_potter_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_sanders"
+            android:title="@string/device_sanders"
+            app:codename="@string/device_sanders_codename"
+            app:maintainer="@string/device_sanders_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_lux_x"
+            android:title="@string/device_lux_x"
+            app:codename="@string/device_lux_x_codename"
+            app:maintainer="@string/device_lux_x_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_quark"
+            android:title="@string/device_quark"
+            app:codename="@string/device_quark_codename"
+            app:maintainer="@string/device_quark_maintainer"
+            app:type="phone" />
 
-     <Preference
-        android:id="@+id/device_harpia"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_harpia_summary"
-        android:selectable="false"
-        android:title="@string/device_harpia" />
-	    
-     <Preference
-        android:id="@+id/device_taido_row"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_taido_row_summary"
-        android:selectable="false"
-        android:title="@string/device_taido_row" />	    
-	    
- </PreferenceCategory>
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_harpia"
+            android:title="@string/device_harpia"
+            app:codename="@string/device_harpia_codename"
+            app:maintainer="@string/device_harpia_maintainer"
+            app:type="phone" />
 
-  <PreferenceCategory
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_taido_row"
+            android:title="@string/device_taido_row"
+            app:codename="@string/device_taido_row_codename"
+            app:maintainer="@string/device_taido_row_maintainer"
+            app:type="phone" />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory
         android:id="@+id/device_category_zte"
-        android:title="@string/device_category_zte_title" >
+        android:title="@string/device_category_zte_title">
 
-     <Preference
-        android:id="@+id/device_axon7"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_axon7_summary"
-        android:selectable="false"
-        android:title="@string/device_axon7" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_axon7"
+            android:title="@string/device_axon7"
+            app:codename="@string/device_axon7_codename"
+            app:maintainer="@string/device_axon7_maintainer"
+            app:type="phone" />
 
-     <Preference
-        android:id="@+id/device_a610"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_a610_summary"
-        android:selectable="false"
-        android:title="@string/device_a610" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_a610"
+            android:title="@string/device_a610"
+            app:codename="@string/device_a610_codename"
+            app:maintainer="@string/device_a610_maintainer"
+            app:type="phone" />
 
-  </PreferenceCategory>
+    </PreferenceCategory>
 
     <PreferenceCategory
         android:id="@+id/device_category_coolpad"
-        android:title="@string/device_category_coolpad_title" >
+        android:title="@string/device_category_coolpad_title">
 
-    <Preference
-        android:id="@+id/device_CP8676_I02"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_CP8676_I02_summary"
-        android:selectable="false"
-        android:title="@string/device_CP8676_I02" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_CP8676_I02"
+            android:title="@string/device_CP8676_I02"
+            app:codename="@string/device_CP8676_I02_codename"
+            app:maintainer="@string/device_CP8676_I02_maintainer"
+            app:type="phone" />
 
-  <Preference
-        android:id="@+id/device_CP8298_I00"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_CP8298_I00_summary"
-        android:selectable="false"
-        android:title="@string/device_CP8298_I00" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_CP8298_I00"
+            android:title="@string/device_CP8298_I00"
+            app:codename="@string/device_CP8298_I00_codename"
+            app:maintainer="@string/device_CP8298_I00_maintainer"
+            app:type="phone" />
 
     </PreferenceCategory>
 
     <PreferenceCategory
         android:id="@+id/device_category_lenovo"
-        android:title="@string/device_category_lenovo_title" >
+        android:title="@string/device_category_lenovo_title">
 
-    <Preference
-        android:id="@+id/device_A6020"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_A6020_summary"
-        android:selectable="false"
-        android:title="@string/device_A6020" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_A6020"
+            android:title="@string/device_A6020"
+            app:codename="@string/device_A6020_codename"
+            app:maintainer="@string/device_A6020_maintainer"
+            app:type="phone" />
 
-    <Preference
-  android:id="@+id/device_a6000"
-        android:icon="@drawable/phone_tint"
-  android:summary="@string/device_a6000_summary"
-  android:selectable="false"
-  android:title="@string/device_a6000" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_a6000"
+            android:title="@string/device_a6000"
+            app:codename="@string/device_a6000_codename"
+            app:maintainer="@string/device_a6000_maintainer"
+            app:type="phone" />
 
-    <Preference
-        android:id="@+id/device_aio_row"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_aio_row_summary"
-        android:selectable="false"
-        android:title="@string/device_aio_row" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_aio_row"
+            android:title="@string/device_aio_row"
+            app:codename="@string/device_aio_row_codename"
+            app:maintainer="@string/device_aio_row_maintainer"
+            app:type="phone" />
 
-    <Preference
-        android:id="@+id/device_aio_otfp"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_aio_otfp_summary"
-        android:selectable="false"
-        android:title="@string/device_aio_otfp" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_aio_otfp"
+            android:title="@string/device_aio_otfp"
+            app:codename="@string/device_aio_otfp_codename"
+            app:maintainer="@string/device_aio_otfp_maintainer"
+            app:type="phone" />
 
-    <Preference
-      android:id="@+id/device_A7010a48"
-            android:icon="@drawable/phone_tint"
-      android:summary="@string/device_A7010a48_summary"
-      android:selectable="false"
-      android:title="@string/device_A7010a48" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_A7010a48"
+            android:title="@string/device_A7010a48"
+            app:codename="@string/device_A7010a48_codename"
+            app:maintainer="@string/device_A7010a48_maintainer"
+            app:type="phone" />
 
-	    
-    <Preference
-      android:id="@+id/device_K33"
-            android:icon="@drawable/phone_tint"
-      android:summary="@string/device_K33_summary"
-      android:selectable="false"
-      android:title="@string/device_K33" />
 
-	    
-    <Preference
-      android:id="@+id/device_p2a42"
-            android:icon="@drawable/phone_tint"
-      android:summary="@string/device_p2a42_summary"
-      android:selectable="false"
-      android:title="@string/device_p2a42" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_K33"
+            android:title="@string/device_K33"
+            app:codename="@string/device_K33_codename"
+            app:maintainer="@string/device_K33_maintainer"
+            app:type="phone" />
 
-    <Preference
+
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_p2a42"
+            android:title="@string/device_p2a42"
+            app:codename="@string/device_p2a42_codename"
+            app:maintainer="@string/device_p2a42_maintainer"
+            app:type="phone" />
+
+        <com.android.settings.rr.Preference.DevicePreference
             android:id="@+id/device_lenovo_P1a42"
-            android:icon="@drawable/phone_tint"
-            android:summary="@string/device_lenovo_P1a42_summary"
-            android:selectable="false"
-            android:title="@string/device_lenovo_P1a42" />
+            android:title="@string/device_lenovo_P1a42"
+            app:codename="@string/device_lenovo_P1a42_codename"
+            app:maintainer="@string/device_lenovo_P1a42_maintainer"
+            app:type="phone" />
 
-  </PreferenceCategory>
+    </PreferenceCategory>
 
     <PreferenceCategory
         android:id="@+id/device_category_samsung"
-        android:title="@string/device_category_samsung_title" >
+        android:title="@string/device_category_samsung_title">
 
-     <Preference
-        android:id="@+id/device_manta"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_manta_summary"
-        android:selectable="false"
-        android:title="@string/device_manta" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_manta"
+            android:title="@string/device_manta"
+            app:codename="@string/device_manta_codename"
+            app:maintainer="@string/device_manta_maintainer"
+            app:type="phone" />
 
-     <Preference
-        android:id="@+id/device_d2lte"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_d2lte_summary"
-        android:selectable="false"
-        android:title="@string/device_d2lte" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_d2lte"
+            android:title="@string/device_d2lte"
+            app:codename="@string/device_d2lte_codename"
+            app:maintainer="@string/device_d2lte_maintainer"
+            app:type="phone" />
 
-     <Preference
-        android:id="@+id/device_herolte"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_herolte_summary"
-        android:selectable="false"
-        android:title="@string/device_herolte" />
-     <Preference
-        android:id="@+id/device_hero2lte"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_hero2lte_summary"
-        android:selectable="false"
-        android:title="@string/device_hero2lte" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_herolte"
+            android:title="@string/device_herolte"
+            app:codename="@string/device_herolte_codename"
+            app:maintainer="@string/device_herolte_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_hero2lte"
+            android:title="@string/device_hero2lte"
+            app:codename="@string/device_hero2lte_codename"
+            app:maintainer="@string/device_hero2lte_maintainer"
+            app:type="phone" />
 
-     <Preference
-        android:id="@+id/device_dreamlte"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_dreamlte_summary"
-        android:selectable="false"
-        android:title="@string/device_dreamlte" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_dreamlte"
+            android:title="@string/device_dreamlte"
+            app:codename="@string/device_dreamlte_codename"
+            app:maintainer="@string/device_dreamlte_maintainer"
+            app:type="phone" />
 
-     <Preference
-        android:id="@+id/device_dream2lte"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_dream2lte_summary"
-        android:selectable="false"
-        android:title="@string/device_dream2lte" />
-	    
-     <Preference
-        android:id="@+id/device_greatlte"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_greatlte_summary"
-        android:selectable="false"
-        android:title="@string/device_greatlte" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_dream2lte"
+            android:title="@string/device_dream2lte"
+            app:codename="@string/device_dream2lte_codename"
+            app:maintainer="@string/device_dream2lte_maintainer"
+            app:type="phone" />
 
-     <Preference
-  android:id="@+id/device_sltexx"
-  android:icon="@drawable/phone_tint"
-  android:summary="@string/device_sltexx_summary"
-  android:selectable="false"
-  android:title="@string/device_sltexx" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_greatlte"
+            android:title="@string/device_greatlte"
+            app:codename="@string/device_greatlte_codename"
+            app:maintainer="@string/device_greatlte_maintainer"
+            app:type="phone" />
 
-     <Preference
-  android:id="@+id/device_serrano3gxx"
-  android:icon="@drawable/phone_tint"
-  android:summary="@string/device_serrano3gxx_summary"
-  android:selectable="false"
-  android:title="@string/device_serrano3gxx" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_sltexx"
+            android:title="@string/device_sltexx"
+            app:codename="@string/device_sltexx_codename"
+            app:maintainer="@string/device_sltexx_maintainer"
+            app:type="phone" />
 
-     <Preference
-  android:id="@+id/device_serranodsdd"
-  android:icon="@drawable/phone_tint"
-  android:summary="@string/device_serranodsdd_summary"
-  android:selectable="false"
-  android:title="@string/device_serranodsdd" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_serrano3gxx"
+            android:title="@string/device_serrano3gxx"
+            app:codename="@string/device_serrano3gxx_codename"
+            app:maintainer="@string/device_serrano3gxx_maintainer"
+            app:type="phone" />
 
-     <Preference
-  android:id="@+id/device_serranoltexx"
-  android:icon="@drawable/phone_tint"
-  android:summary="@string/device_serranoltexx_summary"
-  android:selectable="false"
-  android:title="@string/device_serranoltexx" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_serranodsdd"
+            android:title="@string/device_serranodsdd"
+            app:codename="@string/device_serranodsdd_codename"
+            app:maintainer="@string/device_serranodsdd_maintainer"
+            app:type="phone" />
 
-     <Preference
-        android:id="@+id/device_fortuna3g"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_fortuna3g_summary"
-        android:selectable="false"
-        android:title="@string/device_fortuna3g" />
-     <Preference
-        android:id="@+id/device_fortunave3g"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_fortunave3g_summary"
-        android:selectable="false"
-        android:title="@string/device_fortunave3g" />
-     <Preference
-        android:id="@+id/device_fortunafz"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_fortunafz_summary"
-        android:selectable="false"
-        android:title="@string/device_fortunafz" />
-     <Preference
-        android:id="@+id/device_grandprimeve3g"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_grandprimeve3g_summary"
-        android:selectable="false"
-        android:title="@string/device_grandprimeve3g" />
-     <Preference
-        android:id="@+id/device_j5ltexx"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_j5ltexx_summary"
-        android:selectable="false"
-        android:title="@string/device_j5ltexx" />
-     <Preference
-        android:id="@+id/device_maguro"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_maguro_summary"
-        android:selectable="false"
-        android:title="@string/device_maguro" />
-    <Preference
-        android:id="@+id/device_i9300"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_i9300_summary"
-        android:selectable="false"
-        android:title="@string/device_i9300" />
-    <Preference
-        android:id="@+id/device_i9305"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_i9305_summary"
-        android:selectable="false"
-        android:title="@string/device_i9305" />
-    <Preference
-        android:id="@+id/device_jf"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_jf_summary"
-        android:selectable="false"
-        android:title="@string/device_jf" />
-    <Preference
-        android:id="@+id/device_ja3gxx"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_ja3gxx_summary"
-        android:selectable="false"
-        android:title="@string/device_ja3gxx" />
-    <Preference
-        android:id="@+id/device_klte"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_klte_summary"
-        android:selectable="false"
-        android:title="@string/device_klte" />
-    <Preference
-        android:id="@+id/device_k3gxx"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_k3gxx_summary"
-        android:selectable="false"
-        android:title="@string/device_k3gxx" />
-    <Preference
-        android:id="@+id/device_i9100"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_i9100_summary"
-        android:selectable="false"
-        android:title="@string/device_i9100" />
-    <Preference
-        android:id="@+id/device_i9001"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_i9001_summary"
-        android:selectable="false"
-        android:title="@string/device_i9001" />
-    <Preference
-        android:id="@+id/device_w"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_w_summary"
-        android:selectable="false"
-        android:title="@string/device_w" />
-    <Preference
-        android:id="@+id/device_n7100"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_n7100_summary"
-        android:selectable="false"
-        android:title="@string/device_n7100" />
-    <Preference
-        android:id="@+id/device_hlte"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_hlte_summary"
-        android:selectable="false"
-        android:title="@string/device_hlte" />
-    <Preference
-        android:id="@+id/device_ha3g"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_ha3g_summary"
-        android:selectable="false"
-        android:title="@string/device_ha3g" />
-    <Preference
-        android:id="@+id/device_t0ltexx"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_t0ltexx_summary"
-        android:selectable="false"
-        android:title="@string/device_t0ltexx" />
-    <Preference
-        android:id="@+id/device_n7000"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_n7000_summary"
-        android:selectable="false"
-        android:title="@string/device_n7000" />
-    <Preference
-        android:id="@+id/device_i9082"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_i9082_summary"
-        android:selectable="false"
-        android:title="@string/device_i9082" />
-    <Preference
-        android:id="@+id/device_i9105p"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_i9105p_summary"
-        android:selectable="false"
-        android:title="@string/device_i9105p" />
-    <Preference
-	android:id="@+id/device_i9515"
-	android:icon="@drawable/phone_tint"
-	android:summary="@string/device_i9515_summary"	
-	android:selectable="false"	      
-        android:title="@string/device_i9515" />
-    <Preference
-        android:id="@+id/device_mega"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_mega_summary"
-        android:selectable="false"
-        android:title="@string/device_mega" />
-    <Preference
-        android:id="@+id/device_i9200"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_i9200_summary"
-        android:selectable="false"
-        android:title="@string/device_i9200" />
-    <Preference
-        android:id="@+id/device_i9205"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_i9205_summary"
-        android:selectable="false"
-        android:title="@string/device_i9205" />
-    <Preference
-        android:id="@+id/device_tblte"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_tblte_summary"
-        android:selectable="false"
-        android:title="@string/device_tblte" />
-    <Preference
-        android:id="@+id/device_trltexx"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_trltexx_summary"
-        android:selectable="false"
-        android:title="@string/device_trltexx" />
-    <Preference
-        android:id="@+id/device_treltexx"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_treltexx_summary"
-        android:selectable="false"
-        android:title="@string/device_treltexx" />
-    <Preference
-        android:id="@+id/device_smp601"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_smp601_summary"
-        android:selectable="false"
-        android:title="@string/device_smp601" />
-    <Preference
-        android:id="@+id/device_a7"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_a7_summary"
-        android:selectable="false"
-        android:title="@string/device_a7" />
-    <Preference
-        android:id="@+id/device_sm_t217s"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_sm_t217s_summary"
-        android:selectable="false"
-        android:title="@string/device_sm_t217s" />
-    <Preference
-        android:id="@+id/device_n5100"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_n5100_summary"
-        android:selectable="false"
-        android:title="@string/device_n5100" />
-    <Preference
-        android:id="@+id/device_n5110"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_n5110_summary"
-        android:selectable="false"
-        android:title="@string/device_n5110" />
-    <Preference
-        android:id="@+id/device_n5120"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_n5120_summary"
-        android:selectable="false"
-      android:title="@string/device_n5120" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_serranoltexx"
+            android:title="@string/device_serranoltexx"
+            app:codename="@string/device_serranoltexx_codename"
+            app:maintainer="@string/device_serranoltexx_maintainer"
+            app:type="phone" />
 
-    <Preference
-        android:id="@+id/device_ms013g"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_ms013g_summary"
-        android:selectable="false"
-        android:title="@string/device_ms013g" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_fortuna3g"
+            android:title="@string/device_fortuna3g"
+            app:codename="@string/device_fortuna3g_codename"
+            app:maintainer="@string/device_fortuna3g_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_fortunave3g"
+            android:title="@string/device_fortunave3g"
+            app:codename="@string/device_fortunave3g_codename"
+            app:maintainer="@string/device_fortunave3g_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_fortunafz"
+            android:title="@string/device_fortunafz"
+            app:codename="@string/device_fortunafz_codename"
+            app:maintainer="@string/device_fortunafz_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_grandprimeve3g"
+            android:title="@string/device_grandprimeve3g"
+            app:codename="@string/device_grandprimeve3g_codename"
+            app:maintainer="@string/device_grandprimeve3g_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_j5ltexx"
+            android:title="@string/device_j5ltexx"
+            app:codename="@string/device_j5ltexx_codename"
+            app:maintainer="@string/device_j5ltexx_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_maguro"
+            android:title="@string/device_maguro"
+            app:codename="@string/device_maguro_codename"
+            app:maintainer="@string/device_maguro_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_i9300"
+            android:title="@string/device_i9300"
+            app:codename="@string/device_i9300_codename"
+            app:maintainer="@string/device_i9300_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_i9305"
+            android:title="@string/device_i9305"
+            app:codename="@string/device_i9305_codename"
+            app:maintainer="@string/device_i9305_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_jf"
+            android:title="@string/device_jf"
+            app:codename="@string/device_jf_codename"
+            app:maintainer="@string/device_jf_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_ja3gxx"
+            android:title="@string/device_ja3gxx"
+            app:codename="@string/device_ja3gxx_codename"
+            app:maintainer="@string/device_ja3gxx_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_klte"
+            android:title="@string/device_klte"
+            app:codename="@string/device_klte_codename"
+            app:maintainer="@string/device_klte_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_k3gxx"
+            android:title="@string/device_k3gxx"
+            app:codename="@string/device_k3gxx_codename"
+            app:maintainer="@string/device_k3gxx_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_i9100"
+            android:title="@string/device_i9100"
+            app:codename="@string/device_i9100_codename"
+            app:maintainer="@string/device_i9100_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_i9001"
+            android:title="@string/device_i9001"
+            app:codename="@string/device_i9001_codename"
+            app:maintainer="@string/device_i9001_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_w"
+            android:title="@string/device_w"
+            app:codename="@string/device_w_codename"
+            app:maintainer="@string/device_w_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_n7100"
+            android:title="@string/device_n7100"
+            app:codename="@string/device_n7100_codename"
+            app:maintainer="@string/device_n7100_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_hlte"
+            android:title="@string/device_hlte"
+            app:codename="@string/device_hlte_codename"
+            app:maintainer="@string/device_hlte_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_ha3g"
+            android:title="@string/device_ha3g"
+            app:codename="@string/device_ha3g_codename"
+            app:maintainer="@string/device_ha3g_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_t0ltexx"
+            android:title="@string/device_t0ltexx"
+            app:codename="@string/device_t0ltexx_codename"
+            app:maintainer="@string/device_t0ltexx_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_n7000"
+            android:title="@string/device_n7000"
+            app:codename="@string/device_n7000_codename"
+            app:maintainer="@string/device_n7000_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_i9082"
+            android:title="@string/device_i9082"
+            app:codename="@string/device_i9082_codename"
+            app:maintainer="@string/device_i9082_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_i9105p"
+            android:title="@string/device_i9105p"
+            app:codename="@string/device_i9105p_codename"
+            app:maintainer="@string/device_i9105p_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_i9515"
+            android:title="@string/device_i9515"
+            app:codename="@string/device_i9515_codename"
+            app:maintainer="@string/device_i9515_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_mega"
+            android:title="@string/device_mega"
+            app:codename="@string/device_mega_codename"
+            app:maintainer="@string/device_mega_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_i9200"
+            android:title="@string/device_i9200"
+            app:codename="@string/device_i9200_codename"
+            app:maintainer="@string/device_i9200_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_i9205"
+            android:title="@string/device_i9205"
+            app:codename="@string/device_i9205_codename"
+            app:maintainer="@string/device_i9205_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_tblte"
+            android:title="@string/device_tblte"
+            app:codename="@string/device_tblte_codename"
+            app:maintainer="@string/device_tblte_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_trltexx"
+            android:title="@string/device_trltexx"
+            app:codename="@string/device_trltexx_codename"
+            app:maintainer="@string/device_trltexx_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_treltexx"
+            android:title="@string/device_treltexx"
+            app:codename="@string/device_treltexx_codename"
+            app:maintainer="@string/device_treltexx_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_smp601"
+            android:title="@string/device_smp601"
+            app:codename="@string/device_smp601_codename"
+            app:maintainer="@string/device_smp601_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_a7"
+            android:title="@string/device_a7"
+            app:codename="@string/device_a7_codename"
+            app:maintainer="@string/device_a7_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_sm_t217s"
+            android:title="@string/device_sm_t217s"
+            app:codename="@string/device_sm_t217s_codename"
+            app:maintainer="@string/device_sm_t217s_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_n5100"
+            android:title="@string/device_n5100"
+            app:codename="@string/device_n5100_codename"
+            app:maintainer="@string/device_n5100_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_n5110"
+            android:title="@string/device_n5110"
+            app:codename="@string/device_n5110_codename"
+            app:maintainer="@string/device_n5110_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_n5120"
+            android:title="@string/device_n5120"
+            app:codename="@string/device_n5120_codename"
+            app:maintainer="@string/device_n5120_maintainer"
+            app:type="phone" />
 
-       </PreferenceCategory>
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_ms013g"
+            android:title="@string/device_ms013g"
+            app:codename="@string/device_ms013g_codename"
+            app:maintainer="@string/device_ms013g_maintainer"
+            app:type="phone" />
 
-     <PreferenceCategory
+    </PreferenceCategory>
+
+    <PreferenceCategory
         android:id="@+id/device_category_htc"
-        android:title="@string/device_category_htc_title" >
+        android:title="@string/device_category_htc_title">
 
-    <Preference
-        android:id="@+id/device_flounder"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_flounder_summary"
-        android:selectable="false"
-        android:title="@string/device_flounder" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_flounder"
+            android:title="@string/device_flounder"
+            app:codename="@string/device_flounder_codename"
+            app:maintainer="@string/device_flounder_maintainer"
+            app:type="phone" />
 
-  <Preference
-        android:id="@+id/device_m9"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_m9_summary"
-        android:selectable="false"
-        android:title="@string/device_m9" />
-    <Preference
-        android:id="@+id/device_m8"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_m8_summary"
-        android:selectable="false"
-        android:title="@string/device_m8" />
-    <Preference
-        android:id="@+id/device_m7"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_m7_summary"
-        android:selectable="false"
-        android:title="@string/device_m7" />
-    <Preference
-        android:id="@+id/device_htc_10"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_htc_10_summary"
-        android:selectable="false"
-        android:title="@string/device_htc_10" />
-    <Preference
-        android:id="@+id/device_ville"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_ville_summary"
-        android:selectable="false"
-        android:title="@string/device_ville" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_m9"
+            android:title="@string/device_m9"
+            app:codename="@string/device_m9_codename"
+            app:maintainer="@string/device_m9_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_m8"
+            android:title="@string/device_m8"
+            app:codename="@string/device_m8_codename"
+            app:maintainer="@string/device_m8_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_m7"
+            android:title="@string/device_m7"
+            app:codename="@string/device_m7_codename"
+            app:maintainer="@string/device_m7_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_htc_10"
+            android:title="@string/device_htc_10"
+            app:codename="@string/device_htc_10_codename"
+            app:maintainer="@string/device_htc_10_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_ville"
+            android:title="@string/device_ville"
+            app:codename="@string/device_ville_codename"
+            app:maintainer="@string/device_ville_maintainer"
+            app:type="phone" />
 
 
-     </PreferenceCategory>
+    </PreferenceCategory>
 
-     <PreferenceCategory
+    <PreferenceCategory
         android:id="@+id/device_category_hp"
-        android:title="@string/device_category_hp_title" >
+        android:title="@string/device_category_hp_title">
 
-    <Preference
-        android:id="@+id/device_tenderloin"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_tenderloin_summary"
-        android:selectable="false"
-        android:title="@string/device_tenderloin" />
-     </PreferenceCategory>
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_tenderloin"
+            android:title="@string/device_tenderloin"
+            app:codename="@string/device_tenderloin_codename"
+            app:maintainer="@string/device_tenderloin_maintainer"
+            app:type="tablet" />
+    </PreferenceCategory>
 
     <PreferenceCategory
         android:id="@+id/device_category_sony"
-        android:title="@string/device_category_sony_title" >
-    <Preference
-        android:id="@+id/device_huashan"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_huashan_summary"
-        android:selectable="false"
-        android:title="@string/device_huashan" />
-    <Preference
-        android:id="@+id/device_honami"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_honami_summary"
-        android:selectable="false"
-        android:title="@string/device_honami" />
-    <Preference
-        android:id="@+id/device_amami"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_amami_summary"
-        android:selectable="false"
-        android:title="@string/device_amami" />
-    <Preference
-        android:id="@+id/device_togari"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_togari_summary"
-        android:selectable="false"
-        android:title="@string/device_togari" />
-    <Preference
-        android:id="@+id/device_sirius"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_sirius_summary"
-        android:selectable="false"
-        android:title="@string/device_sirius" />
-    <Preference
-        android:id="@+id/device_yuga"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_yuga_summary"
-        android:selectable="false"
-        android:title="@string/device_yuga" />
-    <Preference
-        android:id="@+id/device_odin"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_odin_summary"
-        android:selectable="false"
-        android:title="@string/device_odin" />
-    <Preference
-        android:id="@+id/device_dogo"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_dogo_summary"
-        android:selectable="false"
-        android:title="@string/device_dogo" />
-   <Preference
-        android:id="@+id/device_neov"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_neov_summary"
-        android:selectable="false"
-        android:title="@string/device_neov" />
-     <Preference
-        android:id="@+id/device_taoshan"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_taoshan_summary"
-        android:selectable="false"
-        android:title="@string/device_taoshan" />
-     <Preference
-        android:id="@+id/device_nicki"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_nicki_summary"
-        android:selectable="false"
-        android:title="@string/device_nicki" />
-     <Preference
-        android:id="@+id/device_mint"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_mint_summary"
-        android:selectable="false"
-        android:title="@string/device_mint" />
-     <Preference
-        android:id="@+id/device_hayabusa"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_hayabusa_summary"
-        android:selectable="false"
-        android:title="@string/device_hayabusa" />
-     <Preference
-        android:id="@+id/device_tsubasa"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_tsubasa_summary"
-        android:selectable="false"
-        android:title="@string/device_tsubasa" />
-     <Preference
-        android:id="@+id/device_z3c"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_z3c_summary"
-        android:selectable="false"
-        android:title="@string/device_z3c" />
-   <Preference
-        android:id="@+id/device_anzu"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_anzu_summary"
-        android:selectable="false"
-        android:title="@string/device_anzu" />
-  <Preference
-        android:id="@+id/device_coconut"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_coconut_summary"
-        android:selectable="false"
-        android:title="@string/device_coconut" />
-  <Preference
-        android:id="@+id/device_hallon"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_hallon_summary"
-        android:selectable="false"
-        android:title="@string/device_hallon" />
-  <Preference
-        android:id="@+id/device_iyokan"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_iyokan_summary"
-        android:selectable="false"
-        android:title="@string/device_iyokan" />
-  <Preference
-        android:id="@+id/device_mango"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_mango_summary"
-        android:selectable="false"
-        android:title="@string/device_mango" />
-  <Preference
-        android:id="@+id/device_phoenix"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_phoenix_summary"
-        android:selectable="false"
-        android:title="@string/device_phoenix" />
-  <Preference
-        android:id="@+id/device_satsuma"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_satsuma_summary"
-        android:selectable="false"
-        android:title="@string/device_satsuma" />
-  <Preference
-        android:id="@+id/device_smultron"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_smultron_summary"
-        android:selectable="false"
-        android:title="@string/device_smultron" />
-  <Preference
-        android:id="@+id/device_urushi"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_urushi_summary"
-        android:selectable="false"
-        android:title="@string/device_urushi" />
+        android:title="@string/device_category_sony_title">
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_huashan"
+            android:title="@string/device_huashan"
+            app:codename="@string/device_huashan_codename"
+            app:maintainer="@string/device_huashan_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_honami"
+            android:title="@string/device_honami"
+            app:codename="@string/device_honami_codename"
+            app:maintainer="@string/device_honami_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_amami"
+            android:title="@string/device_amami"
+            app:codename="@string/device_amami_codename"
+            app:maintainer="@string/device_amami_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_togari"
+            android:title="@string/device_togari"
+            app:codename="@string/device_togari_codename"
+            app:maintainer="@string/device_togari_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_sirius"
+            android:title="@string/device_sirius"
+            app:codename="@string/device_sirius_codename"
+            app:maintainer="@string/device_sirius_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_yuga"
+            android:title="@string/device_yuga"
+            app:codename="@string/device_yuga_codename"
+            app:maintainer="@string/device_yuga_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_odin"
+            android:title="@string/device_odin"
+            app:codename="@string/device_odin_codename"
+            app:maintainer="@string/device_odin_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_dogo"
+            android:title="@string/device_dogo"
+            app:codename="@string/device_dogo_codename"
+            app:maintainer="@string/device_dogo_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_neov"
+            android:title="@string/device_neov"
+            app:codename="@string/device_neov_codename"
+            app:maintainer="@string/device_neov_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_taoshan"
+            android:title="@string/device_taoshan"
+            app:codename="@string/device_taoshan_codename"
+            app:maintainer="@string/device_taoshan_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_nicki"
+            android:title="@string/device_nicki"
+            app:codename="@string/device_nicki_codename"
+            app:maintainer="@string/device_nicki_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_mint"
+            android:title="@string/device_mint"
+            app:codename="@string/device_mint_codename"
+            app:maintainer="@string/device_mint_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_hayabusa"
+            android:title="@string/device_hayabusa"
+            app:codename="@string/device_hayabusa_codename"
+            app:maintainer="@string/device_hayabusa_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_tsubasa"
+            android:title="@string/device_tsubasa"
+            app:codename="@string/device_tsubasa_codename"
+            app:maintainer="@string/device_tsubasa_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_z3c"
+            android:title="@string/device_z3c"
+            app:codename="@string/device_z3c_codename"
+            app:maintainer="@string/device_z3c_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_anzu"
+            android:title="@string/device_anzu"
+            app:codename="@string/device_anzu_codename"
+            app:maintainer="@string/device_anzu_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_coconut"
+            android:title="@string/device_coconut"
+            app:codename="@string/device_coconut_codename"
+            app:maintainer="@string/device_coconut_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_hallon"
+            android:title="@string/device_hallon"
+            app:codename="@string/device_hallon_codename"
+            app:maintainer="@string/device_hallon_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_iyokan"
+            android:title="@string/device_iyokan"
+            app:codename="@string/device_iyokan_codename"
+            app:maintainer="@string/device_iyokan_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_mango"
+            android:title="@string/device_mango"
+            app:codename="@string/device_mango_codename"
+            app:maintainer="@string/device_mango_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_phoenix"
+            android:title="@string/device_phoenix"
+            app:codename="@string/device_phoenix_codename"
+            app:maintainer="@string/device_phoenix_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_satsuma"
+            android:title="@string/device_satsuma"
+            app:codename="@string/device_satsuma_codename"
+            app:maintainer="@string/device_satsuma_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_smultron"
+            android:title="@string/device_smultron"
+            app:codename="@string/device_smultron_codename"
+            app:maintainer="@string/device_smultron_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_urushi"
+            android:title="@string/device_urushi"
+            app:codename="@string/device_urushi_codename"
+            app:maintainer="@string/device_urushi_maintainer"
+            app:type="phone" />
 
-  </PreferenceCategory>
+    </PreferenceCategory>
 
     <PreferenceCategory
         android:id="@+id/device_category_oneplus"
-        android:title="@string/device_category_oneplus_title" >
+        android:title="@string/device_category_oneplus_title">
 
-    <Preference
-        android:id="@+id/device_oneplus"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_oneplus_summary"
-        android:selectable="false"
-        android:title="@string/device_oneplus" />
-    <Preference
-        android:id="@+id/device_oneplus2"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_oneplus2_summary"
-        android:selectable="false"
-        android:title="@string/device_oneplus2" />
-   <Preference
-        android:id="@+id/device_onyx"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_onyx_summary"
-        android:selectable="false"
-        android:title="@string/device_onyx" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_oneplus"
+            android:title="@string/device_oneplus"
+            app:codename="@string/device_oneplus_codename"
+            app:maintainer="@string/device_oneplus_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_oneplus2"
+            android:title="@string/device_oneplus2"
+            app:codename="@string/device_oneplus2_codename"
+            app:maintainer="@string/device_oneplus2_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_onyx"
+            android:title="@string/device_onyx"
+            app:codename="@string/device_onyx_codename"
+            app:maintainer="@string/device_onyx_maintainer"
+            app:type="phone" />
 
-   <Preference
-        android:id="@+id/device_oneplus3"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_oneplus3_summary"
-        android:selectable="false"
-        android:title="@string/device_oneplus3" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_oneplus3"
+            android:title="@string/device_oneplus3"
+            app:codename="@string/device_oneplus3_codename"
+            app:maintainer="@string/device_oneplus3_maintainer"
+            app:type="phone" />
 
-   <Preference
-        android:id="@+id/device_oneplus5"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_oneplus5_summary"
-        android:selectable="false"
-        android:title="@string/device_oneplus5" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_oneplus5"
+            android:title="@string/device_oneplus5"
+            app:codename="@string/device_oneplus5_codename"
+            app:maintainer="@string/device_oneplus5_maintainer"
+            app:type="phone" />
 
-   <Preference
-        android:id="@+id/device_oneplus5t"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_oneplus5t_summary"
-        android:selectable="false"
-        android:title="@string/device_oneplus5t" />
-        
-  </PreferenceCategory>
-       
-  <PreferenceCategory
-        android:id="@+id/device_category_yu"
-        android:title="@string/device_category_yu_title" >
-    <Preference
-        android:id="@+id/device_garlic"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_garlic_summary"
-        android:selectable="false"
-        android:title="@string/device_garlic" />
-    <Preference
-        android:id="@+id/device_tomato"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_tomato_summary"
-        android:selectable="false"
-        android:title="@string/device_tomato" />
-    <Preference
-      android:id="@+id/device_lettuce"
-      android:icon="@drawable/phone_tint"
-      android:summary="@string/device_lettuce_summary"
-      android:selectable="false"
-      android:title="@string/device_lettuce" />
-  <Preference
-        android:id="@+id/device_sambar"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_sambar_summary"
-        android:selectable="false"
-        android:title="@string/device_sambar" />
-  <Preference
-      android:id="@+id/device_jalebi"
-      android:icon="@drawable/phone_tint"
-      android:summary="@string/device_jalebi_summary"
-      android:selectable="false"
-      android:title="@string/device_jalebi" />
-       </PreferenceCategory>
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_oneplus5t"
+            android:title="@string/device_oneplus5t"
+            app:codename="@string/device_oneplus5t_codename"
+            app:maintainer="@string/device_oneplus5t_maintainer"
+            app:type="phone" />
 
-  <PreferenceCategory
-       android:id="@+id/device_category_xiaomi"
-       android:title="@string/device_category_xiaomi_title" >
-   <Preference
-       android:id="@+id/device_armani"
-       android:icon="@drawable/phone_tint"
-       android:summary="@string/device_armani_summary"
-       android:selectable="false"
-       android:title="@string/device_armani" />
-   <Preference
-       android:id="@+id/device_cancro"
-       android:icon="@drawable/phone_tint"
-       android:summary="@string/device_cancro_summary"
-       android:selectable="false"
-       android:title="@string/device_cancro" />
-   <Preference
-       android:id="@+id/device_gemini"
-       android:icon="@drawable/phone_tint"
-       android:summary="@string/device_gemini_summary"
-       android:selectable="false"
-       android:title="@string/device_gemini" />
-  <Preference
-       android:id="@+id/device_capricorn"
-       android:icon="@drawable/phone_tint"
-       android:summary="@string/device_capricorn_summary"
-       android:selectable="false"
-       android:title="@string/device_capricorn" />
-  <Preference
-       android:id="@+id/device_natrium"
-       android:icon="@drawable/phone_tint"
-       android:summary="@string/device_natrium_summary"
-       android:selectable="false"
-       android:title="@string/device_natrium" />
-	<Preference
-       android:id="@+id/device_sagit"
-       android:icon="@drawable/phone_tint"
-       android:summary="@string/device_sagit_summary"
-       android:selectable="false"
-       android:title="@string/device_sagit" />
-  <Preference
-       android:id="@+id/device_scorpio"
-       android:icon="@drawable/phone_tint"
-       android:summary="@string/device_scorpio_summary"
-       android:selectable="false"
-       android:title="@string/device_scorpio" />
-  <Preference
-       android:id="@+id/device_lithium"
-       android:icon="@drawable/phone_tint"
-       android:summary="@string/device_lithium_summary"
-       android:selectable="false"
-       android:title="@string/device_lithium" />
-   <Preference
-       android:id="@+id/device_dior"
-       android:icon="@drawable/phone_tint"
-       android:summary="@string/device_dior_summary"
-       android:selectable="false"
-       android:title="@string/device_dior" />
-   <Preference
-       android:id="@+id/device_ferrari"
-       android:icon="@drawable/phone_tint"
-       android:summary="@string/device_ferrari_summary"
-       android:selectable="false"
-       android:title="@string/device_ferrari" />
-   <Preference
-       android:id="@+id/device_hydrogen"
-       android:icon="@drawable/phone_tint"
-       android:summary="@string/device_hydrogen_summary"
-       android:selectable="false"
-       android:title="@string/device_hydrogen" />
-<Preference
-       android:id="@+id/device_helium"
-       android:icon="@drawable/phone_tint"
-       android:summary="@string/device_helium_summary"
-       android:selectable="false"
-       android:title="@string/device_helium" />	  
-   <Preference
-       android:id="@+id/device_kenzo"
-       android:icon="@drawable/phone_tint"
-       android:summary="@string/device_kenzo_summary"
-       android:selectable="false"
-       android:title="@string/device_kenzo" />
-   <Preference
-       android:id="@+id/device_mido"
-       android:icon="@drawable/phone_tint"
-       android:summary="@string/device_mido_summary"
-       android:selectable="false"
-       android:title="@string/device_mido" />
-   <Preference
-       android:id="@+id/device_libra"
-       android:icon="@drawable/phone_tint"
-       android:summary="@string/device_libra_summary"
-       android:selectable="false"
-       android:title="@string/device_libra" />
-   <Preference
-       android:id="@+id/device_redmi2"
-       android:icon="@drawable/phone_tint"
-       android:summary="@string/device_redmi2_summary"
-       android:selectable="false"
-       android:title="@string/device_redmi2" />
-    <Preference
-       android:id="@+id/device_redmi3"
-       android:icon="@drawable/phone_tint"
-       android:summary="@string/device_redmi3_summary"
-       android:selectable="false"
-       android:title="@string/device_redmi3" />
-     <Preference
-	android:id="@+id/device_land"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_land_summary"
-        android:selectable="false"
-        android:title="@string/device_land" />
-    <Preference
-       android:id="@+id/device_piccolo"
-       android:icon="@drawable/phone_tint"
-       android:summary="@string/device_piccolo_summary"
-       android:selectable="false"
-       android:title="@string/device_piccolo" />
-    <Preference
-       android:id="@+id/device_santoni"
-       android:icon="@drawable/phone_tint"
-       android:summary="@string/device_santoni_summary"
-       android:selectable="false"
-       android:title="@string/device_santoni" />
-       </PreferenceCategory>
-
-  <PreferenceCategory
-  android:id="@+id/device_category_one"
-  android:title="@string/device_category_one_title">
-    <Preference
-        android:id="@+id/device_sprout4"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_sprout4_summary"
-        android:selectable="false"
-        android:title="@string/device_sprout4" />
-    <Preference
-        android:id="@+id/device_sprout8"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_sprout8_summary"
-        android:selectable="false"
-        android:title="@string/device_sprout8" />
-    <Preference
-        android:id="@+id/device_seed"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_seed_summary"
-        android:selectable="false"
-        android:title="@string/device_seed" />
-    <Preference
-        android:id="@+id/device_shamrock"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_shamrock_summary"
-        android:selectable="false"
-        android:title="@string/device_shamrock" />
-  </PreferenceCategory>
-
- <PreferenceCategory
-        android:id="@+id/device_category_leeco"
-        android:title="@string/device_category_leeco_title" >
-
-    <Preference
-        android:id="@+id/device_s2"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_s2_summary"
-        android:selectable="false"
-        android:title="@string/device_s2" />
-    <Preference
-        android:id="@+id/device_X3"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_X3_summary"
-        android:selectable="false"
-        android:title="@string/device_X3" />
-    <Preference
-        android:id="@+id/device_x2"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_x2_summary"
-        android:selectable="false"
-        android:title="@string/device_x2" />
-    <Preference
-        android:id="@+id/device_zl1"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_zl1_summary"
-        android:selectable="false"
-        android:title="@string/device_zl1" />
-  </PreferenceCategory>
-
-  <PreferenceCategory
-  android:id="@+id/device_category_oppo"
-  android:title="@string/device_category_oppo_title">
-    <Preference
-        android:id="@+id/device_find7"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_find7_summary"
-        android:selectable="false"
-        android:title="@string/device_find7" />
-    <Preference
-        android:id="@+id/device_find7a"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_find7a_summary"
-        android:selectable="false"
-        android:title="@string/device_find7a" />
-    <Preference
-        android:id="@+id/device_r7plus"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_r7plus_summary"
-        android:selectable="false"
-        android:title="@string/device_r7plus" />
     </PreferenceCategory>
 
-<PreferenceCategory
-       android:id="@+id/device_category_huawei "
-       android:title="@string/device_category_huawei_title" >
+    <PreferenceCategory
+        android:id="@+id/device_category_yu"
+        android:title="@string/device_category_yu_title">
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_garlic"
+            android:title="@string/device_garlic"
+            app:codename="@string/device_garlic_codename"
+            app:maintainer="@string/device_garlic_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_tomato"
+            android:title="@string/device_tomato"
+            app:codename="@string/device_tomato_codename"
+            app:maintainer="@string/device_tomato_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_lettuce"
+            android:title="@string/device_lettuce"
+            app:codename="@string/device_lettuce_codename"
+            app:maintainer="@string/device_lettuce_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_sambar"
+            android:title="@string/device_sambar"
+            app:codename="@string/device_sambar_codename"
+            app:maintainer="@string/device_sambar_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_jalebi"
+            android:title="@string/device_jalebi"
+            app:codename="@string/device_jalebi_codename"
+            app:maintainer="@string/device_jalebi_maintainer"
+            app:type="phone" />
+    </PreferenceCategory>
 
-    <Preference
-        android:id="@+id/device_u9500"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_u9500_summary"
-        android:selectable="false"
-        android:title="@string/device_u9500" />
-    <Preference
-        android:id="@+id/device_kiwi"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_kiwi_summary"
-        android:selectable="false"
-        android:title="@string/device_kiwi" />
-    <Preference
-        android:id="@+id/device_angler"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_angler_summary"
-        android:selectable="false"
-        android:title="@string/device_angler" />
-  </PreferenceCategory>
+    <PreferenceCategory
+        android:id="@+id/device_category_xiaomi"
+        android:title="@string/device_category_xiaomi_title">
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_armani"
+            android:title="@string/device_armani"
+            app:codename="@string/device_armani_codename"
+            app:maintainer="@string/device_armani_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_cancro"
+            android:title="@string/device_cancro"
+            app:codename="@string/device_cancro_codename"
+            app:maintainer="@string/device_cancro_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_gemini"
+            android:title="@string/device_gemini"
+            app:codename="@string/device_gemini_codename"
+            app:maintainer="@string/device_gemini_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_capricorn"
+            android:title="@string/device_capricorn"
+            app:codename="@string/device_capricorn_codename"
+            app:maintainer="@string/device_capricorn_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_natrium"
+            android:title="@string/device_natrium"
+            app:codename="@string/device_natrium_codename"
+            app:maintainer="@string/device_natrium_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_sagit"
+            android:title="@string/device_sagit"
+            app:codename="@string/device_sagit_codename"
+            app:maintainer="@string/device_sagit_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_scorpio"
+            android:title="@string/device_scorpio"
+            app:codename="@string/device_scorpio_codename"
+            app:maintainer="@string/device_scorpio_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_lithium"
+            android:title="@string/device_lithium"
+            app:codename="@string/device_lithium_codename"
+            app:maintainer="@string/device_lithium_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_dior"
+            android:title="@string/device_dior"
+            app:codename="@string/device_dior_codename"
+            app:maintainer="@string/device_dior_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_ferrari"
+            android:title="@string/device_ferrari"
+            app:codename="@string/device_ferrari_codename"
+            app:maintainer="@string/device_ferrari_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_hydrogen"
+            android:title="@string/device_hydrogen"
+            app:codename="@string/device_hydrogen_codename"
+            app:maintainer="@string/device_hydrogen_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_helium"
+            android:title="@string/device_helium"
+            app:codename="@string/device_helium_codename"
+            app:maintainer="@string/device_helium_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_kenzo"
+            android:title="@string/device_kenzo"
+            app:codename="@string/device_kenzo_codename"
+            app:maintainer="@string/device_kenzo_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_mido"
+            android:title="@string/device_mido"
+            app:codename="@string/device_mido_codename"
+            app:maintainer="@string/device_mido_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_libra"
+            android:title="@string/device_libra"
+            app:codename="@string/device_libra_codename"
+            app:maintainer="@string/device_libra_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_redmi2"
+            android:title="@string/device_redmi2"
+            app:codename="@string/device_redmi2_codename"
+            app:maintainer="@string/device_redmi2_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_redmi3"
+            android:title="@string/device_redmi3"
+            app:codename="@string/device_redmi3_codename"
+            app:maintainer="@string/device_redmi3_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_land"
+            android:title="@string/device_land"
+            app:codename="@string/device_land_codename"
+            app:maintainer="@string/device_land_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_piccolo"
+            android:title="@string/device_piccolo"
+            app:codename="@string/device_piccolo_codename"
+            app:maintainer="@string/device_piccolo_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_santoni"
+            android:title="@string/device_santoni"
+            app:codename="@string/device_santoni_codename"
+            app:maintainer="@string/device_santoni_maintainer"
+            app:type="phone" />
+    </PreferenceCategory>
 
-<PreferenceCategory
-       android:id="@+id/device_category_asus "
-       android:title="@string/device_category_asus_title" >
+    <PreferenceCategory
+        android:id="@+id/device_category_one"
+        android:title="@string/device_category_one_title">
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_sprout4"
+            android:title="@string/device_sprout4"
+            app:codename="@string/device_sprout4_codename"
+            app:maintainer="@string/device_sprout4_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_sprout8"
+            android:title="@string/device_sprout8"
+            app:codename="@string/device_sprout8_codename"
+            app:maintainer="@string/device_sprout8_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_seed"
+            android:title="@string/device_seed"
+            app:codename="@string/device_seed_codename"
+            app:maintainer="@string/device_seed_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_shamrock"
+            android:title="@string/device_shamrock"
+            app:codename="@string/device_shamrock_codename"
+            app:maintainer="@string/device_shamrock_maintainer"
+            app:type="phone" />
+    </PreferenceCategory>
 
-    <Preference
-        android:id="@+id/device_nexus7"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_nexus7_summary"
-        android:selectable="false"
-        android:title="@string/device_nexus7" />
-		
-	<Preference
-        android:id="@+id/device_z012d"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_z012d_summary"
-        android:selectable="false"
-        android:title="@string/device_z012d" />
+    <PreferenceCategory
+        android:id="@+id/device_category_leeco"
+        android:title="@string/device_category_leeco_title">
 
-    <Preference
-        android:id="@+id/device_z00a"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_z00a_summary"
-        android:selectable="false"
-        android:title="@string/device_z00a" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_s2"
+            android:title="@string/device_s2"
+            app:codename="@string/device_s2_codename"
+            app:maintainer="@string/device_s2_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_X3"
+            android:title="@string/device_X3"
+            app:codename="@string/device_X3_codename"
+            app:maintainer="@string/device_X3_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_x2"
+            android:title="@string/device_x2"
+            app:codename="@string/device_x2_codename"
+            app:maintainer="@string/device_x2_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_zl1"
+            android:title="@string/device_zl1"
+            app:codename="@string/device_zl1_codename"
+            app:maintainer="@string/device_zl1_maintainer"
+            app:type="phone" />
+    </PreferenceCategory>
 
-    <Preference
-        android:id="@+id/device_z008"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_z008_summary"
-        android:selectable="false"
-        android:title="@string/device_z008" />
+    <PreferenceCategory
+        android:id="@+id/device_category_oppo"
+        android:title="@string/device_category_oppo_title">
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_find7"
+            android:title="@string/device_find7"
+            app:codename="@string/device_find7_codename"
+            app:maintainer="@string/device_find7_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_find7a"
+            android:title="@string/device_find7a"
+            app:codename="@string/device_find7a_codename"
+            app:maintainer="@string/device_find7a_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_r7plus"
+            android:title="@string/device_r7plus"
+            app:codename="@string/device_r7plus_codename"
+            app:maintainer="@string/device_r7plus_maintainer"
+            app:type="phone" />
+    </PreferenceCategory>
 
-        <Preference
-        android:id="@+id/device_T00F"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_T00F_summary"
-        android:selectable="false"
-        android:title="@string/device_T00F" />
+    <PreferenceCategory
+        android:id="@+id/device_category_huawei"
+        android:title="@string/device_category_huawei_title">
 
-        <Preference
-        android:id="@+id/device_z00t"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_z00t_summary"
-        android:selectable="false"
-        android:title="@string/device_z00t" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_u9500"
+            android:title="@string/device_u9500"
+            app:codename="@string/device_u9500_codename"
+            app:maintainer="@string/device_u9500_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_kiwi"
+            android:title="@string/device_kiwi"
+            app:codename="@string/device_kiwi_codename"
+            app:maintainer="@string/device_kiwi_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_angler"
+            android:title="@string/device_angler"
+            app:codename="@string/device_angler_codename"
+            app:maintainer="@string/device_angler_maintainer"
+            app:type="phone" />
+    </PreferenceCategory>
 
-  <Preference
-        android:id="@+id/device_z00l"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_z00l_summary"
-        android:selectable="false"
-        android:title="@string/device_z00t" />
+    <PreferenceCategory
+        android:id="@+id/device_category_asus"
+        android:title="@string/device_category_asus_title">
 
-  <Preference
-  android:id="@+id/device_Z00D"
-  android:icon="@drawable/phone_tint"
-  android:summary="@string/device_Z00D_summary"
-  android:selectable="false"
-  android:title="@string/device_Z00D" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_nexus7"
+            android:title="@string/device_nexus7"
+            app:codename="@string/device_nexus7_codename"
+            app:maintainer="@string/device_nexus7_maintainer"
+            app:type="phone" />
 
-  </PreferenceCategory>
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_z012d"
+            android:title="@string/device_z012d"
+            app:codename="@string/device_z012d_codename"
+            app:maintainer="@string/device_z012d_maintainer"
+            app:type="phone" />
 
-<PreferenceCategory
-       android:id="@+id/device_category_wfx "
-       android:title="@string/device_category_wfx_title" >
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_z00a"
+            android:title="@string/device_z00a"
+            app:codename="@string/device_z00a_codename"
+            app:maintainer="@string/device_z00a_maintainer"
+            app:type="phone" />
 
-    <Preference
-        android:id="@+id/device_wfxs"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_wfxs_summary"
-        android:selectable="false"
-        android:title="@string/device_wfxs" />
-    <Preference
-        android:id="@+id/device_wfxk"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_wfxk_summary"
-        android:selectable="false"
-        android:title="@string/device_wfxk" />
-  </PreferenceCategory>
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_z008"
+            android:title="@string/device_z008"
+            app:codename="@string/device_z008_codename"
+            app:maintainer="@string/device_z008_maintainer"
+            app:type="phone" />
 
-<PreferenceCategory
-       android:id="@+id/device_category_nvidia "
-       android:title="@string/device_category_nvidia_title" >
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_T00F"
+            android:title="@string/device_T00F"
+            app:codename="@string/device_T00F_codename"
+            app:maintainer="@string/device_T00F_maintainer"
+            app:type="phone" />
 
-    <Preference
-        android:id="@+id/device_shieldtablet"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_shieldtablet_summary"
-        android:selectable="false"
-        android:title="@string/device_shieldtablet" />
-  </PreferenceCategory>
-<PreferenceCategory
-       android:id="@+id/device_category_bq"
-       android:title="@string/device_category_bq_title" >
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_z00t"
+            android:title="@string/device_z00t"
+            app:codename="@string/device_z00t_codename"
+            app:maintainer="@string/device_z00t_maintainer"
+            app:type="phone" />
 
-    <Preference
-        android:id="@+id/device_paella"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_paella_summary"
-        android:selectable="false"
-        android:title="@string/device_paella" />
-</PreferenceCategory>
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_z00l"
+            android:title="@string/device_z00l"
+            app:codename="@string/device_z00l_codename"
+            app:maintainer="@string/device_z00l_maintainer"
+            app:type="phone" />
 
-<PreferenceCategory
-       android:id="@+id/device_category_zuk"
-       android:title="@string/device_category_zuk_title" >
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_Z00D"
+            android:title="@string/device_Z00D"
+            app:codename="@string/device_Z00D_codename"
+            app:maintainer="@string/device_Z00D_maintainer"
+            app:type="phone" />
 
-    <Preference
-        android:id="@+id/device_ham"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_ham_summary"
-        android:selectable="false"
-        android:title="@string/device_ham" />
+    </PreferenceCategory>
 
-    <Preference
-        android:id="@+id/device_Zuk_Z2"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_Zuk_Z2_summary"
-        android:selectable="false"
-        android:title="@string/device_Zuk_Z2" />
-  </PreferenceCategory>
+    <PreferenceCategory
+        android:id="@+id/device_category_wfx"
+        android:title="@string/device_category_wfx_title">
 
-<PreferenceCategory
-       android:id="@+id/device_category_nubia"
-       android:title="@string/device_category_nubia_title" >
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_wfxs"
+            android:title="@string/device_wfxs"
+            app:codename="@string/device_wfxs_codename"
+            app:maintainer="@string/device_wfxs_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_wfxk"
+            android:title="@string/device_wfxk"
+            app:codename="@string/device_wfxk_codename"
+            app:maintainer="@string/device_wfxk_maintainer"
+            app:type="phone" />
+    </PreferenceCategory>
 
-     <Preference
-        android:id="@+id/device_nubia_nx531j"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_nubia_nx531j_summary"
-        android:selectable="false"
-        android:title="@string/device_nubia_nx531j" />
-        
-     <Preference
-        android:id="@+id/device_nubia_nx512j"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_nubia_nx512j_summary"
-        android:selectable="false"
-        android:title="@string/device_nubia_nx512j" />        
-     </PreferenceCategory>
+    <PreferenceCategory
+        android:id="@+id/device_category_nvidia"
+        android:title="@string/device_category_nvidia_title">
 
-<PreferenceCategory
-       android:id="@+id/device_category_vega"
-       android:title="@string/device_category_vega_title" >
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_shieldtablet"
+            android:title="@string/device_shieldtablet"
+            app:codename="@string/device_shieldtablet_codename"
+            app:maintainer="@string/device_shieldtablet_maintainer"
+            app:type="tablet" />
+    </PreferenceCategory>
+    <PreferenceCategory
+        android:id="@+id/device_category_bq"
+        android:title="@string/device_category_bq_title">
 
-      <Preference
-        android:id="@+id/device_vega_A910"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_vega_A910_summary"
-        android:selectable="false"
-        android:title="@string/device_vega_A910" />
-      <Preference
-        android:id="@+id/device_vega_A900"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_vega_A900_summary"
-        android:selectable="false"
-        android:title="@string/device_vega_A900" />
-      <Preference
-        android:id="@+id/device_vega_A890"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_vega_A890_summary"
-        android:selectable="false"
-        android:title="@string/device_vega_A890" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_paella"
+            android:title="@string/device_paella"
+            app:codename="@string/device_paella_codename"
+            app:maintainer="@string/device_paella_maintainer"
+            app:type="phone" />
+    </PreferenceCategory>
 
-       </PreferenceCategory>
+    <PreferenceCategory
+        android:id="@+id/device_category_zuk"
+        android:title="@string/device_category_zuk_title">
 
-<PreferenceCategory
-       android:id="@+id/device_category_jiayu"
-       android:title="@string/device_category_jiayu_title" >
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_ham"
+            android:title="@string/device_ham"
+            app:codename="@string/device_ham_codename"
+            app:maintainer="@string/device_ham_maintainer"
+            app:type="phone" />
 
-      <Preference
-        android:id="@+id/device_s3_h560"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_s3_h560_summary"
-        android:selectable="false"
-        android:title="@string/device_s3_h560" />
-       </PreferenceCategory>
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_Zuk_Z2"
+            android:title="@string/device_Zuk_Z2"
+            app:codename="@string/device_Zuk_Z2_codename"
+            app:maintainer="@string/device_Zuk_Z2_maintainer"
+            app:type="phone" />
+    </PreferenceCategory>
 
-<PreferenceCategory
-       android:id="@+id/device_category_nextbit"
-       android:title="@string/device_category_nextbit_title" >
-  <Preference
-        android:id="@+id/device_nextbit_ether"
-        android:icon="@drawable/phone_tint"
-        android:summary="@string/device_nextbit_ether_summary"
-        android:selectable="false"
-        android:title="@string/device_nextbit_ether" />
-        </PreferenceCategory>
+    <PreferenceCategory
+        android:id="@+id/device_category_nubia"
+        android:title="@string/device_category_nubia_title">
 
-        <PreferenceCategory
-               android:id="@+id/device_category_google"
-               android:title="@string/device_category_google_title" >
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_nubia_nx531j"
+            android:title="@string/device_nubia_nx531j"
+            app:codename="@string/device_nubia_nx531j_codename"
+            app:maintainer="@string/device_nubia_nx531j_maintainer"
+            app:type="phone" />
 
-  <Preference
-      android:id="@+id/device_google_marlin"
-      android:icon="@drawable/phone_tint"
-      android:summary="@string/device_google_marlin_summary"
-      android:selectable="false"
-      android:title="@string/device_google_marlin" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_nubia_nx512j"
+            android:title="@string/device_nubia_nx512j"
+            app:codename="@string/device_nubia_nx512j_codename"
+            app:maintainer="@string/device_nubia_nx512j_maintainer"
+            app:type="phone" />
+    </PreferenceCategory>
 
-  <Preference
-          android:id="@+id/device_google_dragon"
-          android:icon="@drawable/phone_tint"
-          android:summary="@string/device_google_dragon_summary"
-          android:selectable="false"
-          android:title="@string/device_google_dragon" />
-</PreferenceCategory>
+    <PreferenceCategory
+        android:id="@+id/device_category_vega"
+        android:title="@string/device_category_vega_title">
+
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_vega_A910"
+            android:title="@string/device_vega_A910"
+            app:codename="@string/device_vega_A910_codename"
+            app:maintainer="@string/device_vega_A910_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_vega_A900"
+            android:title="@string/device_vega_A900"
+            app:codename="@string/device_vega_A900_codename"
+            app:maintainer="@string/device_vega_A900_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_vega_A890"
+            android:title="@string/device_vega_A890"
+            app:codename="@string/device_vega_A890_codename"
+            app:maintainer="@string/device_vega_A890_maintainer"
+            app:type="phone" />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:id="@+id/device_category_jiayu"
+        android:title="@string/device_category_jiayu_title">
+
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_s3_h560"
+            android:title="@string/device_s3_h560"
+            app:codename="@string/device_s3_h560_codename"
+            app:maintainer="@string/device_s3_h560_maintainer"
+            app:type="phone" />
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:id="@+id/device_category_nextbit"
+        android:title="@string/device_category_nextbit_title">
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_nextbit_ether"
+            android:title="@string/device_nextbit_ether"
+            app:codename="@string/device_nextbit_ether_codename"
+            app:maintainer="@string/device_nextbit_ether_maintainer"
+            app:type="phone" />
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:id="@+id/device_category_google"
+        android:title="@string/device_category_google_title">
+
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_google_marlin"
+            android:title="@string/device_google_marlin"
+            app:codename="@string/device_google_marlin_codename"
+            app:maintainer="@string/device_google_marlin_maintainer"
+            app:type="phone" />
+
+        <com.android.settings.rr.Preference.DevicePreference
+            android:id="@+id/device_google_dragon"
+            android:title="@string/device_google_dragon"
+            app:codename="@string/device_google_dragon_codename"
+            app:maintainer="@string/device_google_dragon_maintainer"
+            app:type="tablet" />
+    </PreferenceCategory>
 </PreferenceScreen>

--- a/src/com/android/settings/rr/Preferences/DevicePreference.java
+++ b/src/com/android/settings/rr/Preferences/DevicePreference.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2018 deletescape <deletescape@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.rr.Preferences;
+
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.support.v7.preference.Preference;
+import android.util.AttributeSet;
+
+import com.android.settings.R;
+
+public class DevicePreference extends Preference {
+
+    public DevicePreference(Context context, AttributeSet attrs,
+                            int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+        init(context, attrs);
+    }
+
+    public DevicePreference(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init(context, attrs);
+    }
+
+    public DevicePreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        init(context, attrs);
+    }
+
+    private void init(Context context, AttributeSet attrs) {
+        setSelectable(false);
+        TypedArray ta = context.obtainStyledAttributes(attrs, R.styleable.DevicePreference);
+        String codename = ta.getString(R.styleable.DevicePreference_codename);
+        String maintainer = ta.getString(R.styleable.DevicePreference_maintainer);
+        int type = ta.getInt(R.styleable.DevicePreference_type, 0);
+        String summary = context.getString(R.string.device_summary);
+        ta.recycle();
+        setSummary(String.format(summary, codename, maintainer));
+        setIcon(type == 1 ? R.drawable.tablet_tint : R.drawable.phone_tint);
+    }
+}
+


### PR DESCRIPTION
The new fragment makes it a lot harder for Maintainers to f***k up the formatting of their addition and makes translating a lot easier. In addition to that it also adds a simple way to display a tablet icon next to tablet devices and a simple way to extend the device types in the future.

I currently don't have a RR build env and no way to set one up. The fragment, all the code and the migrated data has been tested in a seperate, small app. I advise you to actually make a build with this commit to test if everything still works.

If any additions/changes are needed just reach out to me 😄 