### PR TITLE
Settings: Add an option to force pre-O apps to use full screen aspect…

### DIFF
--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -340,4 +340,8 @@
 
     <!-- Volume settings - Volume adjustment sound -->
     <string name="volume_adjust_sounds_title">Volume adjustment sounds</string>
+
+    <!-- Full screen aspect ratio -->
+    <string name="full_screen_aspect_ratio_title">Full screen aspect ratio</string>
+    <string name="full_screen_aspect_ratio_summary">Force apps to use full screen aspect ratio, note that some apps may not work properly in full screen</string>
 </resources>

--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -138,7 +138,14 @@
         android:summary="@string/proximity_wake_summary"
         lineage:requiresConfig="@*lineageos.platform:bool/config_proximityCheckOnWake" />
 
-    <!-- Use LineageParts for styles 
+
+    <lineageos.preference.LineageSystemSettingSwitchPreference
+        android:key="full_screen_aspect_ratio"
+        android:title="@string/full_screen_aspect_ratio_title"
+        android:summary="@string/full_screen_aspect_ratio_summary"
+        lineage:requiresConfig="@*lineageos.platform:bool/config_haveHigherAspectRatioScreen" />
+
+    <!-- Use LineageParts for styles
     <ListPreference
         android:key="theme"
         android:title="@string/device_theme"


### PR DESCRIPTION
… ratio

When an app target pre-O releases, the default max aspect ratio
is 1.86:1 which leads to ugly black areas on devices that have
screens with higher aspect ratio (for example Galaxy S8/S9).

This change adds an option to allow users to change default
aspect ratio for pre-O apps to 2.1 which would fit recent devices.

Change-Id: I398d21ffd137faa0be7fb11a138683813f80f3fe