### PR TITLE
minor typo in strings

### DIFF
--- a/res/values/rr_strings.xml
+++ b/res/values/rr_strings.xml
@@ -1133,7 +1133,7 @@
     <string name="immersive_recents_statusbar">Statusbar only</string>
     <string name="immersive_recents_navbar">Navbar only</string>
     <string name="recents_icon_pack_title">Recents icon pack</string>
-    <string name="recents_icon_pack_summary">In recents view, hoose your app icon style using the icon packs included in your phone</string>
+    <string name="recents_icon_pack_summary">In recents view, Choose your app icon style using the icon packs included in your phone</string>
 
     <string name="show_4g_title">Show 4G</string>
     <string name="show_4g_summary">Show 4g instead of LTE in signal icons</string>


### PR DESCRIPTION
This also needs to be corrected in the `values-ro` folder but I dont know if it is automatically done or manually