### PR TITLE
settings: [SQUASH] Allow to customize notification led light [1/2]

### DIFF
--- a/res/layout/preference_nitrogen_seekbar.xml
+++ b/res/layout/preference_nitrogen_seekbar.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2014-2016 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="?android:attr/listPreferredItemHeightSmall"
+    android:gravity="center_vertical"
+    android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+    android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
+    android:clickable="false"
+    android:orientation="horizontal">
+
+    <LinearLayout
+        android:id="@+id/text_container"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:minWidth="44dp"
+        android:gravity="center"
+        android:orientation="horizontal"
+        android:paddingEnd="12dp"
+        android:paddingTop="4dp"
+        android:paddingBottom="4dp">
+        <TextView
+            android:id="@+id/seekBarPrefValue"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAlignment="center"
+            android:singleLine="true"
+            android:ellipsize="end"
+            android:textAppearance="@android:style/TextAppearance.Material.Body1"
+            android:textColor="?android:attr/textColorSecondary"/>
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:layout_marginTop="8dip"
+        android:layout_marginBottom="8dip">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+            <TextView
+                android:id="@android:id/title"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingStart="16dp"
+                android:singleLine="true"
+                android:textAppearance="@android:style/TextAppearance.Material.Subhead"
+                android:textColor="?android:attr/textColorPrimary"
+                android:ellipsize="marquee"
+                android:fadingEdge="horizontal"/>
+            <!-- Preference should place its actual preference widget here. -->
+            <LinearLayout
+                android:id="@android:id/widget_frame"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:gravity="end|center_vertical"
+                android:paddingStart="16dp"
+                android:orientation="vertical"/>
+        </LinearLayout>
+
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp">
+
+            <LinearLayout android:id="@+id/seekBarPrefBarContainer"
+                android:layout_gravity="center_vertical"
+                android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+        </FrameLayout>
+    </LinearLayout>
+
+</LinearLayout>

--- a/res/values/mcd_attrs.xml
+++ b/res/values/mcd_attrs.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2016 The Pure Nexus Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<resources>
+    <!-- Base attributes available to CustomSeekBarPreference. -->
+    <declare-styleable name="CustomSeekBarPreference">
+        <attr name="interval" format="integer" />
+        <attr name="min" format="integer" />
+        <attr name="units" format="string|reference" />
+        <attr name="defaultText" format="string|reference" />
+    </declare-styleable>
+
+    <!-- Value to pass to callback when restore button is pressed -->
+    <declare-styleable name="ColorPickerPreference">
+        <attr name="defaultColorValue" format="integer" />
+        <attr name="ledPreview" format="boolean" />
+        <attr name="alphaSlider" format="boolean" />
+    </declare-styleable>
+</resources>

--- a/res/values/mcd_strings.xml
+++ b/res/values/mcd_strings.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2016 The Pure Nexus Project
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+          http://www.apache.org/licenses/LICENSE-2.0
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+
+    <!-- Custom light color -->
+    <string name="light_customization">Led light notification</string>
+    <string name="custom_light_title">Light color</string>
+    <string name="custom_light_on_time_title">Light ON time during led pulse (ms)</string>
+    <string name="custom_light_off_time_title">Light OFF time during led pulse (ms)"</string>
+    <string name="app_notifications_info_desc">Tap on one of above channels to configure their light colors and other options</string>
+    <string name="value_equals_default">default</string>
+    <string name="show_light_on_zen_title">Blink during Do Not Disturb</string>
+</resources>

--- a/res/xml/legacy_channel_notification_settings.xml
+++ b/res/xml/legacy_channel_notification_settings.xml
@@ -42,4 +42,39 @@
         android:summary="@string/app_notification_override_dnd_summary"
         settings:useAdditionalSummary="true" />
 
