### PR TITLE
Change natrium oreo device maintainer to me

### DIFF
--- a/res/values/resurrection_device_maintainers_strings.xml
+++ b/res/values/resurrection_device_maintainers_strings.xml
@@ -696,7 +696,7 @@
 
   <string name="device_natrium" translatable="false">Xiaomi MI 5s Plus</string>
   <string name="device_natrium_codename" translatable="false">Natrium</string>
-  <string name="device_natrium_maintainer" translatable="false">Ali İhsan Hatun (Asderdd)</string>
+  <string name="device_natrium_maintainer" translatable="false">hacker1024</string>
 
   <string name="device_sagit" translatable="false">Xiaomi MI 6</string>
   <string name="device_sagit_codename" translatable="false">Sagit</string>


### PR DESCRIPTION
The previous person does not maintain oreo builds.

Can you please make this device official?
natrium device tree: https://github.com/hacker1024/android_device_xiaomi_natrium
msm8996-common device tree: https://github.com/hacker1024/android_device_xiaomi_msm8996-common
kernel: https://github.com/LineageOS/android_kernel_xiaomi_msm8996