### PR TITLE
Fix ampersand in att_g3 maintainer

### DIFF
--- a/res/values/resurrection_device_maintainers_strings.xml
+++ b/res/values/resurrection_device_maintainers_strings.xml
@@ -546,7 +546,7 @@
   <string name="device_g3_can_codename" translatable="false">D852</string>
   <string name="device_g3_can_maintainer" translatable="false">HardStyl3r</string>
 
-  <string name="device_att_g3" translatable="false">LG G3 AT&T</string>
+  <string name="device_att_g3" translatable="false">LG G3 AT&amp;T</string>
   <string name="device_att_g3_codename" translatable="false">D850</string>
   <string name="device_att_g3_maintainer" translatable="false">Hasan Okarci</string>
 


### PR DESCRIPTION
& is used as an escape character in XML, so a literal ampersand must be properly escaped as `&amp;`.