+    <PreferenceCategory
+        android:key="light_customization"
+        android:title="@string/light_customization">
+    <!-- Custom led color -->
+        <com.android.settingslib.RestrictedSwitchPreference
+            android:key="lights"
+            android:title="@string/notification_show_lights_title" />
+
+	<SwitchPreference
+            android:key="show_light_on_zen"
+            android:title="@string/show_light_on_zen_title" />
+
+        <net.margaritov.preference.colorpicker.ColorPickerPreference
+            android:key="custom_light"
+            android:title="@string/custom_light_title"
+            settings:defaultColorValue="0xFFFFFFFF" />
+
+        <com.nitrogen.settings.preferences.CustomSeekBarPreference
+            android:key="custom_light_on_time"
+            android:title="@string/custom_light_on_time_title"
+            settings:defaultText="@string/value_equals_default"
+            settings:min="0"
+            android:max="10000"
+            settings:interval="100"
+            settings:units="" />
+
+        <com.nitrogen.settings.preferences.CustomSeekBarPreference
+            android:key="custom_light_off_time"
+            android:title="@string/custom_light_off_time_title"
+            settings:defaultText="@string/value_equals_default"
+            settings:min="0"
+            android:max="10000"
+            settings:interval="100"
+            settings:units="" />
+    </PreferenceCategory>
 </PreferenceScreen>

--- a/res/xml/upgraded_channel_notification_settings.xml
+++ b/res/xml/upgraded_channel_notification_settings.xml
@@ -46,12 +46,6 @@
             android:key="visibility_override"
             android:title="@string/app_notification_visibility_override_title" />
 
-        <!-- Lights -->
-        <com.android.settingslib.RestrictedSwitchPreference
-            android:key="lights"
-            android:title="@string/notification_show_lights_title"
-            settings:useAdditionalSummary="true" />
-
         <!-- Show badge -->
         <com.android.settingslib.RestrictedSwitchPreference
             android:key="badge"
@@ -68,4 +62,39 @@
 
     </PreferenceCategory>
 
+    <PreferenceCategory
+        android:key="light_customization"
+        android:title="@string/light_customization">
+        <!-- Lights -->
+        <com.android.settingslib.RestrictedSwitchPreference
+            android:key="lights"
+            android:title="@string/notification_show_lights_title" />
+
+        <SwitchPreference
+            android:key="show_light_on_zen"
+            android:title="@string/show_light_on_zen_title" />
+
+        <net.margaritov.preference.colorpicker.ColorPickerPreference
+            android:key="custom_light"
+            android:title="@string/custom_light_title"
+            settings:defaultColorValue="0xFFFFFFFF" />
+
+        <com.nitrogen.settings.preferences.CustomSeekBarPreference
+            android:key="custom_light_on_time"
+            android:title="@string/custom_light_on_time_title"
+            settings:defaultText="@string/value_equals_default"
+            settings:min="0"
+            android:max="10000"
+            settings:interval="100"
+            settings:units="" />
+
+        <com.nitrogen.settings.preferences.CustomSeekBarPreference
+            android:key="custom_light_off_time"
+            android:title="@string/custom_light_off_time_title"
+            settings:defaultText="@string/value_equals_default"
+            settings:min="0"
+            android:max="10000"
+            settings:interval="100"
+            settings:units="" />
+    </PreferenceCategory>
 </PreferenceScreen>

--- a/src/com/android/settings/notification/AppNotificationSettings.java
+++ b/src/com/android/settings/notification/AppNotificationSettings.java
@@ -25,6 +25,7 @@ import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.provider.Settings;
+import android.support.v14.preference.SwitchPreference;
 import android.support.v7.preference.Preference;
 import android.support.v7.preference.PreferenceCategory;
 import android.text.TextUtils;
@@ -34,6 +35,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.Switch;
 
+import com.nitrogen.settings.preferences.CustomSeekBarPreference;
 import com.android.internal.logging.nano.MetricsProto.MetricsEvent;
 import com.android.settings.R;
 import com.android.settings.Utils;
@@ -45,6 +47,10 @@ import com.android.settings.widget.MasterSwitchPreference;
 import com.android.settings.widget.SwitchBar;
 import com.android.settingslib.RestrictedSwitchPreference;
 import com.android.settingslib.widget.FooterPreference;
+
+import net.margaritov.preference.colorpicker.ColorPickerPreference;
+
+import static android.provider.Settings.System.NOTIFICATION_LIGHT_PULSE;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -63,9 +69,25 @@ public class AppNotificationSettings extends NotificationSettingsBase {
     private static String KEY_GENERAL_CATEGORY = "categories";
     private static String KEY_DELETED = "deleted";
 
+    private static final String KEY_INFO_DESC = "info_desc";
+    private static final String KEY_LIGHTS = "lights";
+    private static final String KEY_CUSTOM_LIGHT = "custom_light";
+    private static final String KEY_LIGHTS_ON_TIME = "custom_light_on_time";
+    private static final String KEY_LIGHTS_OFF_TIME = "custom_light_off_time";
+    private static final String KEY_LIGHT_ON_ZEN = "show_light_on_zen";
+
     private List<NotificationChannelGroup> mChannelGroupList;
     private List<PreferenceCategory> mChannelGroups = new ArrayList();
     private FooterPreference mDeletedChannels;
+
+    private PreferenceCategory mLightCategory;
+    private RestrictedSwitchPreference mLights;
+    private ColorPickerPreference mCustomLight;
+    private CustomSeekBarPreference mLightOnTime;
+    private CustomSeekBarPreference mLightOffTime;
+    private SwitchPreference mLightOnZen;
+    
+    private int mLedColor = 0;
 
     @Override
     public int getMetricsCategory() {
@@ -99,6 +121,9 @@ public class AppNotificationSettings extends NotificationSettingsBase {
             mChannel = mBackend.getChannel(
                     mAppRow.pkg, mAppRow.uid, NotificationChannel.DEFAULT_CHANNEL_ID);
             populateDefaultChannelPrefs();
+            mLightCategory = (PreferenceCategory) findPreference("light_customization");
+            //setup lights for legacy app default channel
+            setupLights();
         } else {
             addPreferencesFromResource(R.xml.upgraded_app_notification_settings);
             setupBadge();
@@ -118,11 +143,147 @@ public class AppNotificationSettings extends NotificationSettingsBase {
                     }
                     populateChannelList();
                     addAppLinkPref();
+                    setupInfoDesc(R.string.app_notifications_info_desc);
                 }
             }.execute();
         }
 
         updateDependents(mAppRow.banned);
+    }
+
+    private void setupLights() {
+        //find light prefs
+        mLights = (RestrictedSwitchPreference) findPreference(KEY_LIGHTS);
+        mCustomLight = (ColorPickerPreference) findPreference(KEY_CUSTOM_LIGHT);
+        mLightOnTime =(CustomSeekBarPreference) findPreference(KEY_LIGHTS_ON_TIME);
+        mLightOffTime = (CustomSeekBarPreference) findPreference(KEY_LIGHTS_OFF_TIME);
+        mLightOnZen = (SwitchPreference) findPreference(KEY_LIGHT_ON_ZEN);
+        mLights.setDisabledByAdmin(mSuspendedAppsAdmin);
+        mLights.setChecked(mChannel.shouldShowLights());
+        //enable custom light prefs is light is enabled
+        mCustomLight.setEnabled(!mLights.isDisabledByAdmin() && mChannel.shouldShowLights());
+        mLightOnTime.setEnabled(!mLights.isDisabledByAdmin() && mChannel.shouldShowLights());
+        mLightOffTime.setEnabled(!mLights.isDisabledByAdmin() && mChannel.shouldShowLights());
+        mLightOnZen.setEnabled(!mLights.isDisabledByAdmin() && mChannel.shouldShowLights());
+
+        //light pref
+        mLights.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                final boolean lights = (Boolean) newValue;
+                mChannel.enableLights(lights);
+                mChannel.lockFields(NotificationChannel.USER_LOCKED_LIGHTS);
+                mBackend.updateChannel(mPkg, mUid, mChannel);
+                showLedPreview();
+                if (!lights) {
+                    mNm.forcePulseLedLight(-1, -1, -1);
+                }
+                mCustomLight.setEnabled(lights);
+                mLightOnTime.setEnabled(lights);
+                mLightOffTime.setEnabled(lights);
+                mLightOnZen.setEnabled(lights);
+                //enable NOTIFICATION_LIGHT_PULSE if the user wants to enable notification light for an app
+                //if he disables mLights, don't do anything (other apps may have it still enabled)
+                if (lights && Settings.System.getInt(mContext.getContentResolver(),
+                        NOTIFICATION_LIGHT_PULSE, 1) == 0) {
+                    Settings.System.putInt(mContext.getContentResolver(),
+                        NOTIFICATION_LIGHT_PULSE, 1);
+                }
+                return true;
+            }
+        });
+        //light color pref
+        int defaultLightColor = getResources().getColor(com.android.internal.R.color.config_defaultNotificationColor);
+        mCustomLight.setDefaultColor(defaultLightColor);
+        mLedColor = (mChannel.getLightColor() != 0 ? mChannel.getLightColor() : defaultLightColor);
+        mCustomLight.setAlphaSliderEnabled(false);
+        mCustomLight.setNewPreviewColor(mLedColor);
+        mCustomLight.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                mLedColor = ((Integer) newValue).intValue();
+                mChannel.setLightColor(mLedColor);
+                mBackend.updateChannel(mPkg, mUid, mChannel);
+                showLedPreview();
+                return true;
+            }
+        });
+        //light on time pref
+        int lightOn = mChannel.getLightOnTime();
+        int defaultLightOn = getResources().getInteger(
+                com.android.internal.R.integer.config_defaultNotificationLedOn);
+        mLightOnTime.setDefaultValue(defaultLightOn);
+        lightOn = lightOn == 0 ? defaultLightOn : lightOn;
+        mLightOnTime.setValue(lightOn);
+        mLightOnTime.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                int val = (Integer) newValue;
+                mChannel.setLightOnTime(val);
+                mBackend.updateChannel(mPkg, mUid, mChannel);
+                showLedPreview();
+                return true;
+            }
+        });
+        //light off time pref
+        int lightOff = mChannel.getLightOffTime();
+        int defaultLightOff = getResources().getInteger(
+                com.android.internal.R.integer.config_defaultNotificationLedOff);
+        mLightOffTime.setDefaultValue(defaultLightOff);
+        lightOff = lightOff == 0 ? defaultLightOff : lightOff;
+        mLightOffTime.setValue(lightOff);
+        mLightOffTime.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                int val = (Integer) newValue;
+                mChannel.setLightOffTime(val);
+                mBackend.updateChannel(mPkg, mUid, mChannel);
+                showLedPreview();
+                return true;
+            }
+        });
+        //light on zen pref
+        mLightOnZen.setChecked(mChannel.shouldLightOnZen());
+        mLightOnZen.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                final boolean show = (Boolean) newValue;
+                mChannel.setLightOnZen(show);
+                mBackend.updateChannel(mPkg, mUid, mChannel);
+                return true;
+            }
+        });
+
+        showLedPreview();
+    }
+
+    private void showLedPreview() {
+        if (mChannel.shouldShowLights()) {
+            if (mLedColor == 0xFFFFFFFF) {
+                // i've no idea why atm but this is needed 
+                mLedColor = 0xffffff;
+            }
+            mNm.forcePulseLedLight(
+                    mLedColor, mChannel.getLightOnTime(), mChannel.getLightOffTime());
+        }
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        mNm.forcePulseLedLight(-1, -1, -1);
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+        mNm.forcePulseLedLight(-1, -1, -1);
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        mNm.forcePulseLedLight(-1, -1, -1);
     }
 
     private void addHeaderPref() {
@@ -307,6 +468,17 @@ public class AppNotificationSettings extends NotificationSettingsBase {
         setupBlockDesc(R.string.app_notifications_off_desc);
     }
 
+    protected void setupInfoDesc(int summaryResId) {
+        FooterPreference infoDesc = (FooterPreference) getPreferenceScreen().findPreference(
+                KEY_INFO_DESC);
+        infoDesc = new FooterPreference(getPrefContext());
+        infoDesc.setSelectable(false);
+        infoDesc.setTitle(summaryResId);
+        infoDesc.setEnabled(false);
+        infoDesc.setOrder(50);
+        getPreferenceScreen().addPreference(infoDesc);
+    }
+
     protected void updateDependents(boolean banned) {
         for (PreferenceCategory category : mChannelGroups) {
             setVisible(category, !banned);
@@ -323,6 +495,7 @@ public class AppNotificationSettings extends NotificationSettingsBase {
                     && mDndVisualEffectsSuppressed));
             setVisible(mVisibilityOverride, !banned &&
                     checkCanBeVisible(NotificationManager.IMPORTANCE_LOW) && isLockScreenSecure());
+            setVisible(mLightCategory, !banned);
         }
         if (mAppLink != null) {
             setVisible(mAppLink, !banned);

--- a/src/com/android/settings/notification/PulseNotificationPreferenceController.java
+++ b/src/com/android/settings/notification/PulseNotificationPreferenceController.java
@@ -83,13 +83,9 @@ public class PulseNotificationPreferenceController extends AbstractPreferenceCon
 
     @Override
     public void updateState(Preference preference) {
-        try {
-            final boolean checked = Settings.System.getInt(mContext.getContentResolver(),
-                    NOTIFICATION_LIGHT_PULSE) == 1;
-            ((TwoStatePreference) preference).setChecked(checked);
-        } catch (Settings.SettingNotFoundException snfe) {
-            Log.e(TAG, NOTIFICATION_LIGHT_PULSE + " not found");
-        }
+       final boolean checked = Settings.System.getInt(mContext.getContentResolver(),
+                NOTIFICATION_LIGHT_PULSE, 1) == 1;
+        ((TwoStatePreference) preference).setChecked(checked);
     }
 
     @Override

--- a/src/com/nitrogen/settings/preferences/CustomSeekBarPreference.java
+++ b/src/com/nitrogen/settings/preferences/CustomSeekBarPreference.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright (C) 2016 The Dirty Unicorns Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.nitrogen.settings.preferences;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.util.AttributeSet;
+import android.util.Log;
+import android.view.ViewParent;
+import android.view.ViewGroup;
+import android.widget.SeekBar;
+import android.widget.TextView;
+import android.support.v7.preference.*;
+
+import com.android.settings.R;
+
+public class CustomSeekBarPreference extends Preference implements SeekBar.OnSeekBarChangeListener {
+    private final String TAG = getClass().getName();
+    private static final String SETTINGS_NS = "http://schemas.android.com/apk/res/com.android.settings";
+    private static final String ANDROIDNS = "http://schemas.android.com/apk/res/android";
+    private static final int DEFAULT_VALUE = 50;
+
+    private int mMin = 0;
+    private int mInterval = 1;
+    private int mCurrentValue;
+    private int mDefaultValue = -1;
+    private int mMax = 255;
+    private String mUnits = "";
+    private String mDefaultText = "";
+    private SeekBar mSeekBar;
+    private TextView mTitle;
+    private TextView mStatusText;
+
+    public CustomSeekBarPreference(Context context, AttributeSet attrs, int defStyleAttr,
+            int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+        final TypedArray a = context.obtainStyledAttributes(
+                attrs, R.styleable.CustomSeekBarPreference);
+
+        mMax = attrs.getAttributeIntValue(ANDROIDNS, "max", 255);
+        mMin = attrs.getAttributeIntValue(SETTINGS_NS, "min", 0);
+        mDefaultValue = attrs.getAttributeIntValue(ANDROIDNS, "defaultValue", -1);
+        if (mDefaultValue > mMax) {
+            mDefaultValue = mMax;
+        }
+        mUnits = getAttributeStringValue(attrs, SETTINGS_NS, "units", "");
+        mDefaultText = getAttributeStringValue(attrs, SETTINGS_NS, "defaultText", "Def");
+
+        Integer id = a.getResourceId(R.styleable.CustomSeekBarPreference_units, 0);
+        if (id > 0) {
+            mUnits = context.getResources().getString(id);
+        }
+        id = a.getResourceId(R.styleable.CustomSeekBarPreference_defaultText, 0);
+        if (id > 0) {
+            mDefaultText = context.getResources().getString(id);
+        }
+
+        try {
+            String newInterval = attrs.getAttributeValue(SETTINGS_NS, "interval");
+            if (newInterval != null)
+                mInterval = Integer.parseInt(newInterval);
+        } catch (Exception e) {
+            Log.e(TAG, "Invalid interval value", e);
+        }
+
+        a.recycle();
+        mSeekBar = new SeekBar(context, attrs);
+        mSeekBar.setMax(mMax - mMin);
+        mSeekBar.setOnSeekBarChangeListener(this);
+        setLayoutResource(R.layout.preference_nitrogen_seekbar);
+    }
+
+    public CustomSeekBarPreference(Context context, AttributeSet attrs, int defStyleAttr) {
+        this(context, attrs, defStyleAttr, 0);
+    }
+
+    public CustomSeekBarPreference(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public CustomSeekBarPreference(Context context) {
+        this(context, null);
+    }
+
+    private String getAttributeStringValue(AttributeSet attrs, String namespace, String name,
+            String defaultValue) {
+        String value = attrs.getAttributeValue(namespace, name);
+        if (value == null)
+            value = defaultValue;
+
+        return value;
+    }
+
+    @Override
+    public void onDependencyChanged(Preference dependency, boolean disableDependent) {
+        super.onDependencyChanged(dependency, disableDependent);
+        this.setShouldDisableView(true);
+        if (mTitle != null)
+            mTitle.setEnabled(!disableDependent);
+        if (mSeekBar != null)
+            mSeekBar.setEnabled(!disableDependent);
+        if (mStatusText != null)
+            mStatusText.setEnabled(!disableDependent);
+    }
+
+    @Override
+    public void onBindViewHolder(PreferenceViewHolder view) {
+        super.onBindViewHolder(view);
+        try
+        {
+            // move our seekbar to the new view we've been given
+            ViewParent oldContainer = mSeekBar.getParent();
+            ViewGroup newContainer = (ViewGroup) view.findViewById(R.id.seekBarPrefBarContainer);
+
+            if (oldContainer != newContainer) {
+                // remove the seekbar from the old view
+                if (oldContainer != null) {
+                    ((ViewGroup) oldContainer).removeView(mSeekBar);
+                }
+                // remove the existing seekbar (there may not be one) and add ours
+                newContainer.removeAllViews();
+                newContainer.addView(mSeekBar, ViewGroup.LayoutParams.FILL_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT);
+            }
+        } catch (Exception ex) {
+            Log.e(TAG, "Error binding view: " + ex.toString());
+        }
+        mStatusText = (TextView) view.findViewById(R.id.seekBarPrefValue);
+        if (mCurrentValue == mDefaultValue) {
+            mStatusText.setText(mDefaultText);
+        } else {
+            mStatusText.setText(String.valueOf(mCurrentValue) + mUnits);
+        }
+        mSeekBar.setProgress(mCurrentValue - mMin);
+        mTitle = (TextView) view.findViewById(android.R.id.title);
+
+        view.setDividerAllowedAbove(false);
+        //view.setDividerAllowedBelow(false);
+
+        mSeekBar.setEnabled(isEnabled());
+    }
+
+    public void setMax(int max) {
+        mMax = max;
+        mSeekBar.setMax(mMax - mMin);
+    }
+
+    public void setMin(int min) {
+        mMin = min;
+        mSeekBar.setMax(mMax - mMin);
+    }
+
+    public void setIntervalValue(int value) {
+        mInterval = value;
+    }
+
+    public void setValue(int value) {
+        mCurrentValue = value;
+    }
+
+    @Override
+    public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
+        int newValue = progress + mMin;
+        if (newValue > mMax)
+            newValue = mMax;
+        else if (newValue < mMin)
+            newValue = mMin;
+        else if (mInterval != 1 && newValue % mInterval != 0)
+            newValue = Math.round(((float) newValue) / mInterval) * mInterval;
+
+        // change rejected, revert to the previous value
+        if (!callChangeListener(newValue)) {
+            seekBar.setProgress(mCurrentValue - mMin);
+            return;
+        }
+        // change accepted, store it
+        mCurrentValue = newValue;
+        if (mStatusText != null) {
+            if (newValue == mDefaultValue) {
+                mStatusText.setText(mDefaultText);
+            } else {
+                mStatusText.setText(String.valueOf(newValue) + mUnits);
+            }
+        }
+        persistInt(newValue);
+    }
+
+    @Override
+    public void onStartTrackingTouch(SeekBar seekBar) {
+    }
+
+    @Override
+    public void onStopTrackingTouch(SeekBar seekBar) {
+        notifyChanged();
+    }
+
+    @Override
+    protected Object onGetDefaultValue(TypedArray ta, int index) {
+        int defaultValue = ta.getInt(index, DEFAULT_VALUE);
+        return defaultValue;
+    }
+
+    @Override
+    protected void onSetInitialValue(boolean restoreValue, Object defaultValue) {
+        if (restoreValue) {
+            mCurrentValue = getPersistedInt(mCurrentValue);
+        }
+        else {
+            int temp = 0;
+            try {
+                temp = (Integer) defaultValue;
+            } catch (Exception ex) {
+                Log.e(TAG, "Invalid default value: " + defaultValue.toString());
+            }
+            persistInt(temp);
+            mCurrentValue = temp;
+        }
+    }
+
+    public void setDefaultValue(int value) {
+        mDefaultValue = value;
+        if (mDefaultValue > mMax) {
+            mDefaultValue = mMax;
+        }
+        if (mCurrentValue == mDefaultValue) {
+            mStatusText.setText(mDefaultText);
+        }
+    }
+
+    @Override
+    public void setEnabled(boolean enabled) {
+        if (mSeekBar != null && mStatusText != null && mTitle != null) {
+            mSeekBar.setEnabled(enabled);
+            mStatusText.setEnabled(enabled);
+            mTitle.setEnabled(enabled);
+        }
+        super.setEnabled(enabled);
+    }
+}

--- a/src/net/margaritov/preference/colorpicker/ColorPickerDialog.java
+++ b/src/net/margaritov/preference/colorpicker/ColorPickerDialog.java
@@ -18,6 +18,7 @@
 package net.margaritov.preference.colorpicker;
 
 import android.app.AlertDialog;
+import android.app.NotificationManager;
 import android.content.Context;
 import android.graphics.PixelFormat;
 import android.os.Bundle;
@@ -38,15 +39,21 @@ public class ColorPickerDialog extends AlertDialog implements ColorPickerView.On
     private ColorPickerPanelView mNewColor;
     private EditText mHex;
 
+    private boolean mShowLedPreview;
+
+    private NotificationManager mNoMan;
+    private Context mContext;
+
     private OnColorChangedListener mListener;
 
     public interface OnColorChangedListener {
         void onColorChanged(int color);
     }
 
-    ColorPickerDialog(Context context, int initialColor) {
+    ColorPickerDialog(Context context, int initialColor, boolean showLedPreview) {
         super(context);
-
+        mContext = context;
+        mShowLedPreview = showLedPreview;
         init(initialColor);
     }
 
@@ -62,6 +69,8 @@ public class ColorPickerDialog extends AlertDialog implements ColorPickerView.On
 
         LayoutInflater inflater = (LayoutInflater) getContext().getSystemService(
                 Context.LAYOUT_INFLATER_SERVICE);
+        mNoMan = (NotificationManager)
+                mContext.getSystemService(Context.NOTIFICATION_SERVICE);
 
         assert inflater != null;
         View layout = inflater.inflate(R.layout.dui_dialog_color_picker, null);
@@ -81,6 +90,7 @@ public class ColorPickerDialog extends AlertDialog implements ColorPickerView.On
         mColorPicker.setOnColorChangedListener(this);
         mOldColor.setColor(color);
         mColorPicker.setColor(color, true);
+        showLed(color);
 
         if (mHex != null) {
             mHex.setText(ColorPickerPreference.convertToARGB(color));
@@ -109,6 +119,23 @@ public class ColorPickerDialog extends AlertDialog implements ColorPickerView.On
             }
         } catch (Exception ignored) {
         }
+        showLed(color);
+    }
+
+    private void showLed(int color) {
+        if (mShowLedPreview) {
+            if (color == 0xFFFFFFFF) {
+                // argb white doesn't work
+                color = 0xffffff;
+            }
+            mNoMan.forceShowLedLight(color);
+        }
+    }
+
+    private void switchOffLed() {
+        if (mShowLedPreview) {
+            mNoMan.forceShowLedLight(-1);
+        }
     }
 
     void setAlphaSliderVisible(boolean visible) {
@@ -136,6 +163,13 @@ public class ColorPickerDialog extends AlertDialog implements ColorPickerView.On
             }
         }
         dismiss();
+        switchOffLed();
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+        switchOffLed();
     }
 
     @NonNull
@@ -145,6 +179,7 @@ public class ColorPickerDialog extends AlertDialog implements ColorPickerView.On
         state.putInt("old_color", mOldColor.getColor());
         state.putInt("new_color", mNewColor.getColor());
         dismiss();
+        switchOffLed();
         return state;
     }
 

--- a/src/net/margaritov/preference/colorpicker/ColorPickerPreference.java
+++ b/src/net/margaritov/preference/colorpicker/ColorPickerPreference.java
@@ -61,6 +61,8 @@ public class ColorPickerPreference extends Preference implements
     boolean mUsesDefaultButton = false;
     int mDefValue = -1;
 
+    private boolean mShowLedPreview;
+
     private EditText mEditText;
 
     public ColorPickerPreference(Context context) {
@@ -98,6 +100,7 @@ public class ColorPickerPreference extends Preference implements
                 mUsesDefaultButton =  true;
                 mDefValue = defVal;
             }
+            mShowLedPreview = attrs.getAttributeBooleanValue(null, "ledPreview", false);
         }
     }
 
@@ -251,7 +254,7 @@ public class ColorPickerPreference extends Preference implements
     }
 
     protected void showDialog(Bundle state) {
-        mDialog = new ColorPickerDialog(getContext(), mValue);
+        mDialog = new ColorPickerDialog(getContext(), mValue, mShowLedPreview);
         mDialog.setOnColorChangedListener(this);
         if (mAlphaSliderEnabled) {
             mDialog.setAlphaSliderVisible(true);


### PR DESCRIPTION
idea from: https://gerrit.omnirom.org/#/c/26050/
Author ezio84 <brabus84@gmail.com> Sep 16, 2017 3:06 PM
Commit 8c8a660b270ed378c1ab9bec22c9bfcd6f96023c

* Allow to customize notification led light [1/2]
commit 0e62b27ff556696b1451d60e4269cd6e88e7133a

* Notification light: light during DND option [2/2]
commit 4f545c4645c913b1bb1a18ecf304790235218772

* Notification light: if we enable light for an app, enable system setting too
commit 37e586809a083d1016b40e058c1e99be1493e9b5

* Light on zen option: refresh switch state on Light disabled/enabled
commit a15f734a3d42992191ede8e8aacbfb98d44bf298

* Enable notifications led light by default [2/2]
commit 8879cc3f77b7d42e276c7faffa7932dbc6218989

* LED: Fix missed default color
commit a32818f1b7212f3ce0862e262704fe359835930e

* Notification lights: use default resources for color on and off [1/2]
commit b6f0d9e19521d9a1fdc0f495097fbc87b9d482ef

* Notification light: update from abc
commit e4f7d1a40a3d23b3948989ef973613ab1a084c5f

* App notification led customization: activate led preview
commit b94ee1b2d64eb87dfbf5dc468ac549a1ac2e24fd

* Color picker: allow to activate ongoing led light as color preview
commit b2e2a5bfc6c11c86a6caad10b6849e5669db31a7

* Disable useless alpha slider for notification lights color picker
commit 8febdee14a5681a3e89eaa60a3975702e7f97323