### PR TITLE
Cleanup of night light settings required

### DIFF
--- a/res/drawable/ic_perm_vpn.xml
+++ b/res/drawable/ic_perm_vpn.xml
@@ -1,0 +1,26 @@
+<!--
+    Copyright (C) 2017 The Android Open Source Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24.0dp"
+        android:height="24.0dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0"
+        android:tint="#FF000000">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12.65,10C11.7,7.31,8.9,5.5,5.78,6.12C3.49,6.58,1.62,8.41,1.14,10.7C0.32,14.57,3.26,18,7,18c2.61,0,4.83-1.67,5.65-4H16
+v2c0,1.1,0.9,2,2,2h0c1.1,0,2-0.9,2-2v-2h1c1.1,0,2-0.9,2-2v0c0-1.1-0.9-2-2-2H12.65z M7,14c-1.1,0-2-0.9-2-2s0.9-2,2-2s2,0.9,2,2 S8.1,14,7,14z"/>
+</vector>

--- a/res/layout/expanded_item.xml
+++ b/res/layout/expanded_item.xml
@@ -23,8 +23,7 @@
     android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
     android:paddingTop="8dip"
     android:paddingBottom="8dip"
-    android:orientation="horizontal"
-    android:background="@drawable/expanded_item_background">
+    android:orientation="horizontal">
 
     <ImageView
         android:id="@+id/app_icon"

--- a/res/menu/main.xml
+++ b/res/menu/main.xml
@@ -26,7 +26,7 @@
     <item
         android:id="@+id/rr_panels_navigation"
         android:icon="@drawable/rr_panel_icon"
-        android:title="@string/rr_notification_panel_title"
+        android:title="@string/rr_panels_title"
         app:showAsAction="ifRoom|withText"/>
 
     <item

--- a/res/values-ar/rr_strings.xml
+++ b/res/values-ar/rr_strings.xml
@@ -102,6 +102,7 @@
   <string name="github_akhilnarang">https://github.com/akhilnarang</string>
   <string name="github_bdogg718k">https://github.com/bdogg718k</string>
   <string name="github_apascual89">https://github.com/apascual89</string>
+  <string name="github_mracar">https://github.com/mracar07</string>
   <string name="rr">الروابط</string>
   <string name="rr_website_title">موقع ويب</string>
   <string name="rr_website_summary">احصل على المزيد من المعلومات حول نظام تشغيل ريمكس القيامة</string>
@@ -133,6 +134,7 @@
   <string name="christopher_kardas_summary">● مشرف \n● محرر\n● مساهم</string>
   <string name="matt_summary">● مشرف \n● محرر\n● مساهم</string>
   <string name="justen_summary">● مشرف \n● محرر\n● مساهم</string>
+  <string name="mracar_summary">● المطور \n● المنطم</string>
   <string name="support_team_title">علامة المشرف</string>
   <string name="device_maintainers_title">الأجهزة و المشرفين</string>
   <string name="device_maintainers_title_summary">قائمة بالأجهزة وعلى مشرفي RR-نظام التشغيل الرسمي</string>
@@ -488,6 +490,7 @@
   <string name="rr_density_summary">خصص كثافة الشاشة بحيث يتم تحديد حجم الشاشة الى حدها المطلق</string>
   <string name="rr_fonts_summary">إختر حجم الخط المفضل لديك</string>
   <string name="stock_recents_category">التطبيقات الحالية القياسية</string>
+  <string name="edge_gestures_summary">التنقل باستخدام إيمائات حواف الشاشة</string>
   <!-- QS rows and columns -->
   <string name="qs_rows_portrait_title">صفوف البلاط في وضع قائم</string>
   <string name="qs_rows_landscape_title">صفوف البلاط في وضع عريض</string>
@@ -822,6 +825,8 @@
   <string name="pulse_render_mode_solid_lines">خطوط صلبة</string>
   <string name="fling_pulse_color">لون النبض</string>
   <string name="fling_pulse_color_summary">يستخدم أيضا كخيار إحتياطي للون التلقائي</string>
+  <string name="fling_smoothing_enabled_title">شغل شيئا ما</string>
+  <string name="fling_smoothing_enabled_summary">كل شريط سيتم عرضه بسلاسة</string>
   <string name="eos_fling_lavalamp_title">شغّل مصباح الحمم</string>
   <string name="eos_fling_lavalamp_summary">النبض يرسم مزيج لون نمط مصباح حمم سلس</string>
   <string name="pulse_advanced_category">متقدم</string>
@@ -1819,4 +1824,12 @@
   <string name="menu_show_substratum">أظهر الطبقات</string>
   <string name="menu_hide_substratum">أخفِ الطبقات</string>
   <!-- Edge gestures -->
+  <string name="edge_gestures_title">إيماءات حافة الشاشة</string>
+  <string name="edge_gestures_feedback_duration_title">مدّة اهتزاز الأزرار</string>
+  <string name="edge_gestures_long_press_delay_title">الفترة قبل تفعيل خيارات الضغط الطويل</string>
+  <string name="edge_gestures_back_category_title">إيماء الرجوع</string>
+  <string name="edge_gestures_back_edges_title">فعل إيماء الرجوع من</string>
+  <string name="edge_gestures_landscape_back_edges_title">فعل إيماء الرجوع في وضع العرض الأفقي من</string>
+  <string name="edge_gestures_back_screen_percent_title">إيماء الرجوع يجب أن يبدأ تحت هذه النسبة من الشاشة</string>
+  <string name="edge_gestures_back_screen_percent_summary">سيتفعل أسفل % من الشاشة</string>
 </resources>

--- a/res/values-ar/rr_strings.xml
+++ b/res/values-ar/rr_strings.xml
@@ -203,7 +203,6 @@
   <string name="rr_statusbar_title">شريط المعلومات</string>
   <string name="rr_sb_gestures_title">إيماءات شريط الحالة</string>
   <string name="qs_advanced_title">إعدادات متقدمة</string>
-  <string name="rr_notification_panel_title">لوحات</string>
   <string name="rr_tuner">نظام موالف واجهة المستخدم</string>
   <string name="rr_tuner_summary">جزء من تخصيصات الأسهم</string>
   <string name="rr_battery">البطارية</string>

--- a/res/values-az-rAZ/rr_strings.xml
+++ b/res/values-az-rAZ/rr_strings.xml
@@ -116,7 +116,6 @@
   <string name="rr_statusbar_title">Vəziyyət çubuğu</string>
   <string name="rr_sb_gestures_title">Vəziyyət çubuğu hərəkətləri</string>
   <string name="qs_advanced_title">İnkişaf etmiş</string>
-  <string name="rr_notification_panel_title">Panellər</string>
   <string name="rr_tuner">Sistem İnterfeysi nizamlayıcısı</string>
   <string name="rr_tuner_summary">Ehtiyat özəlləşdirmələrinin bir qismi</string>
   <string name="rr_battery">Batereya</string>

--- a/res/values-ca/rr_strings.xml
+++ b/res/values-ca/rr_strings.xml
@@ -101,6 +101,7 @@
   <string name="github_akhilnarang">https://github.com/akhilnarang</string>
   <string name="github_bdogg718k">https://github.com/bdogg718k</string>
   <string name="github_apascual89">https://github.com/apascual89</string>
+  <string name="github_mracar">https://github.com/mracar07</string>
   <string name="rr">Enllaços</string>
   <string name="rr_website_title">Lloc web</string>
   <string name="rr_website_summary">Obtenir més informació sobre Resurrection Remix OS</string>
@@ -132,6 +133,7 @@
   <string name="christopher_kardas_summary">● Moderator\n● Editor\n● Contribuent</string>
   <string name="matt_summary">● Moderator\n● Editor\n● Contribuent</string>
   <string name="justen_summary">● Moderator\n● Editor\n● Contribuent</string>
+  <string name="mracar_summary">•Desenvolupador\n•Mantenidor</string>
   <string name="support_team_title">Moderador d\'etiquetes</string>
   <string name="device_maintainers_title">Dispositius i mantenidors</string>
   <string name="device_maintainers_title_summary">Llista de dispositius i els seus maintenidlrs oficials RR-OS</string>
@@ -488,6 +490,7 @@
   <string name="rr_density_summary">Personalitzeu la densitat de la pantalla per l\'escalar de la pantalla fins al límit absolut</string>
   <string name="rr_fonts_summary">Tria la mida de la font preferida</string>
   <string name="stock_recents_category">Tauler de recents predeterminat</string>
+  <string name="edge_gestures_summary">Navegueu utilitzant gestos de la vora</string>
   <!-- QS rows and columns -->
   <string name="qs_rows_portrait_title">Files d\'icones en mode vertical</string>
   <string name="qs_rows_landscape_title">Files d\'icones en mode horitzontal</string>
@@ -822,6 +825,8 @@
   <string name="pulse_render_mode_solid_lines">Línies sòlides</string>
   <string name="fling_pulse_color">Color de Pulse</string>
   <string name="fling_pulse_color_summary">S\'utilitza també com a alternativa per al color automàtic</string>
+  <string name="fling_smoothing_enabled_title">Activa el suavitzat</string>
+  <string name="fling_smoothing_enabled_summary">L\'animació de les barres és més suau</string>
   <string name="eos_fling_lavalamp_title">Encendre la llum de lava</string>
   <string name="eos_fling_lavalamp_summary">Pulse crea una animació amb una suau barreja de colors tipus llum de lava</string>
   <string name="pulse_advanced_category">Avançat</string>
@@ -1819,4 +1824,9 @@
   <string name="menu_show_substratum">Mostra les superposicions</string>
   <string name="menu_hide_substratum">Amaga les superposicions</string>
   <!-- Edge gestures -->
+  <string name="edge_gestures_title">Gestos de la vora</string>
+  <string name="edge_gestures_long_press_delay_title">Retard fins que comença l\'acció de pulsació llarga</string>
+  <string name="edge_gestures_back_category_title">Gest de retrocés</string>
+  <string name="edge_gestures_back_screen_percent_title">El gest de retrocés ha de començar per sota d\'aquest percentatge de la pantalla</string>
+  <string name="edge_gestures_back_screen_percent_summary">Inicia per sota del % de la pantalla</string>
 </resources>

--- a/res/values-ca/rr_strings.xml
+++ b/res/values-ca/rr_strings.xml
@@ -203,7 +203,6 @@
   <string name="rr_statusbar_title">Barra d\'estat</string>
   <string name="rr_sb_gestures_title">Gestos de la barra d\'estat</string>
   <string name="qs_advanced_title">Avançat</string>
-  <string name="rr_notification_panel_title">Taulells</string>
   <string name="rr_tuner">Personalitzador d\'interfície d\'usuari</string>
   <string name="rr_tuner_summary">Part de les personalitzacions comuns</string>
   <string name="rr_battery">Bateria</string>

--- a/res/values-ca/rr_strings.xml
+++ b/res/values-ca/rr_strings.xml
@@ -1790,6 +1790,7 @@
   <string name="qs_footer_settings_title">Mostra la icona de configuració</string>
   <string name="qs_footer_settings_summary">Icona de configuració de la pantalla en el peu de pàgina de configuració ràpida</string>
   <!-- Recents Grid -->
+  <string name="recents_grid_title">Graella recent</string>
   <string name="recents_grid_summary">Mostra els recents en un estil de quadrícula</string>
   <!-- Recents Lock Icon -->
   <string name="recents_lock_summary">Mostra la icona de bloqueig al capçalera de l\'aplicació recent</string>

--- a/res/values-cs/rr_strings.xml
+++ b/res/values-cs/rr_strings.xml
@@ -202,7 +202,6 @@
   <string name="rr_statusbar_title">Stavová lišta</string>
   <string name="rr_sb_gestures_title">Gesta stavové lišty</string>
   <string name="qs_advanced_title">Rozšířené</string>
-  <string name="rr_notification_panel_title">Panely</string>
   <string name="rr_tuner">Nástroj na ladění System UI</string>
   <string name="rr_tuner_summary">Část standardních úprav</string>
   <string name="rr_battery">Baterie</string>

--- a/res/values-cs/rr_strings.xml
+++ b/res/values-cs/rr_strings.xml
@@ -101,6 +101,7 @@
   <string name="github_akhilnarang">https://github.com/akhilnarang</string>
   <string name="github_bdogg718k">https://github.com/bdogg718k</string>
   <string name="github_apascual89">https://github.com/apascual89</string>
+  <string name="github_mracar">https://github.com/mracar07</string>
   <string name="rr">Odkazy</string>
   <string name="rr_website_title">Webová stránka</string>
   <string name="rr_website_summary">Získat více informací o Resurrection Remix OS</string>
@@ -132,6 +133,7 @@
   <string name="christopher_kardas_summary">● Moderátor\n● Editor\n● Přispěvatel</string>
   <string name="matt_summary">● Moderátor\n● Editor\n● Přispěvatel</string>
   <string name="justen_summary">● Moderátor\n● Editor\n● Přispěvatel</string>
+  <string name="mracar_summary">● Vývojář\n● Správce</string>
   <string name="support_team_title">Štítek moderátora</string>
   <string name="device_maintainers_title">Zařízení a správci</string>
   <string name="device_maintainers_title_summary">Seznam zařízení a jejich oficiální správci RR-OS</string>

--- a/res/values-da/rr_strings.xml
+++ b/res/values-da/rr_strings.xml
@@ -111,7 +111,6 @@
   <string name="rr_config_main_title">RR-OS</string>
   <string name="rr_ota_fab_title">Vis flydende knap</string>
   <string name="qs_advanced_title">Avanceret</string>
-  <string name="rr_notification_panel_title">Paneler</string>
   <string name="rr_tuner">System UI tuner</string>
   <string name="rr_battery">Batteri</string>
   <string name="rr_sb_icons">Systemikoner</string>

--- a/res/values-de/rr_strings.xml
+++ b/res/values-de/rr_strings.xml
@@ -202,7 +202,6 @@
   <string name="rr_statusbar_title">Statusleiste</string>
   <string name="rr_sb_gestures_title">Statusleisten Gesten</string>
   <string name="qs_advanced_title">Erweitert</string>
-  <string name="rr_notification_panel_title">Panels</string>
   <string name="rr_tuner">System UI-Tuner</string>
   <string name="rr_tuner_summary">Teil der Android-Stock-Anpassung</string>
   <string name="rr_battery">Akku</string>

--- a/res/values-de/rr_strings.xml
+++ b/res/values-de/rr_strings.xml
@@ -101,6 +101,7 @@
   <string name="github_akhilnarang">https://github.com/akhilnarang</string>
   <string name="github_bdogg718k">https://github.com/bdogg718k</string>
   <string name="github_apascual89">https://github.com/apascual89</string>
+  <string name="github_mracar">https://github.com/mracar07</string>
   <string name="rr">Links</string>
   <string name="rr_website_title">Webseite</string>
   <string name="rr_website_summary">Mehr Informationen über Resurrection Remix OS</string>
@@ -132,6 +133,7 @@
   <string name="christopher_kardas_summary">● Moderator\n● Editor\n● Mitwirkender</string>
   <string name="matt_summary">● Moderator\n● Editor\n● Mitwirkender</string>
   <string name="justen_summary">● Moderator\n● Editor\n● Mitwirkender</string>
+  <string name="mracar_summary">● Entwickler\n● Maintainer</string>
   <string name="support_team_title">Moderator-Tag</string>
   <string name="device_maintainers_title">Geräte und Maintainer</string>
   <string name="device_maintainers_title_summary">Liste der Geräten und ihrer offiziellen RR-OS Maintainer</string>

--- a/res/values-el/rr_strings.xml
+++ b/res/values-el/rr_strings.xml
@@ -200,7 +200,6 @@
   <string name="rr_statusbar_title">Γραμμή κατάστασης</string>
   <string name="rr_sb_gestures_title">Χειρονομίες γραμμής κατάστασης</string>
   <string name="qs_advanced_title">Προηγμένες</string>
-  <string name="rr_notification_panel_title">Πάνελ</string>
   <string name="rr_tuner">System UI tuner</string>
   <string name="rr_tuner_summary">Μέρος των προεπιλεγμένων ρυθμίσεων</string>
   <string name="rr_battery">Μπαταρία</string>

--- a/res/values-es/rr_strings.xml
+++ b/res/values-es/rr_strings.xml
@@ -101,6 +101,7 @@
   <string name="github_akhilnarang">https://github.com/akhilnarang</string>
   <string name="github_bdogg718k">https://github.com/bdogg718k</string>
   <string name="github_apascual89">https://github.com/apascual89</string>
+  <string name="github_mracar">https://github.com/mracar07</string>
   <string name="rr">Enlaces</string>
   <string name="rr_website_title">Sitio web</string>
   <string name="rr_website_summary">Conseguír más información sobre Resurrection Remix OS</string>
@@ -132,6 +133,7 @@
   <string name="christopher_kardas_summary">● Moderador \n● Editor\n● Colaborador</string>
   <string name="matt_summary">● Moderador \n● Editor\n● Colaborador</string>
   <string name="justen_summary">● Moderador \n● Editor\n● Colaborador</string>
+  <string name="mracar_summary">● Desarrollador \n● Encargado de mantenimiento</string>
   <string name="support_team_title">Etiqueta del Moderador</string>
   <string name="device_maintainers_title">Dispositivos y Mantenedores</string>
   <string name="device_maintainers_title_summary">Lista de dispositivos y sus mantenedores de RR-OS oficiales</string>
@@ -488,6 +490,7 @@ https://plus.google.com/communities/109352646351468373340</string>
   <string name="rr_density_summary">Personalizar la densidad de pantalla para escalarla a su límite absoluto</string>
   <string name="rr_fonts_summary">Elija su tamaño de fuente preferido</string>
   <string name="stock_recents_category">Panel recientes predeterminado</string>
+  <string name="edge_gestures_summary">Navegar usando gestos \"Edge\"</string>
   <!-- QS rows and columns -->
   <string name="qs_rows_portrait_title">Filas de iconos en modo vertical</string>
   <string name="qs_rows_landscape_title">Filas en modo horizontal</string>
@@ -822,6 +825,8 @@ https://plus.google.com/communities/109352646351468373340</string>
   <string name="pulse_render_mode_solid_lines">Líneas sólidas</string>
   <string name="fling_pulse_color">Color de Pulse</string>
   <string name="fling_pulse_color_summary">Usado también como retroceso para color automático</string>
+  <string name="fling_smoothing_enabled_title">Encender suavizado</string>
+  <string name="fling_smoothing_enabled_summary">La animación de las barras es mas suave</string>
   <string name="eos_fling_lavalamp_title">Encender la lámpara de lava</string>
   <string name="eos_fling_lavalamp_summary">Pulse crea una animación con una suave mezcla de colores tipo lámpara de lava</string>
   <string name="pulse_advanced_category">Avanzada</string>
@@ -1791,6 +1796,7 @@ https://plus.google.com/communities/109352646351468373340</string>
   <string name="recents_lock_title">Cerradura reciente</string>
   <string name="recents_lock_summary">Mostrar ícono de bloqueo en el encabezado de la aplicación reciente</string>
   <!-- Tiles animation style  -->
+  <string name="qs_tiles">Ajustes rápidos</string>
   <string name="qs_tile_animation_style_title">Estilo de la animación</string>
   <string name="qs_tile_animation_duration_title">Duración de la animación</string>
   <string name="qs_tile_animation_interpolator_title">Interpolador de la animación de los ajustes</string>
@@ -1821,4 +1827,12 @@ https://plus.google.com/communities/109352646351468373340</string>
   <string name="menu_show_substratum">Mostrar capas</string>
   <string name="menu_hide_substratum">Ocultar capas</string>
   <!-- Edge gestures -->
+  <string name="edge_gestures_title">Gestos Edge</string>
+  <string name="edge_gestures_feedback_duration_title">Duración de retroalimentación háptica</string>
+  <string name="edge_gestures_long_press_delay_title">Demora hasta que comience la acción de presión prolongada</string>
+  <string name="edge_gestures_back_category_title">Gesto de retroceso</string>
+  <string name="edge_gestures_back_edges_title">Lanzar gesto de retroceso de</string>
+  <string name="edge_gestures_landscape_back_edges_title">Lanzar gesto de retroceso en posición vertical de</string>
+  <string name="edge_gestures_back_screen_percent_title">Gesto de retroceder debe empezar por debajo de este porcentaje de la pantalla</string>
+  <string name="edge_gestures_back_screen_percent_summary">Lanzar debajo de cierto porcentaje de pantalla</string>
 </resources>

--- a/res/values-es/rr_strings.xml
+++ b/res/values-es/rr_strings.xml
@@ -203,7 +203,6 @@ https://plus.google.com/communities/109352646351468373340</string>
   <string name="rr_statusbar_title">Barra de estado</string>
   <string name="rr_sb_gestures_title">Gestos en la barra de estado</string>
   <string name="qs_advanced_title">Avanzado</string>
-  <string name="rr_notification_panel_title">Paneles</string>
   <string name="rr_tuner">Configurador de IU del sistema</string>
   <string name="rr_tuner_summary">Parte de las personalizaciones comunes</string>
   <string name="rr_battery">Batería</string>

--- a/res/values-fi/rr_strings.xml
+++ b/res/values-fi/rr_strings.xml
@@ -202,7 +202,6 @@
   <string name="rr_statusbar_title">Tilapalkki</string>
   <string name="rr_sb_gestures_title">Tilapalkki eleet</string>
   <string name="qs_advanced_title">Lisäasetukset</string>
-  <string name="rr_notification_panel_title">Paneelit</string>
   <string name="rr_tuner">System UI tuunaaja</string>
   <string name="rr_tuner_summary">Osa perusmukautuksia</string>
   <string name="rr_battery">Akku</string>

--- a/res/values-fi/rr_strings.xml
+++ b/res/values-fi/rr_strings.xml
@@ -47,6 +47,7 @@
   <string name="battery_style_dotted_circle">Pilkullinen ympyrä</string>
   <string name="battery_style_big_circle">Iso ympyrä</string>
   <string name="battery_style_big_dotted_circle">Iso pilkullinen ympyrä</string>
+  <string name="battery_style_square">Neliö</string>
   <string name="battery_style_text">Teksti</string>
   <string name="battery_style_hidden">Piilotettu</string>
   <string name="battery_style_category">Akun tyyli</string>
@@ -100,6 +101,7 @@
   <string name="github_akhilnarang">https://github.com/akhilnarang</string>
   <string name="github_bdogg718k">https://github.com/bdogg718k</string>
   <string name="github_apascual89">https://github.com/apascual89</string>
+  <string name="github_mracar">https://github.com/mracar07</string>
   <string name="rr">Links</string>
   <string name="rr_website_title">Website</string>
   <string name="rr_website_summary">Lisätietoa Resurrection Remix OS:sta</string>
@@ -111,6 +113,10 @@
   <string name="rr_facebook_summary">Facebook yhteisö</string>
   <string name="rr_google_plus_title">Google</string>
   <string name="rr_google_plus_summary">Google+ yhteisö</string>
+  <string name="rr_pb_title">Sysimusta teema</string>
+  <string name="rr_pb_summary">Remix OS:n virallinen substratum teema</string>
+  <string name="rr_twitter_title">Twitter</string>
+  <string name="rr_twitter_summary">Twitter tili</string>
   <string name="maintainer_categorie_title">Viralliset laitteet</string>
   <string name="title_about">Tietoa</string>
   <string name="dev_categorie_title">Kehittäjän nimike</string>
@@ -127,6 +133,7 @@
   <string name="christopher_kardas_summary">● Moderaattori \n● Editori \n● Avustaja</string>
   <string name="matt_summary">● Moderaattori \n● Editori \n● Avustaja</string>
   <string name="justen_summary">● Moderaattori \n● Editori \n● Avustaja</string>
+  <string name="mracar_summary">● Kehittäjä\n● Ylläpitäjä</string>
   <string name="support_team_title">Moderaattorin nimike</string>
   <string name="device_maintainers_title">Laitteet ja ylläpitäjät</string>
   <string name="device_maintainers_title_summary">Luettelo laitteista ja niiden virallisista RR-OS ylläpitäjistä</string>
@@ -279,6 +286,7 @@
   <string name="ticker_disabled">Ei valikkoa</string>
   <string name="ticker_enabled">Ilmoitus valikko</string>
   <string name="ticker_media_enabled">Ilmoitus ja musiikki valikko</string>
+  <string name="ticker_animation_mode_title">Ilmoitusvalikon laattojen animaation tyyli</string>
   <string name="ticker_animation_mode_alpha_fade">Häivytys</string>
   <string name="ticker_animation_mode_scroll">Vieritys</string>
   <!-- Heads up -->
@@ -322,16 +330,37 @@
   <string name="status_bar_quick_qs_pulldown_right">Oikea</string>
   <string name="status_bar_double_tap_to_sleep_title">Lepotila kaksoisnapautuksella</string>
   <string name="status_bar_double_tap_to_sleep_summary">Sulje laitteen näyttö tuplanapauttamalla</string>
+  <string name="qs_tile_title_visibility_title">Näytä laattojen otsikko</string>
+  <string name="qs_tile_title_visibility_summary">Näytä laattaotsikot alla kun valittu</string>
   <!-- QS Headers -->
   <string name="status_bar_custom_header_title">Ota käyttöön</string>
+  <string name="daylight_header_pack_title">Ylätunnisteen kuvakokoelma</string>
+  <string name="status_bar_custom_header_shadow_title">Ylätunnisteen kuvan varjo</string>
+  <string name="status_bar_custom_header_shadow_summary">Parempaan näkyvyyteen kirkkaille kuville</string>
+  <string name="unit_percent">\u0025</string>
+  <string name="static_header_provider_title">Pysyvä kuva</string>
   <string name="daylight_header_provider_title">Kuvat</string>
+  <string name="custom_header_provider_title">Ylätunnisteen toimittaja</string>
+  <string name="custom_header_browse_title">Selaa asennettuja ylätunnisteita</string>
+  <string name="custom_header_browse_summary">Valitse jokin kuva käytettäväksi pysyvänä kuvana</string>
+  <string name="custom_header_browse_summary_new">Selaa kaikkia saatavilla olevia ylätunnistekokoelmia</string>
+  <string name="custom_header_pick_title">Valitse ylätunnisteen kuva</string>
+  <string name="custom_header_pick_summary">Valitse kuva käytettäväksi pysyvässä tilassa</string>
+  <string name="style_enabled_summary">Mukautettu ylätunnisteen kuva on PÄÄLLÄ</string>
+  <string name="style_disabled_summary">Mukautettu ylätunnisteen kuva on POIS PÄÄLTÄ</string>
   <string name="header_provider_disabled">Poissa käytöstä</string>
+  <string name="custom_header_title">Mukautettu ylätunnisteen kuva</string>
   <string name="file_header_select_title">Valitse kuva</string>
+  <string name="file_header_select_summary">Valitse mukautettu kuva</string>
+  <string name="file_header_provider_title">Mukautettu kuva</string>
   <!-- Smart pulldown-->
+  <string name="smart_pulldown_title">Älykäs alasveto</string>
   <string name="smart_pulldown_off">Pois päältä</string>
   <string name="smart_pulldown_none">Ei ilmoituksia</string>
   <string name="smart_pulldown_dismissable">Ei tyhjennettäviä ilmoituksia</string>
+  <string name="smart_pulldown_ongoing">Ei meneillään olevia ilmoituksia</string>
   <string name="smart_pulldown_summary">Avaa pika-asetukset, kun on %1$s</string>
+  <string name="smart_pulldown_none_summary">Avaa pika-asetukset kun ilmoituksia ei ole</string>
   <string name="smart_pulldown_off_summary">Poissa päältä</string>
   <!-- Status bar - icons -->
   <string name="status_bar_icons_title">Tilapalkin kuvakkeet</string>
@@ -388,6 +417,8 @@
   <string name="show_carrier_keyguard">Lukitusnäyttö</string>
   <string name="show_carrier_statusbar">Tilapalkki</string>
   <string name="show_carrier_enabled">Molemmat</string>
+  <string name="status_bar_carrier_size">Operaattorinimen tekstin koko</string>
+  <string name="status_bar_carrier_font_style_title">Operaattorinimen fontti</string>
   <!-- Battery bar -->
   <string name="battery_bar_title">Akkupalkki</string>
   <string name="battery_bar_position_title">Sijainti</string>
@@ -405,6 +436,9 @@
   <string name="battery_bar_use_charging_color_title">Kustomoitu lataustilan väri</string>
   <string name="battery_bar_blend_color_title">Sekoita värit</string>
   <string name="battery_bar_blend_color_summary">Sekoita täysi/tyhjä värit vastaamaan akun määrää</string>
+  <string name="battery_bar_blend_color_reverse_title">Käänteinen värin suunta</string>
+  <string name="battery_bar_blend_color_reverse_summary_off">Täysi → tyhjä: punainen ← vihreä ← sininen ← punainen</string>
+  <string name="battery_bar_blend_color_reverse_summary_on">Täysi → tyhjä: punainen → vihreä → sininen → punainen</string>
   <!--RR Configurations Summaries-->
   <string name="clock_custom_summary">Mukauta useita tilapalkin kellon ja päivämäärän elementtejä</string>
   <string name="status_bar_logo_summary">Ota tai poista käytöstä tilapalkin Resurrection logo. Mukauta väriä ja sijaintia</string>
@@ -418,6 +452,8 @@
   <string name="rr_sb_gestures_summary">Ota tai poista käytöstä tilapalkin eleet</string>
   <string name="breathing_notifications_summary">Näytä mm. sms, vastaamaton puhelu ja vastaaja ilmoituksissa hengitys-efekti</string>
   <string name="rr_trans_summary">Mukauta useita ilmoituslistan elementtejä, kuten läpikuultavuutta ja vetoa</string>
+  <string name="rr_volume_summary">Muokkaa eri elementtejä äänenvoimakkuusvalikossa kuten läpinäkyvyyttä ja viivanleveyttä</string>
+  <string name="rr_power_summary">Mukauta virtavalikon himmeys ja läpinäkyvyysasetuksia</string>
   <string name="rr_np_summary">Muokkaa pika-asetuksia ja ilmoituspaneelia</string>
   <!-- QS rows and columns -->
   <!-- QuickSettings Panel Transparency -->

--- a/res/values-fr/rr_strings.xml
+++ b/res/values-fr/rr_strings.xml
@@ -202,7 +202,6 @@
   <string name="rr_statusbar_title">Barre d\'état</string>
   <string name="rr_sb_gestures_title">Gestes sur la barre d\'état</string>
   <string name="qs_advanced_title">Options avancées</string>
-  <string name="rr_notification_panel_title">Panneaux</string>
   <string name="rr_tuner">Réglage de l\'UI du système</string>
   <string name="rr_tuner_summary">Partie de personnalisations d\'usine (stock)</string>
   <string name="rr_battery">Batterie</string>

--- a/res/values-fr/rr_strings.xml
+++ b/res/values-fr/rr_strings.xml
@@ -823,6 +823,7 @@
   <string name="pulse_render_mode_solid_lines">Lignes pleines</string>
   <string name="fling_pulse_color">Couleur de Pulse</string>
   <string name="fling_pulse_color_summary">Utilisé aussi comme secours pour la couleur automatique</string>
+  <string name="fling_smoothing_enabled_title">Activer le lissage</string>
   <string name="eos_fling_lavalamp_title">Activer le filtre Lava Lamp</string>
   <string name="eos_fling_lavalamp_summary">Effet visuel de l\'égaliseur affichant un dégradé de couleur aléatoire</string>
   <string name="pulse_advanced_category">Avancée</string>
@@ -1811,4 +1812,5 @@ Ces couleurs sont celles qui teintent l\'arrière-plan flou. Au lieu du gris nor
   <string name="menu_show_substratum">Afficher les surcouches</string>
   <string name="menu_hide_substratum">Masquer les surcouches</string>
   <!-- Edge gestures -->
+  <string name="edge_gestures_feedback_duration_title">Durée de retour au toucher</string>
 </resources>

--- a/res/values-fr/rr_strings.xml
+++ b/res/values-fr/rr_strings.xml
@@ -101,6 +101,7 @@
   <string name="github_akhilnarang">https://github.com/akhilnarang</string>
   <string name="github_bdogg718k">https://github.com/bdogg718k</string>
   <string name="github_apascual89">https://github.com/apascual89</string>
+  <string name="github_mracar">https://github.com/mracar07</string>
   <string name="rr">Liens</string>
   <string name="rr_website_title">Site Web</string>
   <string name="rr_website_summary">Obtenir plus d’informations sur Resurrection Remix OS</string>
@@ -132,6 +133,7 @@
   <string name="christopher_kardas_summary">● Modérateur\n● Éditeur\n● Contributeur</string>
   <string name="matt_summary">● Modérateur\n● Éditeur\n● Contributeur</string>
   <string name="justen_summary">● Modérateur\n● Éditeur\n● Contributeur</string>
+  <string name="mracar_summary">● Développeur\n● Mainteneur</string>
   <string name="support_team_title">Moderator Tag</string>
   <string name="device_maintainers_title">Appareils et mainteneurs</string>
   <string name="device_maintainers_title_summary">Liste des appareils et de leurs mainteneurs officiels RR-OS</string>

--- a/res/values-hi/rr_strings.xml
+++ b/res/values-hi/rr_strings.xml
@@ -200,7 +200,6 @@
   <string name="rr_statusbar_title">स्थिति पट्टी</string>
   <string name="rr_sb_gestures_title">स्थिति पट्टी इशारों</string>
   <string name="qs_advanced_title">उन्नत</string>
-  <string name="rr_notification_panel_title">पैनल</string>
   <string name="rr_tuner">सिस्टम यूआई नियंत्रण</string>
   <string name="rr_tuner_summary">स्टॉक अनुकूलन के भाग के</string>
   <string name="rr_battery">बैटरी</string>

--- a/res/values-hr/rr_strings.xml
+++ b/res/values-hr/rr_strings.xml
@@ -101,6 +101,7 @@
   <string name="github_akhilnarang">https://github.com/akhilnarang</string>
   <string name="github_bdogg718k">https://github.com/bdogg718k</string>
   <string name="github_apascual89">https://github.com/apascual89</string>
+  <string name="github_mracar">https://github.com/mracar07</string>
   <string name="rr">Poveznice</string>
   <string name="rr_website_title">Mrežna stranica</string>
   <string name="rr_website_summary">Saznajte više informacija o Resurrection Remix OS-u</string>
@@ -132,6 +133,7 @@
   <string name="christopher_kardas_summary">● Moderator\n● Urednik\n● Suradnik</string>
   <string name="matt_summary">● Moderator\n● Urednik\n● Suradnik</string>
   <string name="justen_summary">● Moderator\n● Urednik\n● Suradnik</string>
+  <string name="mracar_summary">● Programer\n● Održavatelj</string>
   <string name="support_team_title">Oznaka moderatora</string>
   <string name="device_maintainers_title">Uređaji i održavatelji</string>
   <string name="device_maintainers_title_summary">Popis uređaja i njihovih službenih RR-OS održavatelja</string>

--- a/res/values-hr/rr_strings.xml
+++ b/res/values-hr/rr_strings.xml
@@ -202,7 +202,6 @@
   <string name="rr_statusbar_title">Statusna traka</string>
   <string name="rr_sb_gestures_title">Geste statusne trake</string>
   <string name="qs_advanced_title">Napredno</string>
-  <string name="rr_notification_panel_title">Ploče</string>
   <string name="rr_tuner">Ugađanje korisničkog sučelja</string>
   <string name="rr_tuner_summary">Dio zadanih prilagodbi</string>
   <string name="rr_battery">Baterija</string>

--- a/res/values-hu/rr_strings.xml
+++ b/res/values-hu/rr_strings.xml
@@ -101,6 +101,7 @@
   <string name="github_akhilnarang">https://github.com/akhilnarang</string>
   <string name="github_bdogg718k">https://github.com/bdogg718k</string>
   <string name="github_apascual89">https://github.com/apascual89</string>
+  <string name="github_mracar">https://github.com/mracar07</string>
   <string name="rr">Linkek</string>
   <string name="rr_website_title">Honlap</string>
   <string name="rr_website_summary">Resurrection Remix OS további tudnivalók</string>
@@ -132,6 +133,7 @@
   <string name="christopher_kardas_summary">● Moderátor\n● Szerkesztő\n● Közreműködő</string>
   <string name="matt_summary">● Moderátor\n● Szerkesztő\n● Közreműködő</string>
   <string name="justen_summary">● Moderátor\n● Szerkesztő\n● Közreműködő</string>
+  <string name="mracar_summary">● Fejlesztő\n● Közreműködő</string>
   <string name="support_team_title">Moderátor címke</string>
   <string name="device_maintainers_title">Eszközök és közreműködők</string>
   <string name="device_maintainers_title_summary">Az eszközök és azok hivatalos RR-OS közreműködőinek listája</string>

--- a/res/values-hu/rr_strings.xml
+++ b/res/values-hu/rr_strings.xml
@@ -202,7 +202,6 @@
   <string name="rr_statusbar_title">Állapotsor</string>
   <string name="rr_sb_gestures_title">Állapotsor gesztusok</string>
   <string name="qs_advanced_title">Haladó</string>
-  <string name="rr_notification_panel_title">Panelek</string>
   <string name="rr_tuner">Kezelőfelület-hangoló</string>
   <string name="rr_tuner_summary">Gyári testreszabások része</string>
   <string name="rr_battery">Akkumulátor</string>

--- a/res/values-in/rr_strings.xml
+++ b/res/values-in/rr_strings.xml
@@ -101,6 +101,7 @@
   <string name="github_akhilnarang">https://github.com/akhilnarang</string>
   <string name="github_bdogg718k">https://github.com/bdogg718k</string>
   <string name="github_apascual89">https://github.com/apascual89</string>
+  <string name="github_mracar">https://github.com/mracar07</string>
   <string name="rr">Tautan</string>
   <string name="rr_website_title">Situs Web</string>
   <string name="rr_website_summary">Dapatkan informasi lebih lanjut tentang Resurrection Remix OS</string>
@@ -132,6 +133,7 @@
   <string name="christopher_kardas_summary">● Moderator \n● Editor\n● Kontributor</string>
   <string name="matt_summary">● Moderator \n● Editor\n● Kontributor</string>
   <string name="justen_summary">● Moderator \n● Editor\n● Kontributor</string>
+  <string name="mracar_summary">● Pengembang \n● Pengelola</string>
   <string name="support_team_title">Tag Moderator</string>
   <string name="device_maintainers_title">Perangkat dan pengelola</string>
   <string name="device_maintainers_title_summary">Daftar perangkat dan pengelola resmi RR-OS</string>
@@ -200,7 +202,6 @@
   <string name="rr_statusbar_title">Bilah Status</string>
   <string name="rr_sb_gestures_title">Gerakan status bar</string>
   <string name="qs_advanced_title">Lanjutan</string>
-  <string name="rr_notification_panel_title">Panel</string>
   <string name="rr_tuner">SystemUI tuner</string>
   <string name="rr_tuner_summary">Bagian dari penyesuaian awal</string>
   <string name="rr_battery">Baterai</string>
@@ -487,6 +488,7 @@
   <string name="rr_density_summary">Sesuaikan kerapatan layar ke skala layar sampai batas mutlaknya</string>
   <string name="rr_fonts_summary">Pilih ukuran huruf Anda</string>
   <string name="stock_recents_category">Recent bawaan</string>
+  <string name="edge_gestures_summary">Mengarahkan menggunakan gestur tepi</string>
   <!-- QS rows and columns -->
   <string name="qs_rows_portrait_title">Baris ubin pada tampilan potret</string>
   <string name="qs_rows_landscape_title">Baris ubin pada tampilan landscape</string>
@@ -800,6 +802,7 @@
   <string name="fling_keyboard_cursors_move_summary">Ketika keyboard menunjukkan, tekan lama kiri atau kanan untuk memindahkan teks kursor ke kiri atau kanan. \nTekan dan tahan untuk terus bergerak kursor, satu keran di bar untuk pergi ke layar awal.</string>
   <string name="fling_logo_opacity_title">Kepudaran logo fling</string>
   <string name="fling_factory_reset_title">Setel ulang ke bawaan</string>
+  <string name="fling_factory_reset_confirm">Apakah Anda yakin ingin mengatur ulang Fling ke pengaturan bawaan?</string>
   <string name="fling_backup_current_config_title">Simpan profil</string>
   <string name="fling_restore_config_title">Pulihkan profil</string>
   <string name="fling_config_name_edit_dialog_message">Masukkan nama atau biarkan kosong</string>
@@ -1748,6 +1751,7 @@
   <string name="screenshot_delay_title">Penundaan tangkapan layar</string>
   <string name="screenshot_edit_app">Penyunting tangkapan layar</string>
   <string name="screenshot_edit_app_summary">Pilih aplikasi yang harus dijalankan ketika menekan tombol sunting pemberitahuan tangkapan layar</string>
+  <string name="screenshot_edit_app_no_editor">Penyunting gambar tidak tersedia</string>
   <!-- Face unlock auto -->
   <string name="face_auto_unlock_title">Paksa kunci otomatis</string>
   <string name="face_auto_unlock_summary">Singkirkan layar kunci setelah proses face-unlock. Anda harus mengaktifkan face-unlock/wajah-terpercaya untuk ini</string>
@@ -1762,7 +1766,9 @@
   <string name="notification_guts_kill_app_button_summary">Show a kill app button in the notification\'s longpress menu</string>
   <!-- Smart Pixels -->
   <string name="smart_pixels_title">Smart Pixels</string>
+  <string name="smart_pixels_summary">Menghemat baterai dengan mematikan beberapa piksel</string>
   <string name="smart_pixels_enable_title">Hidupkan Smart Pixels</string>
+  <string name="smart_pixels_enable_summary">Matikan piksel untuk mengurangi konsumsi daya</string>
   <!-- QS footer icons -->
   <string name="qs_footer_settings_title">Menampilkan ikon Pengaturan</string>
   <!-- Recents Grid -->
@@ -1792,4 +1798,6 @@
   <string name="menu_show_substratum">Tampilkan overlay</string>
   <string name="menu_hide_substratum">Sembunyikan overlay</string>
   <!-- Edge gestures -->
+  <string name="edge_gestures_title">Gestur Tepi</string>
+  <string name="edge_gestures_back_category_title">Gestur mundur</string>
 </resources>

--- a/res/values-it/rr_strings.xml
+++ b/res/values-it/rr_strings.xml
@@ -101,6 +101,7 @@
   <string name="github_akhilnarang">https://github.com/akhilnarang</string>
   <string name="github_bdogg718k">https://github.com/bdogg718k</string>
   <string name="github_apascual89">https://github.com/apascual89</string>
+  <string name="github_mracar">https://github.com/mracar07</string>
   <string name="rr">Collegamenti</string>
   <string name="rr_website_title">Sito Web</string>
   <string name="rr_website_summary">Ottieni maggiori informazioni sulla Resurrection Remix OS</string>
@@ -132,6 +133,7 @@
   <string name="christopher_kardas_summary">Moderatore\n Editor\n Contributore</string>
   <string name="matt_summary">Moderatore\n Editor\n Contributore</string>
   <string name="justen_summary">Moderatore\n Editor\n Contributore</string>
+  <string name="mracar_summary">Sviluppatore\n Manutentore</string>
   <string name="support_team_title">Tag del moderatore</string>
   <string name="device_maintainers_title">Dispositivi e manutentori</string>
   <string name="device_maintainers_title_summary">Elenco dei dispositivi e dei loro manutentori ufficiali della RR-OS</string>

--- a/res/values-it/rr_strings.xml
+++ b/res/values-it/rr_strings.xml
@@ -202,7 +202,6 @@
   <string name="rr_statusbar_title">Barra di stato</string>
   <string name="rr_sb_gestures_title">Gesti barra di stato</string>
   <string name="qs_advanced_title">Avanzate</string>
-  <string name="rr_notification_panel_title">Pannelli</string>
   <string name="rr_tuner">Regolatore UI di Sistema</string>
   <string name="rr_tuner_summary">Parte delle personalizzazioni stock</string>
   <string name="rr_battery">Batteria</string>

--- a/res/values-iw/rr_strings.xml
+++ b/res/values-iw/rr_strings.xml
@@ -126,7 +126,6 @@
   <string name="rr_statusbar_title">שורת סטטוס</string>
   <string name="rr_sb_gestures_title">מחוות שורת המצב</string>
   <string name="qs_advanced_title">הגדרות מתקדמות</string>
-  <string name="rr_notification_panel_title">לוחות</string>
   <string name="rr_tuner">כיול ממשק משתמש</string>
   <string name="rr_tuner_summary">חלק מאפשרויות ברירת המחדל</string>
   <string name="rr_battery">סוללה</string>

--- a/res/values-ja/rr_strings.xml
+++ b/res/values-ja/rr_strings.xml
@@ -17,12 +17,12 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="rr_mod_version">RR-OSバージョン</string>
   <string name="build_date">ビルド日時</string>
-  <string name="mod_version_default">既定</string>
+  <string name="mod_version_default">デフォルト</string>
   <!-- General -->
-  <string name="ok">はい</string>
+  <string name="ok">OK</string>
   <string name="reset">リセット</string>
   <string name="dlg_reset_rr">RR</string>
-  <string name="dlg_reset_android">既定</string>
+  <string name="dlg_reset_android">デフォルト</string>
   <string name="default_string">デフォルト</string>
   <string name="add">追加</string>
   <string name="enabled">有効</string>
@@ -43,11 +43,11 @@
   <string name="battery_style_title">バッテリーアイコンのスタイル</string>
   <string name="battery_style_port">縦</string>
   <string name="battery_style_land">横</string>
-  <string name="battery_style_circle">サークル</string>
-  <string name="battery_style_dotted_circle">点付きのサークル</string>
+  <string name="battery_style_circle">円</string>
+  <string name="battery_style_dotted_circle">点線の円</string>
   <string name="battery_style_big_circle">大きいサークル</string>
-  <string name="battery_style_big_dotted_circle">大きい点付きのサークル</string>
-  <string name="battery_style_square">スクエア</string>
+  <string name="battery_style_big_dotted_circle">大きい点線の円</string>
+  <string name="battery_style_square">正方形</string>
   <string name="battery_style_text">文字</string>
   <string name="battery_style_hidden">非表示</string>
   <string name="battery_style_category">バッテリースタイル</string>
@@ -80,7 +80,7 @@
   <string name="listview_anticipate_interpolator">予測</string>
   <string name="listview_overshoot_interpolator">通過</string>
   <string name="listview_anticipate_overshoot_interpolator">予測と通過</string>
-  <string name="listview_bounce_interpolator">跳ねる</string>
+  <string name="listview_bounce_interpolator">弾む</string>
   <!-- Keyboard and IME  -->
   <string name="disable_fullscreen_keyboard_title">全画面キーボードを無効化</string>
   <string name="disable_fullscreen_keyboard_summary">横向画面時にキーボードが画面全体を占有しないようにする</string>
@@ -95,7 +95,7 @@
   <string name="keyboard_ime_summury">IMEの詳細設定</string>
   <string name="ime_switcher_notify">IME選択の通知</string>
   <string name="ime_switcher_notify_summary">入力方法の選択の通知を表示する</string>
-  <string name="devs">デベロッパー タグ</string>
+  <string name="devs">デベロッパータグ</string>
   <string name="github_westcrip">https://github.com/westcripp</string>
   <string name="github_varund7726">https://github.com/varund7726</string>
   <string name="github_akhilnarang">https://github.com/akhilnarang</string>
@@ -172,11 +172,11 @@
   <string name="changelog_version">バージョン</string>
   <string name="changelog_time_today">今日</string>
   <string name="changelog_time_yesterday">昨日</string>
-  <string name="changelog_time_2_days">２日前</string>
-  <string name="changelog_time_3_days">３日前</string>
-  <string name="changelog_time_4_days">４日前</string>
-  <string name="changelog_time_5_days">５日前</string>
-  <string name="changelog_time_6_days">６日前</string>
+  <string name="changelog_time_2_days">2日前</string>
+  <string name="changelog_time_3_days">3日前</string>
+  <string name="changelog_time_4_days">4日前</string>
+  <string name="changelog_time_5_days">5日前</string>
+  <string name="changelog_time_6_days">6日前</string>
   <string name="changelog_time_1_week">1週間前</string>
   <string name="changelog_time_2_weeks">2週間前</string>
   <string name="changelog_time_3_weeks">3週間前</string>
@@ -194,7 +194,7 @@
   <string name="rr_reset_yes">はい</string>
   <string name="rr_reset_cancel">キャンセル</string>
   <string name="rr_category_title">個人設定</string>
-  <string name="rr_title">高度な設定</string>
+  <string name="rr_title">設定</string>
   <string name="rr_title_summary">様々なカスタマイズ</string>
   <string name="rr_config_main_title">RR-OS</string>
   <string name="rr_ota_fab_title">自由配置のボタンの表示</string>
@@ -202,9 +202,8 @@
   <string name="rr_statusbar_title">ステータスバー</string>
   <string name="rr_sb_gestures_title">ステータスバー上のジェスチャー</string>
   <string name="qs_advanced_title">高度な設定</string>
-  <string name="rr_notification_panel_title">パネル</string>
   <string name="rr_tuner">システムUI調整ツール</string>
-  <string name="rr_tuner_summary">ストックカスタマイズの一部</string>
+  <string name="rr_tuner_summary">標準カスタマイズの一部</string>
   <string name="rr_battery">バッテリー表示</string>
   <string name="rr_sb_icons">システムアイコン</string>
   <string name="rr_sb_battery">ステータスバー</string>
@@ -230,8 +229,8 @@
   <string name="rr_header_title">ヘッダー</string>
   <string name="rr_power_panel_title">電源メニュー</string>
   <string name="rr_toast_title">トースト</string>
-  <string name="recents_type_title">最近のタイプ</string>
-  <string name="recents_stock">ストック AOSP</string>
+  <string name="recents_type_title">アプリ履歴のタイプ</string>
+  <string name="recents_stock">標準のAOSP</string>
   <string name="recents_omniswitch">Omniswitch</string>
   <string name="recents_grid">グリッド</string>
   <string name="recents_slim">スリム</string>
@@ -244,9 +243,9 @@
   <string name="listview">リストビュー</string>
   <string name="icons">アイコン</string>
   <string name="general">一般設定</string>
-  <string name="ka_title">Kernel Adiutor</string>
+  <string name="ka_title">パフォーマンス</string>
   <!-- Show VoLTE icon on statusbar -->
-  <string name="volte_icon_title">VoLTEのアイコン</string>
+  <string name="volte_icon_title">VoLTEアイコン</string>
   <string name="volte_icon_summary">利用可能な場合にVoLTEのアイコンを表示する</string>
   <!-- Network traffic -->
   <string name="network_traffic_state_title">ステータスバーに通信速度を表示</string>
@@ -272,9 +271,9 @@
   <string name="headset_connect_player_disabled">無効</string>
   <string name="headset_connect_player_wired">有線ヘッドホン接続時</string>
   <string name="headset_connect_player_bt_no_carkit">Bluetoothヘッドフォン (車以外) 接続時</string>
-  <string name="headset_connect_player_bt">BTヘッドホン接続時</string>
+  <string name="headset_connect_player_bt">Bluetoothヘッドフォン接続時</string>
   <string name="headset_connect_player_both_no_carkit">有線またはBluetoothヘッドフォン (車以外) 接続時</string>
-  <string name="headset_connect_player_both">有線または BT ヘッドフォン接続時</string>
+  <string name="headset_connect_player_both">有線またはBluetoothヘッドセット接続時</string>
   <!-- Status Bar Ticker -->
   <string name="ticker_screen_title">通知ティッカー</string>
   <string name="ticker_title">ステータスバーのアイコン</string>
@@ -312,7 +311,7 @@
   <string name="lockscreen_battery_info_title">バッテリー情報</string>
   <string name="lockscreen_battery_info_summary">充電中のロック画面に接続した充電器の最大電流/電圧とバッテリーの温度を表示する</string>
   <!-- Wake on plugged  -->
-  <string name="wake_plugged_title">接続時にスリープ解除</string>
+  <string name="wake_plugged_title">電源接続時にスリープ解除</string>
   <string name="wake_plugged_summary">電源接続時にスリープ解除</string>
   <!-- Custom LCD density -->
   <string name="custom_density_settings">カスタム液晶ピクセル密度</string>
@@ -325,7 +324,7 @@
   <string name="status_bar_quick_qs_pulldown_summary">ステータスバーの%1$s端から引き下げてクイック設定を開く</string>
   <string name="status_bar_quick_qs_pulldown_summary_left">左</string>
   <string name="status_bar_quick_qs_pulldown_summary_right">右</string>
-  <string name="status_bar_quick_qs_pulldown_off">OFF</string>
+  <string name="status_bar_quick_qs_pulldown_off">オフ</string>
   <string name="status_bar_quick_qs_pulldown_left">左</string>
   <string name="status_bar_quick_qs_pulldown_right">右</string>
   <string name="status_bar_double_tap_to_sleep_title">ダブルタップでスリープ</string>
@@ -336,11 +335,11 @@
   <string name="status_bar_custom_header_title">有効</string>
   <string name="daylight_header_pack_title">ヘッダー画像コレクション</string>
   <string name="status_bar_custom_header_shadow_title">ヘッダー画像の影</string>
-  <string name="status_bar_custom_header_shadow_summary">明るい画像に優れた視認性</string>
+  <string name="status_bar_custom_header_shadow_summary">明るい画像をより見やすくする</string>
   <string name="unit_percent">\u0025</string>
   <string name="static_header_provider_title">固定画像</string>
   <string name="daylight_header_provider_title">画像コレクション</string>
-  <string name="custom_header_provider_title">ヘッダー プロパイダー</string>
+  <string name="custom_header_provider_title">ヘッダープロパイダー</string>
   <string name="custom_header_browse_title">インストールされているヘッダーを参照</string>
   <string name="custom_header_browse_summary">固定モードで使う画像をタップしてください</string>
   <string name="custom_header_browse_summary_new">利用可能なすべてのヘッダーコレクションを参照する</string>
@@ -358,7 +357,7 @@
   <string name="smart_pulldown_off">オフ</string>
   <string name="smart_pulldown_none">通知なし</string>
   <string name="smart_pulldown_dismissable">削除できる通知はありません</string>
-  <string name="smart_pulldown_ongoing">実行中の通知がない</string>
+  <string name="smart_pulldown_ongoing">実行中の通知がない場合</string>
   <string name="smart_pulldown_summary">%1$s直接クイック設定を開く</string>
   <string name="smart_pulldown_none_summary">通知がない場合直接クイック設定を開く</string>
   <string name="smart_pulldown_off_summary">オフになっています</string>
@@ -371,8 +370,8 @@
   <!-- Status bar - Clock -->
   <string name="status_bar_clock_title">時計</string>
   <string name="status_bar_clock_position_title">時計の位置</string>
-  <string name="status_bar_clock_position_right">右寄り</string>
-  <string name="status_bar_clock_position_left">左寄り</string>
+  <string name="status_bar_clock_position_right">右側</string>
+  <string name="status_bar_clock_position_left">左側</string>
   <string name="status_bar_clock_position_center">中央</string>
   <string name="status_bar_am_pm_title">AM/PMのスタイル</string>
   <string name="status_bar_am_pm_info">24時間表示を有効にする</string>
@@ -384,15 +383,15 @@
   <string name="status_bar_battery_style_title">バッテリー表示のスタイル</string>
   <string name="status_bar_battery_style_icon_portrait">縦向きのアイコン</string>
   <string name="status_bar_battery_style_icon_landscape">横向きのアイコン</string>
-  <string name="status_bar_battery_style_circle">サークル</string>
+  <string name="status_bar_battery_style_circle">円</string>
   <string name="status_bar_battery_style_text">テキスト</string>
   <string name="status_bar_battery_style_hidden">非表示</string>
   <!--RR statusbar logo -->
   <string name="status_bar_logo_title">RRブランドロゴ</string>
   <string name="status_bar_rr_logo_position">ロゴの位置</string>
   <string name="status_bar_rr_logo_position_summary">どこにロゴを表示するか選択してください</string>
-  <string name="status_bar_logo_right">右寄り</string>
-  <string name="status_bar_logo_left">左寄り</string>
+  <string name="status_bar_logo_right">右側</string>
+  <string name="status_bar_logo_left">左側</string>
   <string name="status_bar_logo_disabled">無効</string>
   <!-- Status bar - Battery percentage -->
   <string name="status_bar_battery_percentage_title">バッテリー残量表示のスタイル</string>
@@ -456,7 +455,7 @@
   <string name="rr_power_summary">電源メニューのインターフェイスの暗さと透明度をカスタマイズする</string>
   <string name="rr_recents_ui_summary">メモリーバーや全画面などのアプリ履歴の様々な要素をカスタマイズする</string>
   <string name="recents_clear_all_summary">全て終了ボタンの表示 / 非表示とその位置をカスタマイズする</string>
-  <string name="omniswitch_summary">アプリ履歴をomni-recentsに置き換える</string>
+  <string name="omniswitch_summary">アプリ履歴をOmni-recentsに置き換える</string>
   <string name="rr_qs_animation_summary">クイック設定タイルをタップした際のアニメーションを有効 / 無効にする。またそれをカスタマイズする。</string>
   <string name="rr_qs_pulldown_summary">クイックパネルプルダウン設定を調整する</string>
   <string name="qs_tile_layout_summary">クイック設定タイルのレイアウトをカスタマイズする</string>
@@ -502,7 +501,7 @@
   <string name="press_color_to_apply">色を選択して適用</string>
   <string name="arrow_right">→</string>
   <string name="arrow_down">↓</string>
-  <string name="hex">Hex:</string>
+  <string name="hex">16進数:</string>
   <string name="hex_hint">#ff000000</string>
   <string name="set">設定</string>
   <string name="color_default">デフォルト</string>
@@ -588,7 +587,7 @@
   <string name="toast_Toko_animation">Toko</string>
   <string name="toast_Tn_animation">Tn</string>
   <string name="toast_Honami_animation">Honami</string>
-  <string name="toast_FastFade_animation">Fast fade</string>
+  <string name="toast_FastFade_animation">速いフェード</string>
   <string name="toast_GrowFade_animation">Grow fade</string>
   <string name="toast_GrowFadeCenter_animation">Grow fade center</string>
   <string name="toast_GrowFadeBottom_animation">Grow fade bottom</string>
@@ -617,7 +616,7 @@
   <string name="systemui_recents_mem_display_summaryOn">メモリーバー有効</string>
   <string name="systemui_recents_mem_display_summaryOff">メモリーバー無効</string>
   <!-- Slim recents -->
-  <string name="slim_recents_title">Slim Recents</string>
+  <string name="slim_recents_title">Slimアプリ履歴</string>
   <string name="alternative_recents_category">代替のアプリ履歴</string>
   <string name="recents_max_apps_title">許可されたアプリの最大数</string>
   <string name="recent_panel_scale_title">サイズ</string>
@@ -688,7 +687,7 @@
   <string name="volbtn_cursor_control_on_reverse">音量の上/下ボタンでカーソルを 右/左 に移動する</string>
   <string name="power_end_call_title">通話を終了</string>
   <string name="power_end_call_summary">電源ボタンを押して現在の通話を終了する</string>
-  <string name="swap_volume_buttons_title">Reorient</string>
+  <string name="swap_volume_buttons_title">再配置</string>
   <string name="swap_volume_buttons_summary">画面回転時に音量ボタンを入れ替える</string>
   <string name="button_wake_title">スリープ解除</string>
   <string name="volume_answer_call_title">着信に応答</string>
@@ -723,19 +722,19 @@
   <string name="navbar_mode">ナビゲーションモード</string>
   <string name="navbar_mode_summary">使用するナビゲーションモードを選択</string>
   <string name="navbar_visibility">ナビゲーションバーを許可</string>
-  <string name="navigationbar_settings_title">ナビゲーション</string>
+  <string name="navigationbar_settings_title">ナビゲーションバー</string>
   <string name="navigationbar_settings_summary">ナビゲーションのスタイルと動作をカスタマイズする</string>
   <string name="navbar_general_title">高度な設定</string>
   <string name="navigation_bar_left_title">左利きモード</string>
   <string name="navigation_bar_left_summary">画面が横向きの際にナビゲーションバーを画面の左側に配置する</string>
-  <string name="smartbar_interface">ナビバー</string>
+  <string name="smartbar_interface">スマートバー</string>
   <string name="icon_pack_picker_dialog_title">アイコンパック</string>
-  <string name="image_exceeds_max_allowed_size">イメージは 512 x 512 を超えないようにしてください</string>
+  <string name="image_exceeds_max_allowed_size">画像は512x512を超えてはなりません</string>
   <string name="invalid_icon_from_uri">コンテンツ プロバイダーからイメージを読み込むことができません</string>
   <string name="picker_activities">アクティビティ</string>
   <string name="select_custom_app_title">任意のアプリを選択</string>
   <string name="select_custom_activity_title">任意のアクティビティを選択</string>
-  <string name="profile_applist_title">アプリケーション</string>
+  <string name="profile_applist_title">アプリ</string>
   <string name="default_settings">標準の設定</string>
   <string name="default_settings_summary">標準AOSPのナビゲーションバー</string>
   <string name="default_navbar_title">標準のナビゲーションバー</string>
@@ -743,7 +742,7 @@
   <string name="choose_action_title">アクションを選択</string>
   <string name="action_entry_default_action">デフォルトの設定</string>
   <string name="action_entry_select_app">アプリを選択</string>
-  <string name="action_entry_custom_action">アクションを選択する</string>
+  <string name="action_entry_custom_action">アクションを選択</string>
   <!-- Fling -->
   <string name="fling_settings">Flingの設定</string>
   <string name="fling_settings_summary">ユニークで完全カスタマイズ可能なジェスチャーベースのナビゲーションバー</string>
@@ -766,8 +765,8 @@
   <string name="fling_single_left_tap">左をタップ</string>
   <string name="fling_double_left_tap">左を2回タップ</string>
   <string name="fling_long_left_press">左を長押し</string>
-  <string name="long_swipe_portrait_title">ポートレート (縦長モード)</string>
-  <string name="long_swipe_landscape_title">ランドスケープ (横長モード)</string>
+  <string name="long_swipe_portrait_title">縦向き</string>
+  <string name="long_swipe_landscape_title">横向き</string>
   <string name="portrait_right_swipe_title">縦向き時に右スワイプ</string>
   <string name="portrait_left_swipe_title">縦向き時に左スワイプ</string>
   <string name="landscape_right_swipe_title">横向き時に右スワイプ</string>
@@ -807,10 +806,10 @@
   <string name="fling_backup_current_config_title">プロファイルを保存</string>
   <string name="fling_restore_config_title">プロファイルを復元</string>
   <string name="fling_config_name_edit_dialog_title">Flingプロファイル名</string>
-  <string name="fling_config_name_edit_dialog_message">名前を入力するか空白にしてください</string>
+  <string name="fling_config_name_edit_dialog_message">名前を入力するか空欄にしてください</string>
   <string name="fling_config_dialog_title">Flingプロファイル</string>
-  <string name="fling_config_backup_success_toast">Flingプロフィールが正常に保存されました</string>
-  <string name="fling_config_restore_success_toast">Flingプロフィールが正常に復元されました</string>
+  <string name="fling_config_backup_success_toast">Flingプロファイルが正常に保存されました</string>
+  <string name="fling_config_restore_success_toast">Flingプロファイルが正常に復元されました</string>
   <string name="fling_config_backup_error_toast">Flingプロファイルの保存に失敗しました</string>
   <string name="fling_config_restore_error_toast">Flingプロファイルの復元に失敗しました</string>
   <!-- Pulse navigation bar music visualizer -->
@@ -827,14 +826,14 @@
   <string name="fling_smoothing_enabled_title">スムージングを有効にする</string>
   <string name="fling_smoothing_enabled_summary">どちらのバーもよりスムーズに表示されます</string>
   <string name="eos_fling_lavalamp_title">ラーヴァランプモード</string>
-  <string name="eos_fling_lavalamp_summary">Pulseの色がゆるやかに変化する</string>
+  <string name="eos_fling_lavalamp_summary">Pulseの色がゆるやかに変化します</string>
   <string name="pulse_advanced_category">高度な設定</string>
   <string name="pulse_legacy_mode_advanced_category">フェーディングブロックの設定</string>
   <string name="pulse_custom_fudge_factor">ビジュアライザーの感度</string>
   <string name="lavamp_solid_speed_title">ラーヴァランプモードのアニメーション速度</string>
-  <string name="pulse_solid_units_count">実線をカウント</string>
+  <string name="pulse_solid_units_count">ソリッドラインの数</string>
   <string name="pulse_solid_lines_count">実線の数</string>
-  <string name="pulse_solid_units_opacity">実線の不透明度</string>
+  <string name="pulse_solid_units_opacity">ソリッドラインの不透明度</string>
   <string name="pulse_fading_blocks_opacity">フェーディングブロックの不透明度</string>
   <string name="pulse_solid_dimen_category">ソリッドラインの設定</string>
   <string name="pulse_custom_buttons_opacity_title">Pulse上のスマートバーボタンの透明度</string>
@@ -856,8 +855,8 @@
   <string name="land_hor_title">横向き時の高さ</string>
   <string name="positive_done">完了</string>
   <!-- SmartBar -->
-  <string name="smartbar_category">ナビゲーションバー</string>
-  <string name="smartbar_settings_title">ナビゲーションバーの設定</string>
+  <string name="smartbar_category">スマートバー</string>
+  <string name="smartbar_settings_title">スマートバーの設定</string>
   <string name="smartbar_settings_summary">完全にカスタマイズ可能なナビゲーションバー</string>
   <string name="smartbar_editor_title">編集モードを開始する</string>
   <string name="smartbar_editor_summary">スマートバーボタンエディタを開く</string>
@@ -869,11 +868,11 @@
   <string name="smartbar_button_animation_title">ボタンタッチ時のアニメーション</string>
   <string name="smartbar_button_animation_summary">ボタンが押された際のアニメーションを設定する</string>
   <string name="smartbar_button_animation_ripple">波紋</string>
-  <string name="smartbar_button_animation_spring">スプリング</string>
+  <string name="smartbar_button_animation_spring">弾む</string>
   <string name="smartbar_button_animation_flip">反転</string>
-  <string name="smartbar_button_animation_pixel">ピクセル (すべてのボタン)</string>
-  <string name="smartbar_button_animation_pixel_home">ピクセル (ホームボタンのみ)</string>
-  <string name="smartbar_button_animation_pixel_home_ripple">ピクセル (ホームボタンのみ) とリップル</string>
+  <string name="smartbar_button_animation_pixel">Pixel（すべてのボタン）</string>
+  <string name="smartbar_button_animation_pixel_home">Pixel（ホームボタンのみ）</string>
+  <string name="smartbar_button_animation_pixel_home_ripple">Pixel（ホームボタンのみ）と波紋</string>
   <string name="smartbar_factory_reset_title">初期状態にリセット</string>
   <string name="smartbar_factory_reset_confirm">本当にナビゲーションバーを初期設定に戻しても良いですか？</string>
   <string name="smartbar_ime_action_title">入力メソッドとメディアの操作</string>
@@ -885,7 +884,7 @@
   <string name="smartbar_backup_current_config_title">プロファイルを保存</string>
   <string name="smartbar_restore_config_title">プロファイルを復元</string>
   <string name="smartbar_config_name_edit_dialog_title">スマートバーのプロファイル名</string>
-  <string name="smartbar_config_name_edit_dialog_message">名前を入力するか空白のままにする</string>
+  <string name="smartbar_config_name_edit_dialog_message">名前を入力するか空欄にしてください</string>
   <string name="smartbar_config_dialog_title">スマートバーのプロファイル</string>
   <string name="smartbar_config_backup_success_toast">スマートバープロファイルの保存に成功しました</string>
   <string name="smartbar_config_restore_success_toast">スマートバープロファイルの復元に成功しました</string>
@@ -955,7 +954,7 @@
   <string name="animation_duration_title">アニメーション速度</string>
   <string name="title_animation_no_override">アプリによる上書きを防止</string>
   <string name="summary_animation_no_override">アプリによりアニメーションが上書きされることを防止する</string>
-  <string name="animation_duration_default">既定 （デフォルト）</string>
+  <string name="animation_duration_default">デフォルト</string>
   <!-- Power menu and dialogs opacity -->
   <string name="power">電源メニューの設定</string>
   <string name="power_menu_transparency">電源/再起動メニューの不透明度</string>
@@ -965,14 +964,14 @@
   <string name="screen_state_toggles_enable_title">有効</string>
   <string name="screen_state_toggles_enable_summary">アクションは画面オフのときに実行されオンにすると以前の状態が復元されます</string>
   <string name="screen_state_toggles_mobile_title">モバイルネットワーク</string>
-  <string name="screen_state_toggles_location_title">位置</string>
+  <string name="screen_state_toggles_location_title">位置情報</string>
   <string name="screen_state_toggles_twog">2Gに切り替える</string>
   <string name="screen_state_toggles_twog_summary">ネットワークモードは画面オフ時に2Gに切り替わります</string>
   <string name="screen_state_toggles_gps">GPSの無効化</string>
   <string name="screen_state_toggles_gps_summary">画面オフ時にGPSを使用した位置情報サービスを無効化</string>
   <string name="screen_state_toggles_mobile_data">モバイルデータの無効化</string>
   <string name="screen_state_toggles_mobile_data_summary">画面オフ時にモバイルデータが無効</string>
-  <string name="screen_state_off_delay_title">画面オフアクションの遅延</string>
+  <string name="screen_state_off_delay_title">画面消灯時アクションの遅延時間</string>
   <string name="screen_state_off_delay_summary">スリープ時アクションを実行するまでの待機時間 (分) を設定する</string>
   <string name="screen_state_on_delay_title">画面オンアクションの遅延</string>
   <string name="screen_state_on_delay_summary">画面点等時アクションを実行するまでの待機時間 (分) を設定する</string>
@@ -996,9 +995,9 @@
   <string name="screenshot_sound_title">スクリーンショットの音</string>
   <string name="screenshot_sound_summary">スクリーンショットを撮った際に効果音を鳴らす</string>
   <!-- Gesture Anywhere -->
-  <string name="gesture_anywhere_title">常にジェスチャー可能</string>
-  <string name="gesture_anywhere_enabled_title">常にジェスチャー可能</string>
-  <string name="gesture_anywhere_enabled_summary">常にジェスチャー可能にする機能を有効にする</string>
+  <string name="gesture_anywhere_title">どこでもジェスチャー</string>
+  <string name="gesture_anywhere_enabled_title">どこでもジェスチャー</string>
+  <string name="gesture_anywhere_enabled_summary">どこでもジェスチャー機能を有効にする</string>
   <string name="gesture_anywhere_position_title">位置</string>
   <string name="gesture_anywhere_position_left">左端</string>
   <string name="gesture_anywhere_position_right">右端</string>
@@ -1019,7 +1018,7 @@
   <!-- success message, tells the user where the gesture was saved -->
   <string name="ga_save_success">%sにジェスチャーを保存しました</string>
   <!-- Buttons in Rename gesture dialog box -->
-  <string name="ga_rename_action">はい</string>
+  <string name="ga_rename_action">OK</string>
   <!-- Buttons in Rename gesture dialog box -->
   <string name="ga_cancel_action">キャンセル</string>
   <!-- Message displayed when the user opens the gestures settings screen -->
@@ -1051,7 +1050,7 @@
   <string name="immersive_recents_title">アプリ履歴の非表示要素</string>
   <string name="immersive_recents_summary">アプリ履歴の表示を変更</string>
   <string name="immersive_recents_dialog_title">アプリ履歴の表示</string>
-  <string name="immersive_recents_default">既定</string>
+  <string name="immersive_recents_default">デフォルト</string>
   <string name="immersive_recents_fullscreen">フルスクリーン</string>
   <string name="immersive_recents_statusbar">ステータスバーのみ</string>
   <string name="immersive_recents_navbar">ナビゲーションバーのみ</string>
@@ -1080,7 +1079,7 @@
   <string name="pie_status_indicator">ネットワーク表示</string>
   <string name="pie_status_wifi">Wifiのみ</string>
   <string name="pie_status_mobile">モバイルネットワークのみ</string>
-  <string name="pie_status_none">無し</string>
+  <string name="pie_status_none">なし</string>
   <string name="pie_status_both">両方</string>
   <string name="pa_pie_gravity_title">Pieの位置</string>
   <string name="pa_pie_gravity_summary">Pieを配置する場所を選択する</string>
@@ -1106,14 +1105,14 @@
   <string name="delete_success">削除しました</string>
   <string name="delete_fail">削除できません</string>
   <string name="btn_profile">プロファイル</string>
-  <string name="sizer_message_sdnowrite">SDカードに書き込めませんでした。</string>
+  <string name="sizer_message_sdnowrite">SDカードに書き込めませんでした</string>
   <string name="sizer_message_sdnoread">SDカードを読み込めませんでした</string>
   <string name="sizer_message_filesuccess">プロファイルを作成</string>
   <string name="sizer_message_filefail">プロファイルを作成できませんでした</string>
   <string name="sizer_message_noselect">何も選択されていません</string>
   <string name="system_app_remover">システムアプリの削除ツール</string>
   <!-- Pixel Animation Settings -->
-  <string name="pixel_anim_title">Pixelのナビバーアニメーション </string>
+  <string name="pixel_anim_title">Pixelナビゲーションバーのアニメーション </string>
   <string name="pixel_anim_summary">Pixelのナビバーアニメーションの様々な要素をカスタマイズ</string>
   <string name="pixel_anim_warning">Pixelのナビバーアニメーションの様々な要素をカスタマイズします。 警告！ : デフォルトの値を変更するとパフォーマンスが低下する場合があります。自己責任のもと進めてください。</string>
   <string name="pixel_anim_x_title">水平時間</string>
@@ -1129,7 +1128,7 @@
   <string name="dot_bottom_color_title">下のドット</string>
   <string name="dot_left_color_title">左のドット</string>
   <string name="dot_right_color_title">右のドット</string>
-  <string name="dot_obey_themes">既定 (テーマの色)</string>
+  <string name="dot_obey_themes">デフォルト (テーマの色)</string>
   <string name="dot_custom_color">カスタム</string>
   <string name="dot_random_color">ランダム</string>
   <string name="dot_random_color_more">非常にランダム</string>
@@ -1142,13 +1141,13 @@
   <string name="fp_unlock_keystore_summary">再起動後も PIN / パスワード/パターン による認証なしで指紋認証によるロック解除を可能にします。\n注意 : 自己責任で使用してください！</string>
   <!-- Ambient Music Ticker -->
   <string name="force_ambient_for_media_title">アンビエントミュージックティッカー</string>
-  <string name="force_ambient_for_media_summary">アンビエントディスプレイに楽曲情報を表示する</string>
+  <string name="force_ambient_for_media_summary">アンビエント表示に楽曲情報を表示する</string>
   <string name="force_ambient_for_media_off">無効</string>
   <string name="force_ambient_for_media_on">有効</string>
   <string name="force_ambient_for_media_on_forced">強制的に有効</string>
   <string name="force_ambient_for_media_on_forced_clean">強制的に最小化して有効にする</string>
   <!-- Ambient display battery percentage -->
-  <string name="ambient_battery_percent_title">アンビエントディスプレイに電池残量を表示</string>
+  <string name="ambient_battery_percent_title">アンビエント表示に電池残量を表示</string>
   <string name="ambient_battery_percent_summary">dozeモード時に電池残量の表示を有効にする</string>
   <!-- Scrolling Cache -->
   <string name="pref_scrollingcache_title">スクロールキャッシュ</string>
@@ -1177,8 +1176,8 @@
   <string name="data_disabled_icon_title">データ通信が無効のアイコンを表示する</string>
   <string name="data_disabled_icon_summary">モバイルデータが無効の場合シグナルバーの隣にXを表示</string>
   <!-- RR Settings tabs slide effects -->
-  <string name="tabs_effect_title">Ressurection Remixのタブ遷移エフェクト</string>
-  <string name="effect_default">既定（デフォルト）</string>
+  <string name="tabs_effect_title">Resurrection Remixのタブ遷移エフェクト</string>
+  <string name="effect_default">デフォルト</string>
   <string name="effect_accordion">アコーディオン</string>
   <string name="effect_background_to_foreground">奥から前へ</string>
   <string name="effect_cube_in">キューブイン</string>
@@ -1217,9 +1216,9 @@
   <string name="blur_expstatus_cat">ステータスバーの拡張</string>
   <string name="blur_notifications_cat">通知</string>
   <string name="blur_qs_cat">クイック設定</string>
-  <string name="blur_recents_cat">最近使ったアプリ</string>
+  <string name="blur_recents_cat">アプリ履歴</string>
   <string name="blur_colors_cat">カラーフィルターのぼかし</string>
-  <string name="blur_notices_cat">お知らせ</string>
+  <string name="blur_notices_cat">通知</string>
   <string name="blurred_scale">ぼかしの大きさ</string>
   <string name="blurred_scale_summary">ぼかしの鮮明さ</string>
   <string name="blurred_radius">ぼかしの範囲</string>
@@ -1228,7 +1227,7 @@
   <string name="blur_cat_notice_summary">ロック画面ではぼかしが無効になります！半透明の通知のみが有効になります！</string>
   <!-- DSLV -->
   <string name="shortcuts_icon_picker_type">アイコンの種類を選択 :</string>
-  <string name="shortcuts_icon_default">既定 （デフォルト）</string>
+  <string name="shortcuts_icon_default">デフォルト</string>
   <string name="shortcuts_icon_custom">ギャラリー</string>
   <string name="shortcuts_icon_picker_choose_icon_title">アイコンを選択</string>
   <string name="lockscreen_shortcuts_title">画面中央のショートカット</string>
@@ -1247,8 +1246,8 @@
   <string name="shortcuts_icon_picker_calendar">カレンダー</string>
   <string name="shortcuts_icon_picker_camera">カメラ</string>
   <string name="shortcuts_icon_picker_cloud">クラウド</string>
-  <string name="shortcuts_icon_picker_contact">問い合わせ</string>
-  <string name="shortcuts_icon_picker_directdial">ダイレクトダイヤル</string>
+  <string name="shortcuts_icon_picker_contact">連絡先</string>
+  <string name="shortcuts_icon_picker_directdial">直接発信</string>
   <string name="shortcuts_icon_picker_directmessage">ダイレクトメッセージ</string>
   <string name="shortcuts_icon_picker_drive">ドライブ</string>
   <string name="shortcuts_icon_picker_dropbox">Dropbox</string>
@@ -1334,17 +1333,17 @@
   <string name="shortcut_picker_choose_new_action">新しいアクションを選択 :</string>
   <string name="shortcut_picker_reassign_action">アクションを再割り当て :</string>
   <string name="shortcut_picker_choose_action">アクションを選択 :</string>
-  <string name="shortcut_picker_applications_title">アプリケーション</string>
+  <string name="shortcut_picker_applications_title">アプリ</string>
   <string name="shortcut_picker_activities_title">アクティビティ</string>
-  <string name="shortcut_picker_select_app_title">アプリケーションを選択 :</string>
+  <string name="shortcut_picker_select_app_title">アプリを選択 :</string>
   <string name="shortcut_picker_select_activity_title">アクティビティの選択 :</string>
   <string name="shortcut_picker_choose_icon_type_title">アイコンを選択 :</string>
-  <string name="shortcut_picker_icon_type_default_title">Default</string>
+  <string name="shortcut_picker_icon_type_default_title">デフォルト</string>
   <string name="shortcut_picker_icon_type_system_title">システムアイコン</string>
   <string name="shortcut_picker_select_system_icon_title">システムアイコンを選択 :</string>
   <string name="shortcut_picker_icon_type_custom_title">ギャラリー</string>
   <string name="shortcuts_select_custom_app_title">カスタムアプリの選択</string>
-  <string name="shortcuts_applications">アプリケーション</string>
+  <string name="shortcuts_applications">アプリ</string>
   <string name="airplay">Airplay</string>
   <string name="android">Android</string>
   <string name="badoo">Badoo</string>
@@ -1456,7 +1455,7 @@
   <string name="animation_settings_reset_message">全てのアニメーション設定をデフォルトにリセットしますか？</string>
   <!-- Screen Off animation -->
   <string name="screen_off_animation_title">スクリーンオフアニメーション</string>
-  <string name="screen_off_animation_default">既定</string>
+  <string name="screen_off_animation_default">デフォルト</string>
   <string name="screen_off_animation_crt">ブラウン管</string>
   <string name="screen_off_animation_scale">縮小</string>
   <!-- Suppress notification sound/vibration -->
@@ -1482,8 +1481,8 @@
   <string name="status_bar_logo_position_left">左</string>
   <string name="custom_logo_color">カスタムロゴの色</string>
   <string name="custom_logo_position">カスタムロゴの位置</string>
-  <string name="logo0">Resurrection Dark</string>
-  <string name="logo1">Resurrection Light</string>
+  <string name="logo0">Resurrection pure</string>
+  <string name="logo1">Resurrection lollipop</string>
   <string name="logo2">Tuner</string>
   <string name="logo3">BugDroid Minimal </string>
   <string name="logo4">Drupal</string>
@@ -1497,7 +1496,7 @@
   <string name="logo12">FingerPrint</string>
   <string name="logo13">Pugmark</string>
   <string name="logo14">Owl</string>
-  <string name="logo15">Weather Off </string>
+  <string name="logo15">天気 オフ</string>
   <string name="logo16">Blender </string>
   <string name="logo17">Cake</string>
   <string name="logo18">Electric Guitar</string>
@@ -1589,7 +1588,7 @@
   <string name="button14">Swipe Cube</string>
   <string name="button15">Bell </string>
   <string name="button16">Arrow Lines Left </string>
-  <string name="button17">Layers Off </string>
+  <string name="button17">レイヤー オフ </string>
   <string name="button18">Arrow Lines Back</string>
   <string name="button19">Layers</string>
   <string name="button20">Archive </string>
@@ -1645,7 +1644,7 @@
   <string name="expanded_hide_status">ステータスバーを非表示</string>
   <string name="expanded_hide_navigation">ナビゲーションバーを非表示</string>
   <string name="expanded_hide_both">両方を非表示</string>
-  <string name="expanded_nothing_to_show">アプリごとの拡張の状態のカスタム設定を追加するには「すべて拡張」をOFFにしてください。</string>
+  <string name="expanded_nothing_to_show">アプリごとの拡張の状態のカスタム設定を追加するには「すべて拡張」をオフにしてください。</string>
   <string name="expanded_desktop_state">拡張の状態</string>
   <string name="expanded_enabled_for_all">すべて拡張</string>
   <string name="expanded_user_configurable">ユーザー設定</string>
@@ -1698,7 +1697,7 @@
   <string name="navbar_dynamic_summary">前面で動作しているアプリにナビゲーションバーの色を適合させる</string>
   <string name="restart_app_required">それぞれのアプリを再起動して効果を確認する</string>
   <!-- RR config options -->
-  <string name="rr_config_tabs_update_message">あなたは以前のバージョンのRR-OSに存在し、現在では既定の設定であるタブ (Nougat) にレイアウトを変更しようとしています。 続行してもよろしいですか？</string>
+  <string name="rr_config_tabs_update_message">以前のバージョンのRR-OSに存在し、現在では既定の設定であるタブ (Nougat) にレイアウトを変更しようとしています。 続行してもよろしいですか？</string>
   <string name="rr_config_classic_update_message">あなたは以前のバージョンのRR-OSに存在したクラシック (Marshmallow) にレイアウトを変更しようとしています。 続行してもよろしいですか？</string>
   <string name="rr_config_navigation_update_message">あなたはレイアウトを底部ナビゲーションレイアウト (Oreo) に変更しようとしています。これはRR-OSの新しいレイアウトです。 通常のレイアウトとは多少異なるかもしれません。 続行してもよろしいですか？</string>
   <string name="rr_config_navigation_color_enable_title">カスタムナビゲーションバーカラーを有効にする</string>
@@ -1768,7 +1767,7 @@
   <!-- Browser not found -->
   <string name="browser_not_found_toast">既定のブラウザが見つかりません</string>
   <!-- Seekbar default text -->
-  <string name="custom_seekbar_default_text">既定</string>
+  <string name="custom_seekbar_default_text">デフォルト</string>
   <!-- Notification guts kill app button -->
   <string name="notification_guts_kill_app_button_title">アプリ終了ボタン</string>
   <string name="notification_guts_kill_app_button_summary">通知の長押しメニューにアプリ終了ボタンを表示する</string>
@@ -1788,7 +1787,7 @@
   <string name="qs_footer_settings_summary">クイック設定のフッターに設定アイコンを表示する</string>
   <!-- Recents Grid -->
   <string name="recents_grid_title">グリッド形式のアプリ履歴</string>
-  <string name="recents_grid_summary">ストックのアプリ履歴をグリッドスタイルで表示する</string>
+  <string name="recents_grid_summary">標準のアプリ履歴をグリッドスタイルで表示する</string>
   <!-- Recents Lock Icon -->
   <string name="recents_lock_title">アプリ履歴のロック</string>
   <string name="recents_lock_summary">アプリ履歴の上部にロックアイコンを表示する</string>
@@ -1801,7 +1800,7 @@
   <string name="qs_tile_animation_style_flip">左右に回転</string>
   <string name="qs_tile_animation_style_rotate">上下に回転</string>
   <string name="qs_tile_animation_duration_low">ゆっくり</string>
-  <string name="qs_tile_animation_duration_default">既定</string>
+  <string name="qs_tile_animation_duration_default">デフォルト</string>
   <string name="qs_tile_animation_duration_fast">速い</string>
   <string name="qs_tile_animation_interpolator_linearInterpolator">等速</string>
   <string name="qs_tile_animation_interpolator_accelerateInterpolator">加速</string>

--- a/res/values-ja/rr_strings.xml
+++ b/res/values-ja/rr_strings.xml
@@ -17,7 +17,7 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="rr_mod_version">RR-OSバージョン</string>
   <string name="build_date">ビルド日時</string>
-  <string name="mod_version_default">デフォルト</string>
+  <string name="mod_version_default">既定</string>
   <!-- General -->
   <string name="ok">はい</string>
   <string name="reset">リセット</string>
@@ -114,7 +114,7 @@
   <string name="rr_google_plus_title">Google</string>
   <string name="rr_google_plus_summary">Google+コミュニティ</string>
   <string name="rr_pb_title">ピッチブラックテーマ</string>
-  <string name="rr_pb_summary">Resurrection Remix OSの公式基本テーマ</string>
+  <string name="rr_pb_summary">Resurrection Remix OSの公式Substratumテーマ</string>
   <string name="rr_twitter_title">Twitter</string>
   <string name="rr_twitter_summary">Twitterアカウント</string>
   <string name="maintainer_categorie_title">公式にサポートされている端末</string>
@@ -220,7 +220,7 @@
   <string name="rr_recents_title">最近</string>
   <string name="qs_tile_layout">タイルのレイアウト</string>
   <string name="qs_columns_title">列</string>
-  <string name="heads_up_settings">ヘッドアップ通知</string>
+  <string name="heads_up_settings">Heads Up通知</string>
   <string name="system_animations">システムアニメーション</string>
   <string name="rr_ui_title">インターフェース</string>
   <string name="rr_dash_board_title">ダッシュボード</string>
@@ -290,11 +290,11 @@
   <string name="ticker_animation_mode_alpha_fade">フェード</string>
   <string name="ticker_animation_mode_scroll">スクロール</string>
   <!-- Heads up -->
-  <string name="heads_up_title">ヘッドアップを許可する</string>
-  <string name="heads_up_summary_enabled">ヘッドアップ通知は有効です</string>
-  <string name="heads_up_summary_disabled">ヘッドアップ通知は無効です</string>
+  <string name="heads_up_title">Heads Upを許可する</string>
+  <string name="heads_up_summary_enabled">Heads Upは有効です</string>
+  <string name="heads_up_summary_disabled">Heads Upは無効です</string>
   <string name="heads_up_blacklist_add_package_title">アプリを追加</string>
-  <string name="heads_up_blacklist_add_package_summary">これらのアプリ起動中にはヘッドアップ通知を無効化する</string>
+  <string name="heads_up_blacklist_add_package_summary">これらのアプリ起動中にはHeads Upを無効化する</string>
   <string name="heads_up_blacklist_title">ブラックリスト</string>
   <string name="heads_up_blacklist_choose_app">アプリを選択</string>
   <string name="heads_up_blacklist_dialog_delete_title">削除</string>
@@ -477,7 +477,7 @@
   <string name="rr_toast_summary">トーストポップアップの表示アニメーションやアイコンをカスタマイズする</string>
   <string name="rr_expanded_desktop_summary">アプリケーションごとに拡張デスクトップを設定する</string>
   <string name="rr_doze_summary">アンビエント表示の有効 / 無効とその設定をカスタマイズする</string>
-  <string name="rr_heads_up_summary">ヘッドアップ通知の有効 / 無効とその表示時間を設定する</string>
+  <string name="rr_heads_up_summary">Heads Upの有効 / 無効とその表示時間を設定する</string>
   <string name="rr_dash_board_summary">ダッシュ ボードのレイアウトと概要をカスタマイズする</string>
   <string name="misc_weather_settings_summary">時計アプリのウィジェット設定をカスタマイズする</string>
   <string name="system_app_remover_summary">不要なシステムアプリを削除する</string>
@@ -806,13 +806,13 @@
   <string name="fling_factory_reset_confirm">本当にFlingを初期設定に戻しても良いですか？</string>
   <string name="fling_backup_current_config_title">プロファイルを保存</string>
   <string name="fling_restore_config_title">プロファイルを復元</string>
-  <string name="fling_config_name_edit_dialog_title">Flingプロフィール名</string>
+  <string name="fling_config_name_edit_dialog_title">Flingプロファイル名</string>
   <string name="fling_config_name_edit_dialog_message">名前を入力するか空白にしてください</string>
-  <string name="fling_config_dialog_title">Flingプロフィール</string>
+  <string name="fling_config_dialog_title">Flingプロファイル</string>
   <string name="fling_config_backup_success_toast">Flingプロフィールが正常に保存されました</string>
   <string name="fling_config_restore_success_toast">Flingプロフィールが正常に復元されました</string>
-  <string name="fling_config_backup_error_toast">Flingプロファイルの保存中にエラーが発生しました</string>
-  <string name="fling_config_restore_error_toast">Flingプロファイルの復元中にエラーが発生しました</string>
+  <string name="fling_config_backup_error_toast">Flingプロファイルの保存に失敗しました</string>
+  <string name="fling_config_restore_error_toast">Flingプロファイルの復元に失敗しました</string>
   <!-- Pulse navigation bar music visualizer -->
   <string name="pulse_help_policy_notice_summary">デバイスのスピーカーで聴くときに一部のオーディオソースでPulseが機能しません</string>
   <string name="pulse_settings">Pulse</string>
@@ -1654,7 +1654,7 @@
   <string name="expanded_desktop_title">拡張デスクトップのオプション</string>
   <!-- no network switch -->
   <string name="no_sim_cluster_switch_title">SIMカードが刺さっていないネットワークを非表示</string>
-  <string name="no_sim_cluster_switch_summary">SIMの契約が非アクティブで無効になっている場合は、ネットワークバーを非表示にします。SIMが無効になっていない場合、このスイッチは動作しません。注意 : これはシステムUIを再起動します。</string>
+  <string name="no_sim_cluster_switch_summary">SIMのサブスクリプションが非アクティブで無効になっている場合は、ネットワークバーを非表示にします。SIMが無効になっていない場合、このスイッチは動作しません。注意 : これはシステムUIを再起動します。</string>
   <!-- no sim icon switch -->
   <string name="disable_no_sim_title">SIM未挿入のアイコンを無効にする</string>
   <string name="disable_no_sim_summary">SIMが挿入されていない場合はSIM未挿入アイコンを非表示にする</string>
@@ -1817,12 +1817,12 @@
   <string name="force_authorize_substratum_packages_title">すべてのテーマアプリを強制的に承認する</string>
   <string name="force_authorize_substratum_packages_summary">提供元不明のテーマアプリのインストールを許可する</string>
   <!-- Manage applications: show substratum overlays -->
-  <string name="filter_substratum_apps">下層のオーバーレイ</string>
+  <string name="filter_substratum_apps">Substratumオーバーレイ</string>
   <string name="menu_show_substratum">オーバーレイを表示</string>
   <string name="menu_hide_substratum">オーバーレイを非表示</string>
   <!-- Edge gestures -->
   <string name="edge_gestures_title">エッジジェスチャー</string>
-  <string name="edge_gestures_feedback_duration_title">入力時の振動の長さ</string>
+  <string name="edge_gestures_feedback_duration_title">振動フィードバックの長さ</string>
   <string name="edge_gestures_long_press_delay_title">長押し開始までの遅延時間</string>
   <string name="edge_gestures_back_category_title">戻るジェスチャー</string>
   <string name="edge_gestures_back_edges_title">戻るジェスチャーを始める場所</string>

--- a/res/values-ja/rr_strings.xml
+++ b/res/values-ja/rr_strings.xml
@@ -37,7 +37,7 @@
   <string name="about_rr_summary">\@null</string>
   <string name="about_r0m_summary">Resurrection Remix OSに関して</string>
   <string name="rr_donate">開発を支援する</string>
-  <string name="rr_donate_summary">Resurrection Remix OSへの支援を表明して</string>
+  <string name="rr_donate_summary">RRへの支援を表明してください</string>
   <string name="app_name">Resurrection Remix OS</string>
   <!-- Battery Styles -->
   <string name="battery_style_title">バッテリーアイコンのスタイル</string>
@@ -71,24 +71,24 @@
   <string name="listview_translate_left">スライド (左から)</string>
   <string name="listview_translate_right">スライド (右から)</string>
   <string name="listview_title">リストアニメーション</string>
-  <string name="listview_summary">リストビューのアニメーションと補完を設定 </string>
+  <string name="listview_summary">リストビューのアニメーションと補完を設定</string>
   <!-- ListView interpolator -->
   <string name="listview_interpolator_title">リストビューの補完</string>
   <string name="listview_accelerate_interpolator">加速</string>
   <string name="listview_decelerate_interpolator">減速</string>
   <string name="listview_accelerate_decelerate_interpolator">加速と減速</string>
   <string name="listview_anticipate_interpolator">予測</string>
-  <string name="listview_overshoot_interpolator">行き過ぎる</string>
+  <string name="listview_overshoot_interpolator">通過</string>
   <string name="listview_anticipate_overshoot_interpolator">予測と通過</string>
   <string name="listview_bounce_interpolator">跳ねる</string>
   <!-- Keyboard and IME  -->
   <string name="disable_fullscreen_keyboard_title">全画面キーボードを無効化</string>
   <string name="disable_fullscreen_keyboard_summary">横向画面時にキーボードが画面全体を占有しないようにする</string>
   <string name="keyboard_rotation_toggle_title">キーボードの自動回転</string>
-  <string name="keyboard_rotation_toggle_summary">キーボードが表示されている間、強制的にディスプレイの自動回転を有効にします</string>
+  <string name="keyboard_rotation_toggle_summary">キーボードが表示されている間強制的にディスプレイの自動回転を有効にする</string>
   <string name="keyboard_rotation_timeout_title">自動回転のタイムアウト</string>
   <string name="keyboard_rotation_timeout_summary">キーボードが表示されなくなってから<xliff:g id="rotate_timeout">%1$s</xliff:g>秒後に自動回転が無効になります</string>
-  <string name="keyboard_rotation_dialog">この機能はキーボードが表示されている間、一時的にディスプレイの自動回転を有効化します。既に自動回転が有効な場合、この機能に効果はありません</string>
+  <string name="keyboard_rotation_dialog">この機能はキーボードが表示されている間、一時的にディスプレイの自動回転を有効化します。既に自動回転が有効な場合、この機能に効果はありません。</string>
   <string name="show_enter_key_title">Enterキーを表示する</string>
   <string name="show_enter_key_summary">絵文字キーの代わりにEnterを強制表示する</string>
   <string name="keyboard_ime_title">IME設定</string>
@@ -101,6 +101,7 @@
   <string name="github_akhilnarang">https://github.com/akhilnarang</string>
   <string name="github_bdogg718k">https://github.com/bdogg718k</string>
   <string name="github_apascual89">https://GitHub.com/apascual89</string>
+  <string name="github_mracar">https://github.com/mracar07</string>
   <string name="rr">リンク</string>
   <string name="rr_website_title">Webサイト</string>
   <string name="rr_website_summary">Resurrection Remix OSに関してことをもっと知って</string>
@@ -132,6 +133,7 @@
   <string name="christopher_kardas_summary">● モデレーター \n● 編集者 \n● コントリビューター</string>
   <string name="matt_summary">● モデレーター \n● 編集者 \n● コントリビューター</string>
   <string name="justen_summary">● モデレーター \n●編集者 \n● コントリビューター</string>
+  <string name="mracar_summary">● 開発者 \n● メンテナー</string>
   <string name="support_team_title">モデレータタグ</string>
   <string name="device_maintainers_title">デバイスとメンテナ</string>
   <string name="device_maintainers_title_summary">デバイスの一覧と公式 RR-OS メンテナ</string>
@@ -147,7 +149,7 @@
   <string name="commit_message">コミットメッセージ</string>
   <!-- RR Feature lists-->
   <string name="features_title">機能</string>
-  <string name="features_title_summary">利用可能な機能を表示します</string>
+  <string name="features_title_summary">利用可能な機能を表示する</string>
   <string name="features_loading">リストを読み込み中...</string>
   <string name="features_error">リストを読み込めませんでした</string>
   <string name="features_unknown">不明</string>
@@ -155,7 +157,7 @@
   <string name="powermenu_onthego_title">OTG</string>
   <string name="rr_volume_title">音量パネル</string>
   <string name="rr_power_title">電源ダイアログ</string>
-  <string name="rr_lockscreen_target_title">下のショートカット</string>
+  <string name="rr_lockscreen_target_title">下部のショートカット</string>
   <!-- Share RR ROM -->
   <string name="share_rr">シェアする</string>
   <string name="share_rr_summary">みんなにRRを使っていることを知らせましょう</string>
@@ -163,7 +165,7 @@
   <string name="share_chooser_title">Resurrection Remixをシェアする...</string>
   <!-- RR Changelog-->
   <string name="changelog_title">更新履歴</string>
-  <string name="changelog_title_summary">ROMの最近の更新を表示します</string>
+  <string name="changelog_title_summary">ROMの最近の更新を表示する</string>
   <string name="changelog_loading">更新履歴を読み込み中...</string>
   <string name="changelog_error">更新履歴を読み込めませんでした</string>
   <string name="changelog_unknown">不明</string>
@@ -175,9 +177,9 @@
   <string name="changelog_time_4_days">４日前</string>
   <string name="changelog_time_5_days">５日前</string>
   <string name="changelog_time_6_days">６日前</string>
-  <string name="changelog_time_1_week">一週間前</string>
-  <string name="changelog_time_2_weeks">二週間前</string>
-  <string name="changelog_time_3_weeks">三週間前</string>
+  <string name="changelog_time_1_week">1週間前</string>
+  <string name="changelog_time_2_weeks">2週間前</string>
+  <string name="changelog_time_3_weeks">3週間前</string>
   <!--RR Configurations-->
   <string name="fab_updates">アップデート</string>
   <string name="fab_restartui">システムUIの再起動</string>
@@ -185,22 +187,21 @@
   <string name="fab_about">RR-OSについて</string>
   <string name="fab_layout">レイアウトの更新</string>
   <string name="fab_layout_tabs">タッブスレイアウトに切り替える</string>
-  <string name="fab_layout_update">クラシックなレイアウトに切り替える</string>
-  <string name="fab_layout_toggle">ナビゲーションレイアウトに切り替え</string>
+  <string name="fab_layout_update">クラシックレイアウトに切り替える</string>
+  <string name="fab_layout_toggle">ナビゲーションレイアウトに切り替える</string>
   <string name="rr_reset_message">すべての設定を既定値にリセットしますか？</string>
   <string name="rr_reset_settings">設定をリセット</string>
   <string name="rr_reset_yes">はい</string>
   <string name="rr_reset_cancel">キャンセル</string>
   <string name="rr_category_title">個人設定</string>
   <string name="rr_title">高度な設定</string>
-  <string name="rr_title_summary">様々 なカスタマイズ</string>
+  <string name="rr_title_summary">様々なカスタマイズ</string>
   <string name="rr_config_main_title">RR-OS</string>
   <string name="rr_ota_fab_title">自由配置のボタンの表示</string>
-  <string name="rr_ota_fab_summary">高度な設定内のフローティングボタンを有効 / 無効にします
-切り替えると高度な設定を再起動します</string>
+  <string name="rr_ota_fab_summary">高度な設定内のフローティングボタンを有効 / 無効にします。切り替えると高度な設定を再起動します。</string>
   <string name="rr_statusbar_title">ステータスバー</string>
   <string name="rr_sb_gestures_title">ステータスバー上のジェスチャー</string>
-  <string name="qs_advanced_title">上級者モード</string>
+  <string name="qs_advanced_title">高度な設定</string>
   <string name="rr_notification_panel_title">パネル</string>
   <string name="rr_tuner">システムUI調整ツール</string>
   <string name="rr_tuner_summary">ストックカスタマイズの一部</string>
@@ -218,7 +219,7 @@
   <string name="rr_qs_title">クイック設定</string>
   <string name="rr_recents_title">最近</string>
   <string name="qs_tile_layout">タイルのレイアウト</string>
-  <string name="qs_columns_title">カラム</string>
+  <string name="qs_columns_title">列</string>
   <string name="heads_up_settings">ヘッドアップ通知</string>
   <string name="system_animations">システムアニメーション</string>
   <string name="rr_ui_title">インターフェース</string>
@@ -270,14 +271,14 @@
   <string name="headset_connect_player_title">ヘッドセット接続時に音楽アプリを起動する</string>
   <string name="headset_connect_player_disabled">無効</string>
   <string name="headset_connect_player_wired">有線ヘッドホン接続時</string>
-  <string name="headset_connect_player_bt_no_carkit">BTヘッドフォン（車以外）接続時</string>
-  <string name="headset_connect_player_bt">　BTヘッドホン接続時</string>
-  <string name="headset_connect_player_both_no_carkit">有線または BT ヘッドフォン（車以外）接続時</string>
+  <string name="headset_connect_player_bt_no_carkit">Bluetoothヘッドフォン (車以外) 接続時</string>
+  <string name="headset_connect_player_bt">BTヘッドホン接続時</string>
+  <string name="headset_connect_player_both_no_carkit">有線またはBluetoothヘッドフォン (車以外) 接続時</string>
   <string name="headset_connect_player_both">有線または BT ヘッドフォン接続時</string>
   <!-- Status Bar Ticker -->
   <string name="ticker_screen_title">通知ティッカー</string>
   <string name="ticker_title">ステータスバーのアイコン</string>
-  <string name="ticker_summary">古いステータス バーのティッカーを有効にします。</string>
+  <string name="ticker_summary">古いステータスバーのティッカーを有効にする</string>
   <string name="ticker_restore_defaults_title">標準の設定へ戻す</string>
   <string name="text_title">Weather Text</string>
   <string name="icon_title">アイコン</string>
@@ -303,12 +304,13 @@
   <string name="fprint_sucess_vib_summary">指紋認証に成功した際にバイブレーションを作動させる</string>
   <!-- QS quick pulldown using fpc -->
   <string name="status_bar_quick_qs_pulldown_fp_title">指紋認証でクイックスワイプする</string>
+  <string name="status_bar_quick_qs_pulldown_fp_summary">通知を開くために2回下にスワイプするのではなく、これを有効にすれば1回のスワイプで済みます。</string>
   <!-- QuickSettings haptic feedback -->
   <string name="quick_settings_vibrate_title">タッチ時に振動</string>
-  <string name="quick_settings_vibrate_summary">Vibrate when touching tiles</string>
+  <string name="quick_settings_vibrate_summary">タイルに触れたときに振動させる</string>
   <!-- Lockscreen battery info indicator  -->
   <string name="lockscreen_battery_info_title">バッテリー情報</string>
-  <string name="lockscreen_battery_info_summary">充電しながらロックスクリーンにネゴシエートされた充電器最大電流-電圧とバッテリー温度を表示します。</string>
+  <string name="lockscreen_battery_info_summary">充電中のロック画面に接続した充電器の最大電流/電圧とバッテリーの温度を表示する</string>
   <!-- Wake on plugged  -->
   <string name="wake_plugged_title">接続時にスリープ解除</string>
   <string name="wake_plugged_summary">電源接続時にスリープ解除</string>
@@ -327,11 +329,12 @@
   <string name="status_bar_quick_qs_pulldown_left">左</string>
   <string name="status_bar_quick_qs_pulldown_right">右</string>
   <string name="status_bar_double_tap_to_sleep_title">ダブルタップでスリープ</string>
-  <string name="status_bar_double_tap_to_sleep_summary">ステータスバーをダブルタップすると画面をオフにします</string>
+  <string name="status_bar_double_tap_to_sleep_summary">ステータスバーをダブルタップして画面をオフにする</string>
   <string name="qs_tile_title_visibility_title">タイルのタイトルを表示</string>
-  <string name="qs_tile_title_visibility_summary">チェックするとタイルの下にタイトルを表示します</string>
+  <string name="qs_tile_title_visibility_summary">チェックしてタイルの下にタイトルを表示する</string>
   <!-- QS Headers -->
   <string name="status_bar_custom_header_title">有効</string>
+  <string name="daylight_header_pack_title">ヘッダー画像コレクション</string>
   <string name="status_bar_custom_header_shadow_title">ヘッダー画像の影</string>
   <string name="status_bar_custom_header_shadow_summary">明るい画像に優れた視認性</string>
   <string name="unit_percent">\u0025</string>
@@ -340,11 +343,11 @@
   <string name="custom_header_provider_title">ヘッダー プロパイダー</string>
   <string name="custom_header_browse_title">インストールされているヘッダーを参照</string>
   <string name="custom_header_browse_summary">固定モードで使う画像をタップしてください</string>
-  <string name="custom_header_browse_summary_new">利用可能なすべてのヘッダーコレクションを参照します</string>
+  <string name="custom_header_browse_summary_new">利用可能なすべてのヘッダーコレクションを参照する</string>
   <string name="custom_header_pick_title">ヘッダー画像の選択</string>
-  <string name="custom_header_pick_summary">固定モードで使う画像を選択します</string>
-  <string name="style_enabled_summary">カスタムヘッダー画像は ON です</string>
-  <string name="style_disabled_summary">カスタムヘッダー画像は OFF です</string>
+  <string name="custom_header_pick_summary">固定モードで使う画像を選択する</string>
+  <string name="style_enabled_summary">カスタムヘッダー画像はオンです</string>
+  <string name="style_disabled_summary">カスタムヘッダー画像はオフです</string>
   <string name="header_provider_disabled">無効</string>
   <string name="custom_header_title">カスタムヘッダー画像</string>
   <string name="file_header_select_title">画像を選択</string>
@@ -355,7 +358,10 @@
   <string name="smart_pulldown_off">オフ</string>
   <string name="smart_pulldown_none">通知なし</string>
   <string name="smart_pulldown_dismissable">削除できる通知はありません</string>
-  <string name="smart_pulldown_none_summary">通知がない場合、直接クイック設定を開きます</string>
+  <string name="smart_pulldown_ongoing">実行中の通知がない</string>
+  <string name="smart_pulldown_summary">%1$s直接クイック設定を開く</string>
+  <string name="smart_pulldown_none_summary">通知がない場合直接クイック設定を開く</string>
+  <string name="smart_pulldown_off_summary">オフになっています</string>
   <!-- Status bar - icons -->
   <string name="status_bar_icons_title">ステータスバーのアイコン</string>
   <string name="status_bar_notif_count_title">通知の数を表示</string>
@@ -396,14 +402,15 @@
   <!-- Status bar - Brightness -->
   <string name="status_bar_brightness_category">画面の明るさ</string>
   <string name="status_bar_brightness_slider_title">明るさスライダー</string>
-  <string name="status_bar_brightness_slider_summary">クイック設定で明るさを調節します</string>
+  <string name="status_bar_brightness_slider_summary">クイック設定で明るさを調節する</string>
   <string name="status_bar_brightness_slider_auto_title">明るさの自動調節</string>
-  <string name="status_bar_brightness_slider_auto_summary">スライダーの近くに明るさの自動調節のトグルを表示します</string>
+  <string name="status_bar_brightness_slider_auto_summary">スライダーの近くに明るさの自動調節のトグルを表示する</string>
   <string name="status_bar_toggle_brightness">明るさのコントロール</string>
   <string name="status_bar_toggle_brightness_summary">ステータスバーの上をスライドして明るさを調整する</string>
   <!-- Carrier Label -->
   <string name="carrier_options">表示する場所の選択</string>
   <string name="custom_carrier_label_title">カスタムキャリアラベル</string>
+  <string name="custom_carrier_label_explain">ここに通信キャリア名を入力してください。未入力の場合はお使いのキャリアが表示されます。</string>
   <string name="custom_carrier_label_notset">カスタムラベルは設定されていません</string>
   <string name="show_carrier_title">キャリアラベル</string>
   <string name="show_carrier_disabled">無効</string>
@@ -430,40 +437,42 @@
   <string name="battery_bar_blend_color_title">色のブレンド</string>
   <string name="battery_bar_blend_color_summary">バッテリー残量に応じてフル/残量低下時の色をブレンドする</string>
   <string name="battery_bar_blend_color_reverse_title">色の順番を逆転させる</string>
+  <string name="battery_bar_blend_color_reverse_summary_off">フル → 空 : 赤 ← 緑 ← 青 ← 赤</string>
+  <string name="battery_bar_blend_color_reverse_summary_on">フル → 空 : 赤 → 緑 → 青 → 赤</string>
   <!--RR Configurations Summaries-->
-  <string name="clock_custom_summary">ステータスバーの時計と日付のさまざまな要素をカスタマイズします。</string>
-  <string name="status_bar_logo_summary">ステータスバーにおけるResurrectionロゴの表示有無、色と位置をカスタマイズします</string>
-  <string name="sb_custom_logos_summary">ステータスバーのロゴの表示有無と、その他の要素と位置をカスタマイズします。</string>
-  <string name="rr_battery_summary">ステータスバーにおけるバッテリー表示と、バッテリーバーの設定をカスタマイズします。</string>
-  <string name="rr_sb_icons_summary">ステータスバーにおける電波アイコン等のシステムアイコン表示をカスタマイズします。</string>
-  <string name="ticker_screen_summary">ステータスバーのティッカーをカスタマイズします</string>
-  <string name="status_bar_temperature_summary">ステータスバーにおける気温の表示有無と詳細をカスタマイズします。 </string>
-  <string name="network_traffic_summary">ステータスバーにおけるネットワーク トラフィックモニタの表示有無と、そのスタイルや表示しきい値などをカスタマイズします。</string>
-  <string name="carrier_summary">ステータスバーやロック画面におけるキャリアラベルの表示有無と詳細をカスタマイズします。 </string>
-  <string name="rr_sb_gestures_summary">ステータスバー上でのジェスチャーの使用有無をカスタマイズします。</string>
-  <string name="breathing_notifications_summary">Sms、不在着信、音声メーセージの通知を点滅させます</string>
-  <string name="rr_trans_summary">透明度や枠線など、通知ドロワーの様々な要素をカスタマイズします</string>
-  <string name="rr_volume_summary">透明度や枠線など、音量パネルの様々な要素をカスタマイズします</string>
-  <string name="rr_power_summary">電源メニューのインターフェイスの暗さと透明度をカスタマイズします</string>
-  <string name="rr_recents_ui_summary">メモリーバーや全画面など、アプリ履歴の様々な要素をカスタマイズします</string>
-  <string name="recents_clear_all_summary">全て終了ボタンの表示 / 非表示と、その位置をカスタマイズする</string>
+  <string name="clock_custom_summary">ステータスバーの時計と日付のさまざまな要素をカスタマイズする</string>
+  <string name="status_bar_logo_summary">ステータスバーにおけるResurrectionロゴの表示有無、色と位置をカスタマイズします。</string>
+  <string name="sb_custom_logos_summary">ステータスバーのアイコンの表示の有無と、それらの要素と位置をカスタマイズします。</string>
+  <string name="rr_battery_summary">ステータスバーにおけるバッテリー表示とバッテリーバーの設定をカスタマイズする</string>
+  <string name="rr_sb_icons_summary">ステータスバーにおける電波アイコン等のシステムアイコン表示をカスタマイズする</string>
+  <string name="ticker_screen_summary">ステータスバーのティッカーをカスタマイズする</string>
+  <string name="status_bar_temperature_summary">ステータスバーにおける気温の表示有無とスタイルをカスタマイズする</string>
+  <string name="network_traffic_summary">ステータスバーにおけるネットワークトラフィックモニターの表示有無とスタイルや表示しきい値などをカスタマイズする</string>
+  <string name="carrier_summary">ステータスバーやロック画面におけるキャリアラベルの表示有無と詳細をカスタマイズする</string>
+  <string name="rr_sb_gestures_summary">ステータスバー上でのジェスチャーの使用有無をカスタマイズする</string>
+  <string name="breathing_notifications_summary">SMS・不在着信・音声メーセージの通知を点滅させる</string>
+  <string name="rr_trans_summary">透明度や枠線などの通知ドロワーの様々な要素をカスタマイズする</string>
+  <string name="rr_volume_summary">透明度や枠線などの音量パネルの様々な要素をカスタマイズする</string>
+  <string name="rr_power_summary">電源メニューのインターフェイスの暗さと透明度をカスタマイズする</string>
+  <string name="rr_recents_ui_summary">メモリーバーや全画面などのアプリ履歴の様々な要素をカスタマイズする</string>
+  <string name="recents_clear_all_summary">全て終了ボタンの表示 / 非表示とその位置をカスタマイズする</string>
   <string name="omniswitch_summary">アプリ履歴をomni-recentsに置き換える</string>
-  <string name="rr_qs_animation_summary">Qsタイルをタップした際のアニメーションを有効/無効にする、またそれをカスタマイズする</string>
-  <string name="rr_qs_pulldown_summary">クイック パネル プルダウン設定を調整します。</string>
-  <string name="qs_tile_layout_summary">[クイック設定] タイルのレイアウトをカスタマイズします。</string>
+  <string name="rr_qs_animation_summary">クイック設定タイルをタップした際のアニメーションを有効 / 無効にする。またそれをカスタマイズする。</string>
+  <string name="rr_qs_pulldown_summary">クイックパネルプルダウン設定を調整する</string>
+  <string name="qs_tile_layout_summary">クイック設定タイルのレイアウトをカスタマイズする</string>
   <string name="qs_advanced_summary">その他のクイック設定のカスタマイズ</string>
-  <string name="rr_ls_gesture_summary">既得しているジェスチャーのロック画面を選択します。</string>
-  <string name="rr_ls_ui_summary">有効/無効 ロック画面で提供されるさまざまな要素をカスタマイズします。</string>
+  <string name="rr_ls_gesture_summary">ロック画面で取得したさまざまなジェスチャーを選択する</string>
+  <string name="rr_ls_ui_summary">ロック画面で提供されるさまざまな要素を有効・無効・カスタマイズする</string>
   <string name="lockscreen_targets_summary">ロック画面下部のショートカットを編集する</string>
-  <string name="lockscreen_weather_summary">ロック画面の天気のレイアウトをカスタマイズします。</string>
-  <string name="sb_weather_summary">ステータスバーの天気をカスタマイズします</string>
-  <string name="rr_ls_security_summary">ロック画面のさまざまなセキュリティ機能を有効/無効にします。</string>
-  <string name="gesture_anywhere_summary">動作を起動するジェスチャーを設定します</string>
-  <string name="app_sidebar_summary">アプリを簡単にすぐに起動する動作を利用するのにサイド バーを使用します。</string>
-  <string name="app_circle_bar_summary">画面右端をタップすると円状のアプリランチャーを表示します</string>
+  <string name="lockscreen_weather_summary">ロック画面の天気のレイアウトをカスタマイズする</string>
+  <string name="sb_weather_summary">ステータスバーの天気をカスタマイズする</string>
+  <string name="rr_ls_security_summary">ロック画面のさまざまなセキュリティ機能を有効 / 無効にする</string>
+  <string name="gesture_anywhere_summary">動作を起動するジェスチャーを設定する</string>
+  <string name="app_sidebar_summary">アプリを迅速・簡単に起動・使用するのにサイドバーを使用する</string>
+  <string name="app_circle_bar_summary">画面右端をタップして円状のアプリランチャーを表示する</string>
   <string name="pa_pie_control_summary">端からスワイプすることでショートカットとナビゲーションコントロールが利用できるPieを有効/無効にする</string>
-  <string name="rr_navbar_summary">ソフトキーを表示してカスタマイズします</string>
-  <string name="system_animations_summary">システムの各ウィンドウのアニメーションをカスタマイズします。</string>
+  <string name="rr_navbar_summary">ソフトキーを表示してカスタマイズする</string>
+  <string name="system_animations_summary">システムの各ウインドウのアニメーションをカスタマイズする</string>
   <string name="rr_power_anim_summary">電源メニューの表示アニメーションをリストから選択する</string>
   <string name="rr_toast_summary">トーストポップアップの表示アニメーションやアイコンをカスタマイズする</string>
   <string name="rr_expanded_desktop_summary">アプリケーションごとに拡張デスクトップを設定する</string>
@@ -471,13 +480,16 @@
   <string name="rr_heads_up_summary">ヘッドアップ通知の有効 / 無効とその表示時間を設定する</string>
   <string name="rr_dash_board_summary">ダッシュ ボードのレイアウトと概要をカスタマイズする</string>
   <string name="misc_weather_settings_summary">時計アプリのウィジェット設定をカスタマイズする</string>
-  <string name="system_app_remover_summary">不要なシステムアプリを削除します。</string>
+  <string name="system_app_remover_summary">不要なシステムアプリを削除する</string>
   <string name="rr_updater_summary">OTAアップデートと関連リンクをチェックする</string>
   <string name="rr_notif_settings_summary">通知パネルでの通知の外観をカスタマイズする</string>
   <string name="rr_fp_summary">指紋センサーのさまざまなオプションをカスタマイズする</string>
-  <string name="rr_sound_summary">その他のサウンドをカスタマイズします</string>
-  <string name="rr_np_summary">通知パネルの様々な要素をカスタマイズします</string>
+  <string name="rr_sound_summary">その他のサウンドをカスタマイズする</string>
+  <string name="rr_np_summary">通知パネルの様々な要素をカスタマイズする</string>
+  <string name="rr_density_summary">画面の密度をカスタマイズして画面を限界の解像度に合わせる</string>
   <string name="rr_fonts_summary">ご希望のフォントサイズを選択してください</string>
+  <string name="stock_recents_category">標準のアプリ履歴</string>
+  <string name="edge_gestures_summary">エッジジェスチャーを使って操る</string>
   <!-- QS rows and columns -->
   <string name="qs_rows_portrait_title">縦向き時の行数</string>
   <string name="qs_rows_landscape_title">横向き時の行数</string>
@@ -500,7 +512,10 @@
   <!-- Weather - OmniJaws Settings -->
   <string name="weather_title">天気</string>
   <string name="weather_config_title">サービスの設定</string>
+  <string name="header_weather_title">ヘッダーに天気を表示</string>
+  <string name="header_weather_summary">通知パネルのヘッダー画像を有効にする</string>
   <string name="weather_icon_pack_title">状態アイコンパック</string>
+  <string name="weather_icon_pack_note">備考\u003a プレイストアで「Chronusアイコン」を検索することで新しいアイコンパックをインストールできます</string>
   <string name="status_bar_weather_size_title">フォントサイズ</string>
   <string name="status_bar_weather_font_style_title">フォント</string>
   <string name="status_bar_weather_font_normal">標準</string>
@@ -538,16 +553,27 @@
   <string name="lock_screen_show_location_summaryOff">ロック画面に位置情報を表示しない</string>
   <string name="lock_screen_weather_condition_icon_title">天候のアイコンを表示</string>
   <string name="lock_screen_weather_condition_icon_summaryOn">ロック画面に天候のアイコンを表示する</string>
+  <string name="lock_screen_weather_condition_icon_summaryOff">ロック画面に天候のアイコンを表示しない</string>
   <!-- Power Menu -->
   <string name="powermenu_title">電源メニュー</string>
   <string name="powermenu_reboot_title">再起動</string>
   <string name="powermenu_advanced_reboot_title">高度な再起動</string>
+  <string name="powermenu_advanced_reboot_summary">詳細な再起動メニューを有効にすると、リカバリーモード、ブートローダ、システムUIの再起動、クイックリブートが選択出来るようになります。</string>
   <string name="powermenu_screenshot_title">スクリーンショット</string>
   <string name="powermenu_airplane_title">機内モード</string>
   <string name="powermenu_screenrecord_title">画面の録画</string>
-  <string name="powermenu_flashlight">ライト</string>
+  <string name="powermenu_flashlight">フラッシュライト</string>
+  <string name="powermenu_ls_reboot_summary">ロックスクリーンに再起動オプションを表示する</string>
+  <string name="powermenu_ls_advanced_reboot_summary">ロックスクリーンに高度な再起動オプションを表示する</string>
+  <string name="powermenu_ls_screenshot_summary">ロックスクリーンにスクリーンショットオプションを表示する</string>
+  <string name="powermenu_ls_airplane_summary">ロックスクリーンに機内モードオプションを表示する</string>
+  <string name="powermenu_ls_flashlight_summary">ロックスクリーンにフラッシュライトオプションを表示する</string>
+  <string name="powermenu_ls_screenrecord_summary">ロックスクリーンに画面の録画オプションを表示する</string>
+  <string name="powermenu_ls_onthego_summary">ロックスクリーンにOn-The-Goオプションを表示する</string>
   <!-- Lockscreen notif count -->
   <string name="lockscreen_maxnotif_title">通知数</string>
+  <string name="lockscreen_maxnotif_summary">表示する通知の数を調整する</string>
+  <string name="lockscreen_maxnotif_config">表示する通知の最大数</string>
   <!-- Toast icon switch -->
   <string name="toast_icon_title">トーストアイコン</string>
   <string name="toast_icon_summary">トーストを表示したアプリのアイコンを表示する</string>
@@ -570,10 +596,14 @@
   <string name="toast_SlideLeftRight_animation">左から右へスライド</string>
   <string name="toast_SlideRightLeft_animation">右から左にスライド</string>
   <!-- Small quick settings scroller -->
+  <string name="qqs_scroll_title">クイック設定の小さなタイルをスクロールする</string>
+  <string name="qqs_scroll_summary">小さなクイック設定タイルをスクロールできるようにする</string>
   <!-- Volume dialog timeout -->
   <string name="volume_dialog_timeout_title">音量パネルの表示時間</string>
   <!-- Volume dialog opacity -->
-  <string name="volume_dialog_stroke_title">ボリュームダイアログ ストローク</string>
+  <string name="volume_dialog_transparency_title">音量ダイアログの設定</string>
+  <string name="volume_dialog_transparency">音量ダイアログの不透明度</string>
+  <string name="volume_dialog_stroke_title">ボリュームダイアログストローク</string>
   <string name="volume_dialog_stroke_disabled">停止</string>
   <string name="volume_dialog_stroke_accent">アクセントカラー</string>
   <string name="volume_dialog_stroke_custom">カスタムカラー</string>
@@ -588,11 +618,12 @@
   <string name="systemui_recents_mem_display_summaryOff">メモリーバー無効</string>
   <!-- Slim recents -->
   <string name="slim_recents_title">Slim Recents</string>
+  <string name="alternative_recents_category">代替のアプリ履歴</string>
   <string name="recents_max_apps_title">許可されたアプリの最大数</string>
   <string name="recent_panel_scale_title">サイズ</string>
   <string name="recent_panel_expanded_mode_title">拡張モード</string>
-  <string name="recent_panel_expanded_mode_summary">最近のタスクの拡張プレビュー モード</string>
-  <string name="recent_panel_expanded_mode_auto">自動(デフォルト)</string>
+  <string name="recent_panel_expanded_mode_summary">最近のタスクの拡張プレビューモード</string>
+  <string name="recent_panel_expanded_mode_auto">自動 (デフォルト)</string>
   <string name="recent_panel_expanded_mode_always">常に</string>
   <string name="recent_panel_expanded_mode_never">なし</string>
   <string name="recent_panel_bg_color_title">パネルの背景色</string>
@@ -600,10 +631,11 @@
   <string name="slim_recents_mem_display_long_click_clear_title">メモリバーの長押し</string>
   <string name="slim_recents_mem_display_long_click_clear_summary">メモリバーの長押しで最近のアプリを消去</string>
   <string name="slim_icon_pack_title">アイコンパック</string>
-  <string name="slim_icon_pack_summary">パネルのアプリのためにカスタムテーマを適用します</string>
+  <string name="slim_icon_pack_summary">パネルのアプリにカスタムテーマを適用する</string>
   <string name="no_iconpacks_summary">アイコンパックがインストールされていません</string>
   <string name="dialog_pick_iconpack_title">アイコンパックを選択</string>
   <string name="default_iconpack_title">デフォルトアイコン</string>
+  <string name="slim_recents_corner_radius_title">角の丸みの半径</string>
   <string name="recent_panel_expanded_mode_disabled">無効</string>
   <!-- ATTENTION: RTL languages need to replace left with right -->
   <string name="recent_panel_lefty_mode_title">左端に表示</string>
@@ -615,19 +647,22 @@
   <string name="slim_blacklist_apps_title">アプリのブラックリスト</string>
   <string name="slim_blacklist_apps_summary">パネルに表示しないアプリ</string>
   <string name="slim_blacklist_add_apps_title">アプリを追加</string>
+  <string name="slim_blacklist_add_apps_summary">ここをタップして追加し追加済みアプリをタップして削除</string>
   <!-- Slim Recent App Sidebar  -->
   <string name="recent_app_sidebar_title">最近のアプリのサイドバー</string>
-  <string name="use_recent_app_sidebar_title">アプリ サイドバーを有効にします。</string>
-  <string name="use_recent_app_sidebar_summary">一方の端にアプリのショートカットを表示します。</string>
+  <string name="recent_app_sidebar_summary">一方の端にアプリのショートカットを表示する</string>
+  <string name="use_recent_app_sidebar_title">アプリサイドバーを有効にする</string>
+  <string name="use_recent_app_sidebar_summary">一方の端にアプリのショートカットを表示する</string>
   <string name="recent_app_sidebar_content_title">サイドバーコンテンツ</string>
-  <string name="recent_app_sidebar_content_summary">アプリのサイドバーのコンテンツを構成します。</string>
+  <string name="recent_app_sidebar_content_summary">アプリのサイドバーのコンテンツを設定する</string>
   <string name="recent_app_sidebar_style_title">サイドバーのスタイル</string>
+  <string name="recent_app_sidebar_style_summary">サイドバーの外観を変更する</string>
   <string name="recent_app_sidebar_hide_labels_title">アイコンラベルを非表示</string>
   <string name="recent_app_sidebar_label_color_title">ラベルの色</string>
   <string name="recent_app_sidebar_bg_color_title">背景色</string>
   <string name="recent_app_sidebar_scale_title">サイズ</string>
   <string name="recent_app_sidebar_open_simultaneously_title">後書きで開く</string>
-  <string name="recent_app_sidebar_open_simultaneously_summary">これを無効にするとラグを開く recents を減らす</string>
+  <string name="recent_app_sidebar_open_simultaneously_summary">これを無効化するとアプリ履歴を開く際のラグを減らせます</string>
   <!-- Slim recents membar -->
   <string name="slim_recents_mem_display_category_title">メモリ使用量バー</string>
   <string name="slim_recents_mem_display_title">空きメモリ領域を表示する</string>
@@ -641,22 +676,23 @@
   <string name="powermenu_lockscreen_summary">ロック画面でパワーメニューの表示と使用を可能にする</string>
   <!-- Disable QS on secure Lockscreen -->
   <string name="lockscreen_qs_disabled_title">ロック時にクイック設定を無効化</string>
-  <string name="lockscreen_qs_disabled_summary">保護されたロック画面でクイック設定タイルを無効化します</string>
+  <string name="lockscreen_qs_disabled_summary">保護されたロック画面でクイック設定タイルを無効化する</string>
   <string name="torch_long_press_power_gesture_title">長押しでライト点灯</string>
-  <string name="torch_long_press_power_gesture_desc">画面消灯時に電源ボタンを長押ししてライトを点灯します</string>
+  <string name="torch_long_press_power_gesture_desc">画面消灯時に電源ボタンを長押ししてライトを点灯する</string>
   <string name="torch_long_press_power_timeout_title">ライトを自動的にオフにする</string>
-  <string name="volbtn_music_controls_summary">画面消灯時に音量ボタンを長押しして音楽を操作します</string>
+  <string name="volbtn_music_controls_title">再生をコントロール</string>
+  <string name="volbtn_music_controls_summary">画面消灯時に音量ボタンを長押しして音楽を操作する</string>
   <string name="volbtn_cursor_control_title">キーボードのカーソル制御</string>
   <string name="volbtn_cursor_control_off">無効</string>
-  <string name="volbtn_cursor_control_on">音量の上/下ボタンでカーソルを”左/右”に移動する</string>
-  <string name="volbtn_cursor_control_on_reverse">音量の上/下ボタンでカーソルを”右/左”に移動する</string>
+  <string name="volbtn_cursor_control_on">音量の上/下ボタンでカーソルを 左/右 に移動する</string>
+  <string name="volbtn_cursor_control_on_reverse">音量の上/下ボタンでカーソルを 右/左 に移動する</string>
   <string name="power_end_call_title">通話を終了</string>
   <string name="power_end_call_summary">電源ボタンを押して現在の通話を終了する</string>
   <string name="swap_volume_buttons_title">Reorient</string>
   <string name="swap_volume_buttons_summary">画面回転時に音量ボタンを入れ替える</string>
   <string name="button_wake_title">スリープ解除</string>
   <string name="volume_answer_call_title">着信に応答</string>
-  <string name="volume_answer_call_summary">ボリューム ボタンで着信に応答する</string>
+  <string name="volume_answer_call_summary">ボリュームボタンで着信に応答する</string>
   <string name="home_answer_call_title">着信に応答</string>
   <string name="home_answer_call_summary">ホームボタンを押して着信に応答する</string>
   <string name="extras_title">その他</string>
@@ -673,7 +709,7 @@
   <!-- StatusBar weather settings -->
   <string name="rr_weather_title">ステータスバー上の天気</string>
   <string name="statusbar_weather_title">ステータスバー上の天気</string>
-  <string name="statusbar_weather_summary">QS設定/天気から設定する</string>
+  <string name="statusbar_weather_summary">クイック設定/天気から設定する</string>
   <string name="statusbar_weather_dialog_title">ステータスバー上の天気の表示</string>
   <string name="status_bar_weather_hidden">天気を非表示</string>
   <string name="status_bar_temperature_image_show_scale">単位と画像付きで温度を表示</string>
@@ -694,8 +730,8 @@
   <string name="navigation_bar_left_summary">画面が横向きの際にナビゲーションバーを画面の左側に配置する</string>
   <string name="smartbar_interface">ナビバー</string>
   <string name="icon_pack_picker_dialog_title">アイコンパック</string>
-  <string name="image_exceeds_max_allowed_size">イメージは 512 x 512 を超えないようにしてください。</string>
-  <string name="invalid_icon_from_uri">コンテンツ プロバイダーからイメージを読み込むことができません。</string>
+  <string name="image_exceeds_max_allowed_size">イメージは 512 x 512 を超えないようにしてください</string>
+  <string name="invalid_icon_from_uri">コンテンツ プロバイダーからイメージを読み込むことができません</string>
   <string name="picker_activities">アクティビティ</string>
   <string name="select_custom_app_title">任意のアプリを選択</string>
   <string name="select_custom_activity_title">任意のアクティビティを選択</string>
@@ -741,9 +777,9 @@
   <string name="up_swipe_title">上スワイプ</string>
   <string name="down_swipe_title">下スワイプ</string>
   <string name="long_swipe_reset">リセット</string>
-  <string name="fling_advanced">より高度な設定</string>
+  <string name="fling_advanced">高度な設定</string>
   <string name="fling_long_swipe_title">長いスワイプのしきい値</string>
-  <string name="fling_long_swipe_summary">Flingインターフェイスの幅または高さのパーセンテージに基づいて、長いスワイプしきい値を微調整する</string>
+  <string name="fling_long_swipe_summary">Flingインターフェイスの幅または高さのパーセンテージに基づいて長いスワイプのしきい値を微調整する</string>
   <string name="fling_trails_enable_title">ジェスチャーの軌跡を有効化</string>
   <string name="fling_trails_enable_summary">スワイプするジェスチャーの軌跡を表示する</string>
   <string name="fling_trails_color_title">軌跡の色</string>
@@ -763,36 +799,51 @@
   <string name="fling_longpress_timeout_label_right">より多くの遅延</string>
   <string name="fling_longpress_title">長押しの遅延</string>
   <string name="fling_longpress_summary">長押しの実行までにかかる時間を設定する</string>
+  <string name="fling_keyboard_cursors_title">ダイナミックキーボードカーソルアクション</string>
   <string name="fling_keyboard_cursors_move_summary">キーボードが表示されているときは、左または右を長押ししてテキストカーソルを左右に移動します。\nカーソルを移動し続けるには長押しを、バーをタップするとホーム画面に移動します。</string>
   <string name="fling_logo_opacity_title">ロゴの不透明度</string>
   <string name="fling_factory_reset_title">初期状態にリセット</string>
   <string name="fling_factory_reset_confirm">本当にFlingを初期設定に戻しても良いですか？</string>
   <string name="fling_backup_current_config_title">プロファイルを保存</string>
   <string name="fling_restore_config_title">プロファイルを復元</string>
+  <string name="fling_config_name_edit_dialog_title">Flingプロフィール名</string>
+  <string name="fling_config_name_edit_dialog_message">名前を入力するか空白にしてください</string>
   <string name="fling_config_dialog_title">Flingプロフィール</string>
   <string name="fling_config_backup_success_toast">Flingプロフィールが正常に保存されました</string>
   <string name="fling_config_restore_success_toast">Flingプロフィールが正常に復元されました</string>
   <string name="fling_config_backup_error_toast">Flingプロファイルの保存中にエラーが発生しました</string>
   <string name="fling_config_restore_error_toast">Flingプロファイルの復元中にエラーが発生しました</string>
   <!-- Pulse navigation bar music visualizer -->
-  <string name="pulse_help_policy_notice_summary">デバイスのスピーカーで聴くときに一部のオーディオソースでパルスが機能しません</string>
+  <string name="pulse_help_policy_notice_summary">デバイスのスピーカーで聴くときに一部のオーディオソースでPulseが機能しません</string>
   <string name="pulse_settings">Pulse</string>
   <string name="pulse_settings_summary">ナビゲーションバーのグラフィックイコライザー</string>
-  <string name="fling_show_pulse_title">パルスを許可する</string>
+  <string name="fling_show_pulse_title">Pulseを許可する</string>
   <string name="fling_show_pulse_summary">ナビゲーションバー上のグラフィックイコライザー</string>
   <string name="pulse_render_mode_title">レンダリングモード</string>
   <string name="pulse_render_mode_fading_bars">フェーディングブロック</string>
   <string name="pulse_render_mode_solid_lines">ソリッドライン</string>
   <string name="fling_pulse_color">Pulseの色</string>
+  <string name="fling_pulse_color_summary">自動カラーのフォールバックとしても使用します</string>
+  <string name="fling_smoothing_enabled_title">スムージングを有効にする</string>
+  <string name="fling_smoothing_enabled_summary">どちらのバーもよりスムーズに表示されます</string>
   <string name="eos_fling_lavalamp_title">ラーヴァランプモード</string>
-  <string name="eos_fling_lavalamp_summary">Pulseの色がゆるやかに変化します</string>
+  <string name="eos_fling_lavalamp_summary">Pulseの色がゆるやかに変化する</string>
   <string name="pulse_advanced_category">高度な設定</string>
   <string name="pulse_legacy_mode_advanced_category">フェーディングブロックの設定</string>
   <string name="pulse_custom_fudge_factor">ビジュアライザーの感度</string>
+  <string name="lavamp_solid_speed_title">ラーヴァランプモードのアニメーション速度</string>
   <string name="pulse_solid_units_count">実線をカウント</string>
+  <string name="pulse_solid_lines_count">実線の数</string>
   <string name="pulse_solid_units_opacity">実線の不透明度</string>
-  <string name="pulse_fading_blocks_opacity">退色する ブロック 不透明性</string>
+  <string name="pulse_fading_blocks_opacity">フェーディングブロックの不透明度</string>
   <string name="pulse_solid_dimen_category">ソリッドラインの設定</string>
+  <string name="pulse_custom_buttons_opacity_title">Pulse上のスマートバーボタンの透明度</string>
+  <string name="pulse_auto_color_title">自動設定のPulseカラー</string>
+  <string name="pulse_auto_color_summary">アルバムアートの色に同期します。ラーヴァランプモードやラインの不透明度を上書きします。</string>
+  <string name="fling_lavalamp_color_from">ラーヴァランプの開始カラー</string>
+  <string name="fling_lavalamp_color_to">ラーヴァランプの終了カラー</string>
+  <string name="pulse_colors_reset_title">Pulseの色をリセット</string>
+  <string name="pulse_colors_reset_message">これらの色をデフォルトに戻しますか？</string>
   <!-- Pulse config -->
   <string name="pulse_custom_dimen">バーの幅</string>
   <string name="pulse_custom_div">バーの間隔</string>
@@ -807,21 +858,26 @@
   <!-- SmartBar -->
   <string name="smartbar_category">ナビゲーションバー</string>
   <string name="smartbar_settings_title">ナビゲーションバーの設定</string>
+  <string name="smartbar_settings_summary">完全にカスタマイズ可能なナビゲーションバー</string>
+  <string name="smartbar_editor_title">編集モードを開始する</string>
+  <string name="smartbar_editor_summary">スマートバーボタンエディタを開く</string>
+  <string name="smartbar_help_policy_notice_summary">エディタモードでは、ボタンを押しながらドラッグすると位置を変更し、ボタンを長押しすると編集メニューを表示できます。メニューが表示されている間にボタンの位置が変更されることがあります。\n\nダブルタップを設定すると、シングルタップは少し遅れます。</string>
   <string name="smartbar_context_menu_position_title">コンテキストボタンの位置</string>
   <string name="smartbar_context_menu_position_summary">メニューやIME切り替えボタンを表示する位置を設定する</string>
   <string name="smartbar_right">右</string>
   <string name="smartbar_left">左</string>
   <string name="smartbar_button_animation_title">ボタンタッチ時のアニメーション</string>
-  <string name="smartbar_button_animation_summary">ボタンが押された際のアニメーションを設定します</string>
+  <string name="smartbar_button_animation_summary">ボタンが押された際のアニメーションを設定する</string>
   <string name="smartbar_button_animation_ripple">波紋</string>
   <string name="smartbar_button_animation_spring">スプリング</string>
+  <string name="smartbar_button_animation_flip">反転</string>
   <string name="smartbar_button_animation_pixel">ピクセル (すべてのボタン)</string>
   <string name="smartbar_button_animation_pixel_home">ピクセル (ホームボタンのみ)</string>
   <string name="smartbar_button_animation_pixel_home_ripple">ピクセル (ホームボタンのみ) とリップル</string>
   <string name="smartbar_factory_reset_title">初期状態にリセット</string>
   <string name="smartbar_factory_reset_confirm">本当にナビゲーションバーを初期設定に戻しても良いですか？</string>
   <string name="smartbar_ime_action_title">入力メソッドとメディアの操作</string>
-  <string name="smartbar_ime_action_summary">オンスクリーンキーボードを使用中に表示するボタンを選択するまたは音譜遊んでいる</string>
+  <string name="smartbar_ime_action_summary">オンスクリーンキーボードの使用中または音楽の再生中に表示するボタンを選択する</string>
   <string name="smartbar_ime_action_none">なし</string>
   <string name="smartbar_ime_action_arrows">方向キー</string>
   <string name="smartbar_ime_action_switcher">IME切り替え</string>
@@ -831,25 +887,27 @@
   <string name="smartbar_config_name_edit_dialog_title">スマートバーのプロファイル名</string>
   <string name="smartbar_config_name_edit_dialog_message">名前を入力するか空白のままにする</string>
   <string name="smartbar_config_dialog_title">スマートバーのプロファイル</string>
-  <string name="smartbar_config_backup_success_toast">スマートバー プロファイルの保存に成功しました</string>
-  <string name="smartbar_config_restore_success_toast">スマートバー プロファイルの復元に成功しました</string>
-  <string name="smartbar_config_backup_error_toast">スマートバー プロファイルの保存でエラーが発生しました</string>
-  <string name="smartbar_config_restore_error_toast">スマートバー プロファイルの復元でエラーが発生しました</string>
-  <string name="navbar_buttons_alpha_title">Buttons transparency</string>
+  <string name="smartbar_config_backup_success_toast">スマートバープロファイルの保存に成功しました</string>
+  <string name="smartbar_config_restore_success_toast">スマートバープロファイルの復元に成功しました</string>
+  <string name="smartbar_config_backup_error_toast">スマートバープロファイルの保存でエラーが発生しました</string>
+  <string name="smartbar_config_restore_error_toast">スマートバープロファイルの復元でエラーが発生しました</string>
+  <string name="navbar_buttons_alpha_title">ボタンの透明度</string>
   <string name="smartbar_longpress_delay_title">ボタンの長押し遅延</string>
-  <string name="smartbar_longpress_delay_summary">長いプレスアクションをトリガする前にシステムがどれくらい待機するかを設定する</string>
-  <string name="smartbar_longpress_delay_default">デフォルトの遅延（高速）</string>
+  <string name="smartbar_longpress_delay_summary">長押し動作を検知するまでの待機時間を設定する</string>
+  <string name="smartbar_longpress_delay_default">デフォルトの遅延 (高速)</string>
   <string name="smartbar_longpress_delay_normal">通常の遅延</string>
   <string name="smartbar_longpress_delay_long">長時間の遅延</string>
   <string name="smartbar_custom_icon_size_title">カスタムアイコンスケーリング</string>
   <string name="one_handed_mode_title">片手モード</string>
-  <string name="one_handed_mode_summary">ナビゲーション バーをスワイプで片手モードを有効</string>
+  <string name="one_handed_mode_summary">ナビゲーションバーをスワイプで片手モードを有効</string>
   <string name="smartbar_double_tap_sleep_title">ダブルタップでスリープ</string>
-  <string name="smartbar_double_tap_sleep_summary">ナビゲーションバーの空きエリアをダブルタップしてディスプレイを消灯します</string>
+  <string name="smartbar_double_tap_sleep_summary">ナビゲーションバーの空きエリアをダブルタップして画面を消灯する</string>
   <!-- SystemUI theme -->
   <string name="systemui_theme_style_title">テーマ</string>
+  <string name="systemui_theme_style_auto">自動 (壁紙に基づく)</string>
   <string name="systemui_theme_style_light">ライト</string>
   <string name="systemui_theme_style_dark">ダーク</string>
+  <string name="rr_theme_title">テーマ</string>
   <string name="rr_theme_summary">テーマをカスタマイズする</string>
   <!-- Hardware button navigation -->
   <!-- Button brightness -->
@@ -860,11 +918,11 @@
   <string name="button_manual_brightness">明るさレベル</string>
   <string name="button_timeout_title">バックライトの消灯時間</string>
   <string name="button_backlight_on_touch_only_title">タッチ時にのみバックライトを点灯</string>
-  <string name="button_backlight_on_touch_only_summary">ボタンを押したときにだけバックライトが点灯するようになります。タイムアウトはこの設定にも引き続き影響します</string>
+  <string name="button_backlight_on_touch_only_summary">ボタンを押したときにだけバックライトが点灯するようになります。タイムアウトはこの設定にも引き続き影響します。</string>
   <!-- Ability to disable hardware keys via nav bar settings -->
   <string name="hw_keys_title">ハードウェアキー</string>
   <string name="hw_keys_summary">ハードウェアキーを有効化する</string>
-  <string name="rr_hw_keys_summary">ハードウェアキー（ホーム、バック、メニュー）の動作をカスタマイズする</string>
+  <string name="rr_hw_keys_summary">ハードウェアキー（ホーム・バック・メニュー）の動作をカスタマイズする</string>
   <string name="hardware_keys_category">ハードウェアキー</string>
   <string name="hardware_keys_volume_keys_title">音量ボタン制御</string>
   <string name="hardware_keys_home_key_title">ホームボタン</string>
@@ -881,7 +939,7 @@
   <string name="hardware_keys_disable_title">ハードウェアキーを無効にする</string>
   <!-- Three-fingers-swipe to screenshot -->
   <string name="three_finger_gesture">3本指でのジェスチャー</string>
-  <string name="three_finger_gesture_summary">3本指でスワイプしてスクリーンショットを取得します</string>
+  <string name="three_finger_gesture_summary">3本指でスワイプしてスクリーンショットを取得する</string>
   <!-- AOKP custom system animations -->
   <string name="system_animation_title">システムアニメーション</string>
   <string name="activity_open_title">アクティビティ開始時</string>
@@ -901,7 +959,7 @@
   <!-- Power menu and dialogs opacity -->
   <string name="power">電源メニューの設定</string>
   <string name="power_menu_transparency">電源/再起動メニューの不透明度</string>
-  <string name="power_menu_dialog_dim">Power dialog dim background amount</string>
+  <string name="power_menu_dialog_dim">電源/再起動メニューの背景を暗くする量</string>
   <!-- Screen state service -->
   <string name="screen_state_toggles_title">スリープ時のアクション</string>
   <string name="screen_state_toggles_enable_title">有効</string>
@@ -910,23 +968,23 @@
   <string name="screen_state_toggles_location_title">位置</string>
   <string name="screen_state_toggles_twog">2Gに切り替える</string>
   <string name="screen_state_toggles_twog_summary">ネットワークモードは画面オフ時に2Gに切り替わります</string>
-  <string name="screen_state_toggles_gps">GPS の無効化</string>
+  <string name="screen_state_toggles_gps">GPSの無効化</string>
   <string name="screen_state_toggles_gps_summary">画面オフ時にGPSを使用した位置情報サービスを無効化</string>
   <string name="screen_state_toggles_mobile_data">モバイルデータの無効化</string>
   <string name="screen_state_toggles_mobile_data_summary">画面オフ時にモバイルデータが無効</string>
   <string name="screen_state_off_delay_title">画面オフアクションの遅延</string>
-  <string name="screen_state_off_delay_summary">スリープ時アクションを実行するまでの待機時間(分)を設定します</string>
+  <string name="screen_state_off_delay_summary">スリープ時アクションを実行するまでの待機時間 (分) を設定する</string>
   <string name="screen_state_on_delay_title">画面オンアクションの遅延</string>
-  <string name="screen_state_on_delay_summary">画面点等時アクションを実行するまでの待機時間(分)を設定します</string>
+  <string name="screen_state_on_delay_summary">画面点等時アクションを実行するまでの待機時間 (分) を設定する</string>
   <!-- Volume Steps -->
   <string name="volume_steps_title">音量レベル</string>
-  <string name="volume_steps_alarm_title">音量レベル: アラーム</string>
-  <string name="volume_steps_dtmf_title">音量レベル: DTMF</string>
-  <string name="volume_steps_music_title">音量レベル: メディア</string>
-  <string name="volume_steps_notification_title">音量レベル: 通知</string>
-  <string name="volume_steps_ring_title">音量レベル: 着信音</string>
-  <string name="volume_steps_system_title">音量レベル: システム</string>
-  <string name="volume_steps_voice_call_title">音量レベル: 音声通話</string>
+  <string name="volume_steps_alarm_title">音量レベル : アラーム</string>
+  <string name="volume_steps_dtmf_title">音量レベル : DTMF</string>
+  <string name="volume_steps_music_title">音量レベル : メディア</string>
+  <string name="volume_steps_notification_title">音量レベル : 通知</string>
+  <string name="volume_steps_ring_title">音量レベル : 着信音</string>
+  <string name="volume_steps_system_title">音量レベル : システム</string>
+  <string name="volume_steps_voice_call_title">音量レベル : 音声通話</string>
   <string name="volume_steps_reset">リセット</string>
   <string name="volume_steps_60">60</string>
   <string name="volume_steps_45">45</string>
@@ -941,6 +999,7 @@
   <string name="gesture_anywhere_title">常にジェスチャー可能</string>
   <string name="gesture_anywhere_enabled_title">常にジェスチャー可能</string>
   <string name="gesture_anywhere_enabled_summary">常にジェスチャー可能にする機能を有効にする</string>
+  <string name="gesture_anywhere_position_title">位置</string>
   <string name="gesture_anywhere_position_left">左端</string>
   <string name="gesture_anywhere_position_right">右端</string>
   <string name="gesture_anywhere_gestures_title">ジェスチャー</string>
@@ -983,24 +1042,28 @@
   <string name="ga_gestures_error_loading">%sを読み込むことが出来ませんでした。ストレージが使用可能か確認して下さい。</string>
   <string name="trigger_category">起動場所</string>
   <string name="trigger_width_title">起動領域の幅</string>
-  <string name="trigger_width_summary">起動領域の幅を調整します</string>
+  <string name="trigger_width_summary">起動領域の幅を調整する</string>
   <string name="trigger_top_title">起動領域の位置</string>
-  <string name="trigger_top_summary">起動領域の垂直方向の位置を調整します</string>
+  <string name="trigger_top_summary">起動領域の垂直方向の位置を調整する</string>
   <string name="trigger_bottom_title">起動領域の高さ</string>
-  <string name="trigger_bottom_summary">起動領域の高さを調整します</string>
+  <string name="trigger_bottom_summary">起動領域の高さを調整する</string>
   <!-- Immersive Recents -->
-  <string name="immersive_recents_title">没入型の履歴</string>
-  <string name="immersive_recents_summary">最近のアプリケーションの表示を変更</string>
+  <string name="immersive_recents_title">アプリ履歴の非表示要素</string>
+  <string name="immersive_recents_summary">アプリ履歴の表示を変更</string>
   <string name="immersive_recents_dialog_title">アプリ履歴の表示</string>
-  <string name="immersive_recents_default">Default</string>
-  <string name="immersive_recents_fullscreen">Fullscreen</string>
-  <string name="immersive_recents_navbar">Navbar only</string>
+  <string name="immersive_recents_default">既定</string>
+  <string name="immersive_recents_fullscreen">フルスクリーン</string>
+  <string name="immersive_recents_statusbar">ステータスバーのみ</string>
+  <string name="immersive_recents_navbar">ナビゲーションバーのみ</string>
+  <string name="recents_icon_pack_title">アプリ履歴のアイコンパック</string>
+  <string name="recents_icon_pack_summary">アプリ履歴では携帯電話に含まれているアイコンパックを使用してアプリアイコンスタイルを選択します</string>
   <string name="show_4g_title">4G表記</string>
   <string name="show_4g_summary">LTE表示の代わりに4G表示を使用する</string>
   <!-- Circle app bar -->
   <string name="category_app_circle_bar_title">アプリランチャー</string>
+  <string name="app_circle_bar_title">アプリサークルランチャー</string>
   <string name="app_circle_bar_included_apps_title">表示するアプリ</string>
-  <string name="app_circle_bar_included_apps_summary">アプリサークルランチャーに表示するアプリを選択します</string>
+  <string name="app_circle_bar_included_apps_summary">アプリサークルランチャーに表示するアプリを選択する</string>
   <!-- Pie -->
   <string name="pie_enable_title">Pieコントロールを有効化</string>
   <string name="pa_pie_control_title">Pie</string>
@@ -1019,8 +1082,8 @@
   <string name="pie_status_mobile">モバイルネットワークのみ</string>
   <string name="pie_status_none">無し</string>
   <string name="pie_status_both">両方</string>
-  <string name="pa_pie_gravity_title">パイの重力</string>
-  <string name="pa_pie_gravity_summary">Pieを配置する場所を選択します。</string>
+  <string name="pa_pie_gravity_title">Pieの位置</string>
+  <string name="pa_pie_gravity_summary">Pieを配置する場所を選択する</string>
   <string name="pa_pie_gravity_bottom">下詰め</string>
   <string name="pa_pie_gravity_right">右寄り</string>
   <string name="pa_pie_gravity_left">左寄り</string>
@@ -1032,57 +1095,61 @@
   <string name="disable_immersive_message_summary">全画面モード時のメッセージを全て無効化する</string>
   <!-- SlimSizer  -->
   <string name="listsystem">リスト</string>
-  <string name="sizer_title">App remover</string>
-  <string name="caution">Caution!</string>
+  <string name="sizer_title">アプリリムーバー</string>
+  <string name="caution">注意！</string>
   <string name="sizer_message_startup">このツールではシステムアプリをアンインストールすることを許可します。注意して安全なアプリだけをアンインストールしてください。</string>
   <string name="cancel">キャンセル</string>
   <string name="sizer_message_delete">本当にこのアプリケーションを削除してよろしいですか？</string>
   <string name="btn_delete">選択したアプリを削除する！</string>
-  <string name="delete_progress_title">削除します</string>
+  <string name="delete_progress_title">削除中</string>
   <string name="delete_progress">選択したファイルは無効になっています…</string>
   <string name="delete_success">削除しました</string>
   <string name="delete_fail">削除できません</string>
   <string name="btn_profile">プロファイル</string>
   <string name="sizer_message_sdnowrite">SDカードに書き込めませんでした。</string>
-  <string name="sizer_message_sdnoread">SDカードを読み込めませんでした。</string>
+  <string name="sizer_message_sdnoread">SDカードを読み込めませんでした</string>
   <string name="sizer_message_filesuccess">プロファイルを作成</string>
-  <string name="sizer_message_filefail">プロファイルを作成できませんでした。</string>
-  <string name="sizer_message_noselect">何も選択されていません。</string>
+  <string name="sizer_message_filefail">プロファイルを作成できませんでした</string>
+  <string name="sizer_message_noselect">何も選択されていません</string>
   <string name="system_app_remover">システムアプリの削除ツール</string>
   <!-- Pixel Animation Settings -->
   <string name="pixel_anim_title">Pixelのナビバーアニメーション </string>
   <string name="pixel_anim_summary">Pixelのナビバーアニメーションの様々な要素をカスタマイズ</string>
-  <string name="pixel_anim_warning">Pixelのナビバーアニメーションの様々な要素をカスタマイズ 警告！デフォルトの値を変更するとパフォーマンスが低下する場合があります 自己責任でやってください</string>
-  <string name="pixel_anim_x_title">水平期間</string>
-  <string name="pixel_anim_y_title">垂直期間</string>
+  <string name="pixel_anim_warning">Pixelのナビバーアニメーションの様々な要素をカスタマイズします。 警告！ : デフォルトの値を変更するとパフォーマンスが低下する場合があります。自己責任のもと進めてください。</string>
+  <string name="pixel_anim_x_title">水平時間</string>
+  <string name="pixel_anim_y_title">垂直時間</string>
   <string name="collapse_anim_duration_ry_title">崩壊時間</string>
   <string name="collapse_anim_duration_bg_title">崩壊の背景</string>
-  <string name="retract_anim_duration_title">後退期間。</string>
-  <string name="diamond_anim_duration_title">ダイヤモンド期間</string>
-  <string name="dots_anim_duration_title">ドット期間</string>
-  <string name="home_resize_anim_duration_title">ボタン サイズを変更する期間</string>
+  <string name="retract_anim_duration_title">後退時間</string>
+  <string name="diamond_anim_duration_title">ダイヤモンド時間</string>
+  <string name="dots_anim_duration_title">ドット時間</string>
+  <string name="home_resize_anim_duration_title">ボタンサイズを変更する時間</string>
   <string name="pixel_anim_color_title">ドットの色</string>
   <string name="dot_top_color_title">上の点</string>
-  <string name="dot_bottom_color_title">下がドット</string>
+  <string name="dot_bottom_color_title">下のドット</string>
   <string name="dot_left_color_title">左のドット</string>
   <string name="dot_right_color_title">右のドット</string>
   <string name="dot_obey_themes">既定 (テーマの色)</string>
   <string name="dot_custom_color">カスタム</string>
   <string name="dot_random_color">ランダム</string>
-  <string name="dot_random_color_more">非常にランダムです</string>
+  <string name="dot_random_color_more">非常にランダム</string>
   <string name="dot_color_switch_title">スタイル</string>
   <!-- Status bar - Battery saver color -->
   <string name="status_bar_battery_saver_color_title">バッテリーセーバーの色</string>
-  <string name="status_bar_battery_saver_color_summary">注意: バッテリーセーバーが既に有効な場合は、一度無効化して有効化すると設定した色が反映されます</string>
+  <string name="status_bar_battery_saver_color_summary">注意 : バッテリーセーバーが既に有効な場合は、一度無効化して有効化すると設定した色が反映されます。</string>
   <!-- Fingerprint unlock keystore -->
   <string name="fp_unlock_keystore_title">指紋認証によるロック解除</string>
-  <string name="fp_unlock_keystore_summary">指紋ロックのみ（PIN/パスワード/パターンの認証無し）で解除する\n自己責任です</string>
+  <string name="fp_unlock_keystore_summary">再起動後も PIN / パスワード/パターン による認証なしで指紋認証によるロック解除を可能にします。\n注意 : 自己責任で使用してください！</string>
   <!-- Ambient Music Ticker -->
-  <string name="force_ambient_for_media_title">アンビエント音楽ティッカー</string>
+  <string name="force_ambient_for_media_title">アンビエントミュージックティッカー</string>
+  <string name="force_ambient_for_media_summary">アンビエントディスプレイに楽曲情報を表示する</string>
   <string name="force_ambient_for_media_off">無効</string>
   <string name="force_ambient_for_media_on">有効</string>
   <string name="force_ambient_for_media_on_forced">強制的に有効</string>
+  <string name="force_ambient_for_media_on_forced_clean">強制的に最小化して有効にする</string>
   <!-- Ambient display battery percentage -->
+  <string name="ambient_battery_percent_title">アンビエントディスプレイに電池残量を表示</string>
+  <string name="ambient_battery_percent_summary">dozeモード時に電池残量の表示を有効にする</string>
   <!-- Scrolling Cache -->
   <string name="pref_scrollingcache_title">スクロールキャッシュ</string>
   <string name="pref_scrollingcache_summary">スクロールキャッシュはメモリを消費しますがスクロールのパフォーマンスが向上します</string>
@@ -1091,11 +1158,15 @@
   <string name="pref_scrollingcache_default_disable">デフォルトで無効</string>
   <string name="pref_scrollingcache_force_disable">強制的に無効</string>
   <!-- QS footer warnings -->
+  <string name="qs_footer_warnings_title">フッターの警告</string>
+  <string name="qs_footer_warnings_summary">外部アプリやVPNでネットワーク監視されている時にクイック設定パネルの下部に警告を表示する</string>
   <!-- [CHAR LIMIT=80]-->
+  <string name="fp_swipe_to_dismiss_notifications_title">指紋センサーで左右にスワイプして通知を削除</string>
   <!--  [CHAR LIMIT=160]-->
+  <string name="fp_swipe_to_dismiss_notifications_summary">通知を削除するには、端末裏側の指紋センサー上で左右にスワイプしてください。</string>
   <!-- Qs easy tile add -->
   <string name="single_tap_tile_add_title">簡単なタイルの追加</string>
-  <string name="single_tap_tile_add_summary">クイック設定のタイルを編集するときにドラッグする代わりにタップするだけで追加する</string>
+  <string name="single_tap_tile_add_summary">クイック設定のタイルを編集するときにドラッグする代わりにタップで追加する</string>
   <!-- Qs music tile -->
   <string name="qs_music_tile_track_optional_title">音楽タイルのタイトル表示</string>
   <string name="qs_music_tile_track_optional_summary">音楽タイルに再生中のタイトルを表示する</string>
@@ -1103,66 +1174,74 @@
   <string name="roaming_indicator_icon_title">ローミングインジケーターを表示</string>
   <string name="roaming_indicator_icon_summary">ローミング中に電波アイコンにローミング表示をする</string>
   <!-- Data disabled icon -->
-  <string name="data_disabled_icon_title">データを無効にするアイコンを表示する。</string>
+  <string name="data_disabled_icon_title">データ通信が無効のアイコンを表示する</string>
   <string name="data_disabled_icon_summary">モバイルデータが無効の場合シグナルバーの隣にXを表示</string>
   <!-- RR Settings tabs slide effects -->
-  <string name="effect_default">既定 （デフォルト）</string>
+  <string name="tabs_effect_title">Ressurection Remixのタブ遷移エフェクト</string>
+  <string name="effect_default">既定（デフォルト）</string>
   <string name="effect_accordion">アコーディオン</string>
-  <string name="effect_background_to_foreground">バックグラウンドからフォアグラウンドへ</string>
-  <string name="effect_cube_in">キューブの内部</string>
-  <string name="effect_cube_out">キューブの外部</string>
-  <string name="effect_depth_page">深さのページ</string>
+  <string name="effect_background_to_foreground">奥から前へ</string>
+  <string name="effect_cube_in">キューブイン</string>
+  <string name="effect_cube_out">キューブアウト</string>
+  <string name="effect_depth_page">ページが沈む</string>
   <string name="effect_flip_horizontal">水平方向に反転</string>
   <string name="effect_flip_vertical">垂直方向に反転</string>
-  <string name="effect_foreground_to_background">背景を前景に</string>
-  <string name="effect_rotate_down">Rotate down</string>
-  <string name="effect_rotate_up">Rotate up</string>
-  <string name="effect_scale_in_out">Scale in out</string>
-  <string name="effect_stack">Stack</string>
-  <string name="effect_tablet">Tablet</string>
-  <string name="effect_zoom_in">Zoom in</string>
-  <string name="effect_zoom_out_slide">Zoom out slide</string>
-  <string name="effect_zoom_out">Zoom out</string>
+  <string name="effect_foreground_to_background">前を奥に</string>
+  <string name="effect_rotate_down">下に回転</string>
+  <string name="effect_rotate_up">上に回転</string>
+  <string name="effect_scale_in_out">縮小と拡大</string>
+  <string name="effect_stack">積み重ね</string>
+  <string name="effect_tablet">タブレット</string>
+  <string name="effect_zoom_in">ズームイン</string>
+  <string name="effect_zoom_out_slide">縮小してスライド</string>
+  <string name="effect_zoom_out">ズームアウト</string>
   <!-- XOSP Blur personalizations -->
-  <string name="settings_blur_cat">パーソナライズをぼかす</string>
-  <string name="settings_blur_sum">システムの UI の背景設定をぼかす</string>
-  <string name="blurred_status_bar_expanded_enabled_pref">ステータス バーの背景をぼかす</string>
-  <string name="blurred_status_bar_expanded_enabled_pref_summary">ステータス バーを下ろすときに背景をぼかす</string>
-  <string name="translucent_notifications_pref">半透明の通知</string>
-  <string name="translucent_notifications_pref_summary">通知の背景を半透明に設定します。</string>
-  <string name="translucent_quick_settings_pref">透明な拡張されたステータス バー</string>
-  <string name="translucent_quick_settings_pref_summary">クイック設定の背景を透明にします。</string>
-  <string name="transluency_level_universal">透光性レベル</string>
-  <string name="blurred_recent_app_enabled_pref">ぼやしている最近使ったアプリ</string>
-  <string name="blurred_recent_app_enabled_pref_summary">アプリの最近の活動の背景をぼかす</string>
-  <string name="blur_light_color">明るいイメージ カラー フィルター</string>
-  <string name="blur_dark_color">暗いイメージ カラー フィルター</string>
-  <string name="blur_mixed_color">混在イメージ カラー フィルター</string>
+  <string name="settings_blur_cat">ぼかし効果の設定</string>
+  <string name="settings_blur_sum">システムUIの背景のぼかしの設定</string>
+  <string name="blurred_status_bar_expanded_enabled_pref">ステータスバーの背景をぼかす</string>
+  <string name="blurred_status_bar_expanded_enabled_pref_summary">ステータスバーを下ろすときに背景をぼかす</string>
+  <string name="translucent_notifications_pref">通知を半透明にする</string>
+  <string name="translucent_notifications_pref_summary">通知の背景を半透明に設定する</string>
+  <string name="translucent_quick_settings_pref">透明な拡張されたステータスバー</string>
+  <string name="translucent_quick_settings_pref_summary">クイック設定の背景を透明にする</string>
+  <string name="transluency_level_universal">透明性のレベル</string>
+  <string name="blurred_recent_app_enabled_pref">アプリ履歴のぼかし</string>
+  <string name="blurred_recent_app_enabled_pref_summary">アプリ履歴の背景をぼかす</string>
+  <string name="blur_light_color">明るいイメージカラーフィルター</string>
+  <string name="blur_dark_color">暗いイメージカラーフィルター</string>
+  <string name="blur_mixed_color">混合イメージカラーフィルター</string>
   <string name="blur_notice">ぼかし機能について</string>
-  <string name="blur_notice_summary">ロック画面の間ぼかしが無効になります! 半透明通知のみが有効になります!</string>
-  <string name="blur_colors_notice">これらの色は何をしていますか?</string>
-  <string name="blur_expstatus_cat">拡張ステータスバー </string>
+  <string name="blur_notice_summary">ロック画面ではぼかしが無効になります！半透明の通知のみが有効になります！</string>
+  <string name="blur_colors_notice">これらの色は何をしていますか？</string>
+  <string name="blur_colors_notice_summary">背景のぼかしの色を変えます。普通の灰色の代わりに好きな色を選ぶことができます。\n３つの色のフィルターはそれぞれ、明るい背景、暗い背景、またそのどちらでもない背景に使われます。\nこれらの色はどのように使われますか？\n名前の通り、明るいフィルターは明るい背景に、暗いフィルターは暗い背景に、ミックスフィルターはそのどちらでもないフィルターに使われます。\nこれらの色はステータスバーと最近使ったアプリの両方に適用されます。 </string>
+  <string name="blur_expstatus_cat">ステータスバーの拡張</string>
   <string name="blur_notifications_cat">通知</string>
   <string name="blur_qs_cat">クイック設定</string>
   <string name="blur_recents_cat">最近使ったアプリ</string>
-  <string name="blur_colors_cat">色ぼかしフィルター</string>
+  <string name="blur_colors_cat">カラーフィルターのぼかし</string>
   <string name="blur_notices_cat">お知らせ</string>
-  <string name="blurred_scale">スケールをぼかす</string>
+  <string name="blurred_scale">ぼかしの大きさ</string>
   <string name="blurred_scale_summary">ぼかしの鮮明さ</string>
   <string name="blurred_radius">ぼかしの範囲</string>
   <string name="blurred_radius_summary">ぼかしの量</string>
   <string name="blur_cat_notice">注意</string>
-  <string name="blur_cat_notice_summary">ロック画面の間ぼかしが無効になります! 半透明通知のみが有効になります!</string>
+  <string name="blur_cat_notice_summary">ロック画面ではぼかしが無効になります！半透明の通知のみが有効になります！</string>
   <!-- DSLV -->
-  <string name="shortcuts_icon_picker_type">アイコンの種類を選択:</string>
+  <string name="shortcuts_icon_picker_type">アイコンの種類を選択 :</string>
   <string name="shortcuts_icon_default">既定 （デフォルト）</string>
   <string name="shortcuts_icon_custom">ギャラリー</string>
   <string name="shortcuts_icon_picker_choose_icon_title">アイコンを選択</string>
+  <string name="lockscreen_shortcuts_title">画面中央のショートカット</string>
+  <string name="lockscreen_shortcuts_summary">ロック画面のカスタムショートカットを表示または変更する</string>
   <string name="lockscreen_shorcuts_launch_type_title">ショートカットクリックタイプ</string>
   <string name="lockscreen_shortcuts_single_tap">クリック</string>
   <string name="lockscreen_shortcuts_double_tap">ダブルタップ</string>
+  <string name="lockscreen_shortcuts_longpress">長押し</string>
+  <string name="shortcuts_icon_presets">プリセット</string>
+  <string name="lockscreen_shortcuts_longpress_title">長押し</string>
+  <string name="lockscreen_shortcuts_longpress_summary">長押しでショートカットからアプリを開く</string>
   <string name="shortcuts_icon_picker_alarm">アラーム</string>
-  <string name="shortcuts_icon_picker_andy">Andy</string>
+  <string name="shortcuts_icon_picker_andy">Andy (ドロイド君)</string>
   <string name="shortcuts_icon_picker_battery">バッテリー</string>
   <string name="shortcuts_icon_picker_browser">ブラウザー</string>
   <string name="shortcuts_icon_picker_calendar">カレンダー</string>
@@ -1174,15 +1253,15 @@
   <string name="shortcuts_icon_picker_drive">ドライブ</string>
   <string name="shortcuts_icon_picker_dropbox">Dropbox</string>
   <string name="shortcuts_icon_picker_email">E-Mail</string>
-  <string name="shortcuts_icon_picker_email2">E-Mailの代わり</string>
+  <string name="shortcuts_icon_picker_email2">Email（代替）</string>
   <string name="shortcuts_icon_picker_evernote">Evernote</string>
   <string name="shortcuts_icon_picker_facebook">Facebook</string>
   <string name="shortcuts_icon_picker_favorite">お気に入り</string>
   <string name="shortcuts_icon_picker_file_browser">ファイルブラウザ</string>
-  <string name="shortcuts_icon_picker_file_browser2">ファイルブラウザの代わり</string>
+  <string name="shortcuts_icon_picker_file_browser2">ファイルブラウザ（代替）</string>
   <string name="shortcuts_icon_picker_fitness">フィットネス</string>
   <string name="shortcuts_icon_picker_gallery">ギャラリー</string>
-  <string name="shortcuts_icon_picker_gears">ギア</string>
+  <string name="shortcuts_icon_picker_gears">歯車</string>
   <string name="shortcuts_icon_picker_google_small">Google</string>
   <string name="shortcuts_icon_picker_gplus">Google+</string>
   <string name="shortcuts_icon_picker_gtalk">ハングアウト</string>
@@ -1203,13 +1282,13 @@
   <string name="shortcuts_icon_picker_play">再生</string>
   <string name="shortcuts_icon_picker_pocket">Pocket</string>
   <string name="shortcuts_icon_picker_quicksettings">クイック設定</string>
-  <string name="shortcuts_icon_picker_rss">RSS フィード</string>
+  <string name="shortcuts_icon_picker_rss">RSSフィード</string>
   <string name="shortcuts_icon_picker_sdcard">SDカード</string>
   <string name="shortcuts_icon_picker_search">検索</string>
   <string name="shortcuts_icon_picker_sms">メッセージング</string>
   <string name="shortcuts_icon_picker_tasks">タスク</string>
   <string name="shortcuts_icon_picker_terminal">ターミナル</string>
-  <string name="shortcuts_icon_picker_transit">トランジット</string>
+  <string name="shortcuts_icon_picker_transit">交通機関</string>
   <string name="shortcuts_icon_picker_tv">テレビ</string>
   <string name="shortcuts_icon_picker_twitter">Twitter</string>
   <string name="shortcuts_icon_picker_unlock">ロック解除</string>
@@ -1231,40 +1310,40 @@
   <string name="shortcut_action_media_play_pause">音楽 - 再生/一時停止</string>
   <string name="shortcut_action_media_previous">音楽 - 前のトラック</string>
   <string name="shortcut_action_wake_device">端末を起動</string>
-  <string name="shortcut_action_longpress">長押し:</string>
-  <string name="shortcut_action_select_action_longpress">長押しの動作を選択:</string>
+  <string name="shortcut_action_longpress">長押し :</string>
+  <string name="shortcut_action_select_action_longpress">長押しの動作を選択 :</string>
   <string name="shortcut_action_select_action">アクションを選択</string>
-  <string name="shortcut_action_select_action_newaction">新しいアクションを選択:</string>
+  <string name="shortcut_action_select_action_newaction">新しいアクションを選択 :</string>
   <string name="shortcut_action_reset">リセット</string>
   <string name="shortcut_action_add">追加</string>
   <string name="shortcut_action_reset_message">すべてのエントリをデフォルトにリセットしますか？</string>
   <string name="shortcut_action_max">エントリの最大サイズに達しています</string>
-  <string name="shortcut_action_warning">注意　</string>
+  <string name="shortcut_action_warning">注意</string>
   <string name="shortcut_action_warning_message">最後のエントリを削除することはできません</string>
-  <string name="shortcut_action_disable_message">無効 \nを有効にするためにエントリに追加</string>
-  <string name="shortcut_image_not_valid">選択したアプリは使用可能なアイコンがないか、画像のトリミングをサポートしていません。別のアプリを使用します。</string>
-  <string name="shortcut_duplicate_entry">選択した動作を 2 回追加することはできません</string>
+  <string name="shortcut_action_disable_message">無効 \n有効にするためにエントリを追加してください</string>
+  <string name="shortcut_image_not_valid">選択したアプリは使用可能なアイコンがないか、画像のトリミングをサポートしていません。別のアプリを使用してください。</string>
+  <string name="shortcut_duplicate_entry">選択した動作を2回追加することはできません</string>
   <string name="shortcut_action_help_shortcut">ショートカット</string>
   <string name="shortcut_action_help_button">ボタン</string>
   <string name="shortcut_action_help_app">アプリ</string>
-  <string name="shortcut_action_help_icon">、アイコンを選択するとカスタマイズオブションが表示されます</string>
+  <string name="shortcut_action_help_icon">、アイコンを選択するとカスタマイズオブションが表示されます。</string>
   <string name="shortcut_action_help_main">%1$sに追加するには、追加アイコンを選択します。%1$sが追加されたら、行をタップするとターゲットを%2$sに変更することが出来ます。\n\n右または左へ水平にスワイプすると%1$sを、削除することが出来ます。垂直方向左側にアンカーをドラッグすることで、%1$sをリストに再度追加することが出来ます。\n\nクリアまたはデフォルトにリセットするには、リセットオプションを選択します。</string>
   <string name="shortcut_action_help_delete_last_entry">リスト内のすべての%1$sを削除すると、機能を完全に無効にします。</string>
-  <string name="shortcut_action_help_pie_second_layer_delete_last_entry">リスト内のすべての%1$sを削除すると、パイの第二層が完全に無効になります。</string>
-  <string name="shortcut_picker_choose_longpress_action">長押しの動作を選択:</string>
-  <string name="shortcut_picker_choose_new_action">新しいアクションを選択:</string>
-  <string name="shortcut_picker_reassign_action">アクションを再割り当て:</string>
-  <string name="shortcut_picker_choose_action">アクションを選択:</string>
+  <string name="shortcut_action_help_pie_second_layer_delete_last_entry">リスト内のすべての%1$sを削除すると、Pieの第二層が完全に無効になります。</string>
+  <string name="shortcut_picker_choose_longpress_action">長押しの動作を選択 :</string>
+  <string name="shortcut_picker_choose_new_action">新しいアクションを選択 :</string>
+  <string name="shortcut_picker_reassign_action">アクションを再割り当て :</string>
+  <string name="shortcut_picker_choose_action">アクションを選択 :</string>
   <string name="shortcut_picker_applications_title">アプリケーション</string>
   <string name="shortcut_picker_activities_title">アクティビティ</string>
-  <string name="shortcut_picker_select_app_title">アプリケーションを選択:</string>
-  <string name="shortcut_picker_select_activity_title">アクティビティの選択:</string>
-  <string name="shortcut_picker_choose_icon_type_title">アイコンを選択：</string>
+  <string name="shortcut_picker_select_app_title">アプリケーションを選択 :</string>
+  <string name="shortcut_picker_select_activity_title">アクティビティの選択 :</string>
+  <string name="shortcut_picker_choose_icon_type_title">アイコンを選択 :</string>
   <string name="shortcut_picker_icon_type_default_title">Default</string>
   <string name="shortcut_picker_icon_type_system_title">システムアイコン</string>
-  <string name="shortcut_picker_select_system_icon_title">システムアイコンを選択:</string>
+  <string name="shortcut_picker_select_system_icon_title">システムアイコンを選択 :</string>
   <string name="shortcut_picker_icon_type_custom_title">ギャラリー</string>
-  <string name="shortcuts_select_custom_app_title">アプリの選択</string>
+  <string name="shortcuts_select_custom_app_title">カスタムアプリの選択</string>
   <string name="shortcuts_applications">アプリケーション</string>
   <string name="airplay">Airplay</string>
   <string name="android">Android</string>
@@ -1273,14 +1352,14 @@
   <string name="bluetooth">Bluetooth</string>
   <string name="bookmarks">ブックマーク</string>
   <string name="browser">ブラウザー</string>
-  <string name="browser2">Browser2</string>
+  <string name="browser2">ブラウザー2</string>
   <string name="calculator">電卓</string>
   <string name="calendar">カレンダー</string>
   <string name="calls">通話</string>
   <string name="camera">カメラ</string>
   <string name="chrome">Chrome</string>
   <string name="clock">時計</string>
-  <string name="cnn">Cnn</string>
+  <string name="cnn">CNN</string>
   <string name="deezer2">Deezer2</string>
   <string name="deezer">Deezer</string>
   <string name="dolphin2">Dolphin</string>
@@ -1302,14 +1381,14 @@
   <string name="mic">マイク</string>
   <string name="newyorktimes">Newyork times</string>
   <string name="rootexplorer">ルート エクスプローラー</string>
-  <string name="sim">Sim</string>
+  <string name="sim">SIM</string>
   <string name="teamviewer">Teamviewer</string>
   <string name="totalcommander">Total commander</string>
   <string name="weather">天気</string>
   <string name="golocker">Go locker</string>
   <string name="googlecurrents">Google currents</string>
   <string name="googletalk">Googleトーク</string>
-  <string name="gosms">Go sms</string>
+  <string name="gosms">GO SMS</string>
   <string name="meebo">Meebo</string>
   <string name="maps2">Maps2</string>
   <string name="memorycleaner">メモリクリーナー</string>
@@ -1330,13 +1409,13 @@
   <string name="googletranslate">Google 翻訳</string>
   <string name="google">Google</string>
   <string name="googleplus">Google+</string>
-  <string name="imdb">imdb</string>
-  <string name="instagram">instagram</string>
+  <string name="imdb">IMDb</string>
+  <string name="instagram">Instagram</string>
   <string name="lastfm">Lastfm</string>
   <string name="maps">マップ</string>
   <string name="messages">メッセージ</string>
   <string name="music">ミュージック</string>
-  <string name="mxplayer">Mxplayer</string>
+  <string name="mxplayer">MX Player</string>
   <string name="notepad">ダイレクトメッセージ</string>
   <string name="opera">Opera</string>
   <string name="paint">ペイント</string>
@@ -1345,7 +1424,7 @@
   <string name="picasa">Picasa</string>
   <string name="pictures2">Pictures2</string>
   <string name="player_pro">Player pro</string>
-  <string name="playstation">Play station</string>
+  <string name="playstation">PlayStation</string>
   <string name="reddit">Reddit</string>
   <string name="settings">設定</string>
   <string name="skype">Skype</string>
@@ -1358,26 +1437,37 @@
   <string name="videocamera">ビデオ カメラ</string>
   <string name="whatsapp">WhatsApp</string>
   <string name="wifi">Wi-Fi</string>
-  <string name="xda">Xda</string>
+  <string name="xda">XDA</string>
   <string name="yahoo">Yahoo</string>
   <string name="youtube">YouTube</string>
-  <string name="zedge">Zedge</string>
+  <string name="zedge">ZEDGE</string>
   <!-- Scrolling Animation Controls -->
-  <string name="scrolling_title">Scrolling modifiers</string>
-  <string name="scrolling_summary">スクロール アニメーションを表示または変更する</string>
+  <string name="scrolling_title">スクロールの編集</string>
+  <string name="scrolling_summary">スクロールアニメーションを表示または変更する</string>
   <string name="animation_fling_velocity_title">スライド速度</string>
   <string name="animation_scroll_friction_title">スクロール速度</string>
   <string name="animation_overscroll_distance_title">オーバースクロールの距離</string>
   <string name="animation_overfling_distance_title">オーバーフローの距離</string>
   <string name="animation_duration_summary">継続時間を設定</string>
-  <string name="animation_no_scroll_title">Customized scrolling modifiers</string>
+  <string name="animation_no_scroll_title">スクロールのカスタム編集</string>
   <string name="animation_no_scroll_summary_on">有効</string>
   <string name="animation_no_scroll_summary_off">無効</string>
-  <string name="scroll_disclaimer_summary">注: カスタム値を有効にするために再起動する必要があるほとんどのアプリ</string>
+  <string name="scroll_disclaimer_summary">注意 : ほとんどのアプリはカスタム値を有効にするために再起動する必要があります</string>
   <string name="animation_settings_reset_message">全てのアニメーション設定をデフォルトにリセットしますか？</string>
   <!-- Screen Off animation -->
+  <string name="screen_off_animation_title">スクリーンオフアニメーション</string>
+  <string name="screen_off_animation_default">既定</string>
+  <string name="screen_off_animation_crt">ブラウン管</string>
+  <string name="screen_off_animation_scale">縮小</string>
   <!-- Suppress notification sound/vibration -->
+  <string name="notification_sound_vib_screen_on_title">通知が来たら画面を点灯させる</string>
+  <string name="notification_sound_vib_screen_on_display_title">通知に振動とサウンドを使用する</string>
+  <string name="notification_sound_vib_screen_on_never">なし</string>
+  <string name="notification_sound_vib_screen_on_always">常に (既定)</string>
+  <string name="notification_sound_vib_screen_on_nomedia">メディアが再生されていない場合</string>
   <!-- Accidental Touch -->
+  <string name="anbi_enabled_title">誤タッチを防止</string>
+  <string name="anbi_enabled_summary">有効にすると、タッチスクリーンの使用中のハードウェアボタンまたはナビゲーションボタンへの誤操作を防止します。</string>
   <!-- Pocket judge -->
   <string name="pocket_judge_title">ポケット検出機能</string>
   <string name="pocket_judge_summary">ポケットに入っているときにタッチやボタン入力を無効化する</string>
@@ -1385,7 +1475,7 @@
   <string name="rr_custom_logo_summary">様々なカスタムロゴ/画像の中からステータスバー上に表示するものを選択する</string>
   <string name="sb_custom_logos">カスタムロゴ</string>
   <string name="custom_logo_style">表示するロゴ</string>
-  <string name="custom_logos">ロゴを選択する...</string>
+  <string name="custom_logos">ロゴを選択する</string>
   <string name="show_custom_logo_title">カスタムロゴを表示</string>
   <string name="show_custom_logo_summary">システム内で利用可能な様々なロゴをステータスバーに表示する</string>
   <string name="status_bar_logo_position_right">右</string>
@@ -1394,7 +1484,7 @@
   <string name="custom_logo_position">カスタムロゴの位置</string>
   <string name="logo0">Resurrection Dark</string>
   <string name="logo1">Resurrection Light</string>
-  <string name="logo2">Tuner </string>
+  <string name="logo2">Tuner</string>
   <string name="logo3">BugDroid Minimal </string>
   <string name="logo4">Drupal</string>
   <string name="logo5">Cool Smile</string>
@@ -1438,9 +1528,9 @@
   <string name="logo43">Orioles</string>
   <!-- Clock and date immersive recents-->
   <string name="recents_full_screen_clock_title">時計を表示する</string>
-  <string name="recents_full_screen_clock_summary">アプリ履歴の全画面表示時に時計を上部に表示します</string>
+  <string name="recents_full_screen_clock_summary">アプリ履歴の全画面表示時に時計を上部に表示する</string>
   <string name="recents_full_screen_date_title">日付を表示する</string>
-  <string name="recents_full_screen_date_summary">アプリ履歴の全画面表示時に日付を上部に表示します</string>
+  <string name="recents_full_screen_date_summary">アプリ履歴の全画面表示時に日付を上部に表示する</string>
   <!--Recents styles-->
   <string name="show_clear_all_recents_button_title">「全てを終了」ボタン</string>
   <string name="show_clear_all_recents_button_summary">「全てを終了」ボタンを表示する</string>
@@ -1453,12 +1543,12 @@
   <string name="recents_clear_all_location_bottom_center">中央下</string>
   <!-- Clock and date immersive recents-->
   <string name="recents_clear_all_title">全て終了</string>
-  <string name="clear_recents_style">Button Style</string>
+  <string name="clear_recents_style">ボタンのスタイル</string>
   <string name="fab_button_color">Button BG</string>
-  <string name="kill_app_button_color">Close Button</string>
-  <string name="mem_bar_color">Memory Bar</string>
-  <string name="recents_clock_color">FullScreen Recents Clock Text</string>
-  <string name="recents_date_color">FullScreen Recents Date Text</string>
+  <string name="kill_app_button_color">アイコンの色</string>
+  <string name="mem_bar_color">メモリ使用量バー</string>
+  <string name="recents_clock_color">フルスクリーンモードのアプリ履歴の時計テキスト</string>
+  <string name="recents_date_color">フルスクリーンモードのアプリ履歴のデータテキスト</string>
   <string name="recents_styles_1">スタイル</string>
   <string name="recents_colors">スタイル</string>
   <string name="recents_style_2">カラー</string>
@@ -1466,24 +1556,24 @@
   <string name="pin_button_color">Screen Pinning Button </string>
   <string name="mw_button_color">Multi-Window Button</string>
   <string name="float_button_color">Floating Button</string>
-  <string name="tv_app_color">App Icon Fill (Fills Entire Icon)</string>
+  <string name="tv_app_color">アプリアイコンの塗りつぶし (アイコン全体を塗りつぶす)</string>
   <string name="tv_app_text_color">App Description Text</string>
   <string name="recent_styles">Recent Styles </string>
-  <string name="recent_styles_summary">Customize Various Elements In Recents </string>
-  <string name="mem_text_color">MemBar Text</string>
-  <string name="clear_button_color">Clear All</string>
-  <string name="clear_recents_style_enable">Custom Recents Style</string>
-  <string name="clear_recents_style_enable_summary">Enable / Disable Custom Styling of Recent Apps View</string>
-  <string name="recents_rotate_fab">FAB をアニメーション化</string>
-  <string name="recents_rotate_fab_summary">Enable / Disable Rotation of ClearAll Button</string>
-  <string name="recents_fab_vibrate">Vibrate Clear All Button On Press</string>
-  <string name="recents_fab_vibrate_summary">Enable / Disable Haptic Feedback of Dismissall Button</string>
-  <string name="fab_animation_style">Floating Button Animation</string>
-  <string name="recents_fab_lp">Enable LongPress on FAB</string>
-  <string name="recents_fab_lp_summary">Longpress Updates MemoryBar if Present</string>
-  <string name="recents_fab_lp_anim">Long Press FAB animations</string>
-  <string name="clear_animation_style">Clear All Animation</string>
-  <string name="button1">Default </string>
+  <string name="recent_styles_summary">アプリ履歴のさまざまな要素をカスタマイズする</string>
+  <string name="mem_text_color">メモリ使用量バーのテキスト</string>
+  <string name="clear_button_color">全て終了</string>
+  <string name="clear_recents_style_enable">アプリ履歴のスタイルをカスタマイズする</string>
+  <string name="clear_recents_style_enable_summary">アプリ履歴の外観のスタイルのカスタマイズの 有効/無効</string>
+  <string name="recents_rotate_fab">全て終了ボタンをアニメーション化</string>
+  <string name="recents_rotate_fab_summary">全て終了ボタンの回転の 有効/無効</string>
+  <string name="recents_fab_vibrate">全て終了ボタンを押したときに振動させる</string>
+  <string name="recents_fab_vibrate_summary">全て終了ボタンの振動フィードバックの 有効/無効</string>
+  <string name="fab_animation_style">フローティングボタンアニメーション</string>
+  <string name="recents_fab_lp">全て終了ボタンの長押しを有効にする</string>
+  <string name="recents_fab_lp_summary">メモリ使用量バーの長押しで更新する</string>
+  <string name="recents_fab_lp_anim">全て終了ボタンの長押しのアニメーション</string>
+  <string name="clear_animation_style">全てのアニメーションを削除</string>
+  <string name="button1">デフォルト</string>
   <string name="button2">Square Checkbox </string>
   <string name="button3">Graph </string>
   <string name="button4">Vertical Lines 1</string>
@@ -1512,9 +1602,11 @@
   <string name="button27">Resurrection</string>
   <string name="button28">Android Stock</string>
   <string name="button29">Resurrection Lollipop</string>
+  <string name="button30">Resurrection Nougat</string>
   <string name="animation0">Rotation </string>
   <string name="animation1">Recents Exit</string>
   <string name="animation2">Transluscent Exit </string>
+  <string name="animation3">ゆっくりと右にスライド</string>
   <string name="animation4">Toast Exit</string>
   <string name="animation5">Slide Out Down </string>
   <string name="animation6">Xylon Exit </string>
@@ -1529,93 +1621,212 @@
   <string name="animation15">Fast Rotation</string>
   <!-- Config style-->
   <string name="rr_config_style_title">構成</string>
+  <string name="rr_config_n">タブ</string>
   <string name="rr_config_mm">Classic</string>
+  <string name="rr_config_o">ボトムナビゲーションバー</string>
   <!-- Dashboard settings-->
   <string name="dashboard_category">ダッシュボード設定</string>
+  <string name="dashboard_conditions_title">ダッシュボードの状態表示</string>
   <string name="summary_dashboard_conditions_enabled">ダッシュボードの状態の表示が有効になります</string>
   <string name="summary_dashboard_conditions_disabled">ダッシュボードの状態の表示が無効になります</string>
+  <string name="dashboard_suggestions_title">ダッシュボードの候補表示</string>
   <string name="summary_dashboard_suggestions_enabled">ダッシュボードの候補の表示が有効になります</string>
   <string name="summary_dashboard_suggestions_disabled">ダッシュボードの候補の表示が無効になります</string>
   <!-- Incall vibrate options -->
+  <string name="rr_incall">通話</string>
+  <string name="rr_incall_summary">音声通話のさまざまな振動オプションをカスタマイズ</string>
+  <string name="incall_vibration_category">通話中の振動オプション</string>
   <string name="incall_vibrate_connect_title">接続時に振動</string>
+  <string name="incall_vibrate_call_wait_title">割込通話時に振動させる</string>
+  <string name="incall_vibrate_disconnect_title">切断時に振動させる</string>
   <!-- Expanded desktop -->
+  <string name="power_menu_expanded_desktop">拡張デスクトップ</string>
   <string name="expanded_hide_nothing">非表示にしない</string>
   <string name="expanded_hide_status">ステータスバーを非表示</string>
   <string name="expanded_hide_navigation">ナビゲーションバーを非表示</string>
   <string name="expanded_hide_both">両方を非表示</string>
-  <string name="expanded_nothing_to_show">アプリごとの拡張の状態のカスタム設定を追加するには、「すべて拡張」をOFFにしてください。</string>
+  <string name="expanded_nothing_to_show">アプリごとの拡張の状態のカスタム設定を追加するには「すべて拡張」をOFFにしてください。</string>
   <string name="expanded_desktop_state">拡張の状態</string>
   <string name="expanded_enabled_for_all">すべて拡張</string>
   <string name="expanded_user_configurable">ユーザー設定</string>
   <string name="expanded_desktop_style">拡張デスクトップのスタイル</string>
-  <string name="expanded_desktop_style_description">既定の拡張デスクトップ スタイルを選択する</string>
+  <string name="expanded_desktop_style_description">既定の拡張デスクトップスタイルを選択する</string>
   <string name="expanded_desktop_title">拡張デスクトップのオプション</string>
   <!-- no network switch -->
   <string name="no_sim_cluster_switch_title">SIMカードが刺さっていないネットワークを非表示</string>
+  <string name="no_sim_cluster_switch_summary">SIMの契約が非アクティブで無効になっている場合は、ネットワークバーを非表示にします。SIMが無効になっていない場合、このスイッチは動作しません。注意 : これはシステムUIを再起動します。</string>
   <!-- no sim icon switch -->
+  <string name="disable_no_sim_title">SIM未挿入のアイコンを無効にする</string>
+  <string name="disable_no_sim_summary">SIMが挿入されていない場合はSIM未挿入アイコンを非表示にする</string>
   <!-- SystemUI restart prompt -->
   <string name="systemui_restart_title">警告</string>
-  <string name="systemui_restart_message">SystemUI は、選択した設定を正しく適用できるように、再起動します。</string>
+  <string name="systemui_restart_message">システムUIは選択した設定を正しく適用できるように再起動します</string>
   <string name="restarting_ui">UI\u2026を再起動します</string>
   <string name="print_restart">再起動</string>
   <!-- Quick unlock -->
-  <string name="unlock_quick_unlock_control_title">クイックロック解除</string>
+  <string name="unlock_quick_unlock_control_title">クイックアンロック</string>
+  <string name="unlock_quick_unlock_control_summary">正しいPIN / パスワードが入力されると、自動的にロック解除されます。 6桁以下のピンを使用することをお勧めします。 PIN / パスワードが6桁を超えると、ロック解除できなくなる可能性があります。注意してください！</string>
   <!-- Hide Apps from Recents -->
   <string name="hide_apps_from_recents_title">非表示にするアプリ</string>
   <string name="hide_from_recents_add_app">アプリを追加</string>
   <string name="hide_apps_from_recents_summary">アプリ履歴に表示しないアプリケーションを選択する</string>
   <!-- Clock & date settings -->
+  <string name="position_title">位置</string>
   <string name="position_right_title">右寄り</string>
   <string name="position_centered_title">中心</string>
+  <string name="normal_title">標準</string>
   <string name="hidden_title">非表示</string>
+  <string name="status_bar_clock_date_settings_title">時計と日付</string>
+  <string name="status_bar_clock_date_settings_summary">ステータスバーへの時計と日付の表示方法を選択する</string>
+  <string name="clock_date_cat_date_title">日付</string>
+  <string name="clock_date_show_seconds_title">秒を表示</string>
+  <string name="clock_date_show_seconds_summary">ステータスバーに秒単位で時計を表示する</string>
+  <string name="clock_date_show_date_title">曜日を表示する</string>
+  <string name="clock_date_show_date_summary">ステータスバーに時計の隣に曜日を表示する</string>
+  <string name="clock_date_date_format_title">日付の形式</string>
+  <string name="clock_date_date_custom_date_format">カスタムの日付形式</string>
+  <string name="clock_date_date_string_edittext_title">日付形式パターンを入力</string>
+  <string name="clock_date_date_string_edittext_summary">有効な日付形式を入力してください 例：MM/dd/yy</string>
+  <string name="clock_date_date_style_title">スタイル</string>
+  <string name="clock_date_date_style_lowercase">小文字</string>
+  <string name="clock_date_date_style_uppercase">大文字</string>
+  <string name="clock_date_date_size_small_title">小</string>
+  <string name="clock_date_date_size_small_summary">小さい文字で曜日を表示する</string>
+  <string name="status_bar_clock_font_size_title">フォントサイズ</string>
   <!-- Dynamic Navbar -->
+  <string name="navbar_dynamic_title">ダイナミックナビゲーションバーの色</string>
+  <string name="navbar_dynamic_summary">前面で動作しているアプリにナビゲーションバーの色を適合させる</string>
+  <string name="restart_app_required">それぞれのアプリを再起動して効果を確認する</string>
   <!-- RR config options -->
+  <string name="rr_config_tabs_update_message">あなたは以前のバージョンのRR-OSに存在し、現在では既定の設定であるタブ (Nougat) にレイアウトを変更しようとしています。 続行してもよろしいですか？</string>
+  <string name="rr_config_classic_update_message">あなたは以前のバージョンのRR-OSに存在したクラシック (Marshmallow) にレイアウトを変更しようとしています。 続行してもよろしいですか？</string>
+  <string name="rr_config_navigation_update_message">あなたはレイアウトを底部ナビゲーションレイアウト (Oreo) に変更しようとしています。これはRR-OSの新しいレイアウトです。 通常のレイアウトとは多少異なるかもしれません。 続行してもよろしいですか？</string>
+  <string name="rr_config_navigation_color_enable_title">カスタムナビゲーションバーカラーを有効にする</string>
+  <string name="rr_config_navigation_color_enabled">Resurrection Remixの下部ナビゲーションのカスタムカラーを有効にする</string>
+  <string name="rr_config_navigation_color_title">底部のカスタムナビゲーションバーカラー</string>
   <!-- RR summary text -->
+  <string name="rr_settings_summary_title">設定アプリ内のカスタムResurrection Remix説明文</string>
   <string name="custom_summary_title">カスタム RR の概要</string>
   <string name="custom_summary_explain">新しいラベル名を入力してください。空白のままにすると標準のラベルに戻ります。</string>
   <string name="custom_summary_randomize_title">ランダム化の概要</string>
-  <string name="custom_summary_randomize_explain">あらかじめ書き込まれた要約はランダムに選択され、設定アプリを起動するたびに変更されます。\nこれにより、カスタムサマリーセットがオーバーライドされます。</string>
-  <string name="sum2">速報: ドナルド・トランプが髪型を変更！</string>
+  <string name="custom_summary_randomize_explain">あらかじめ書き込まれた要約はランダムに選択され、設定アプリを起動するたびに変更されます。\nこれによりカスタムサマリーセットが上書きされます。</string>
+  <string name="sum1">本当に全部チェックしたのかな？？？</string>
+  <string name="sum2">速報 : ドナルド・トランプが髪型を変更！</string>
+  <string name="sum3">君、もう10万回も押してるよ。</string>
   <string name="sum4">オプションいっぱい！</string>
   <string name="sum5">かかってこい！</string>
   <string name="sum6">これに尽きる！</string>
-  <string name="sum7">俺は君のF1キーじゃないぞ。</string>
-  <string name="sum9">RRへようこそ。</string>
+  <string name="sum7">俺は君のF1キーじゃないぞ</string>
+  <string name="sum8">このク○を見逃すなよ！</string>
+  <string name="sum9">RRへようこそ</string>
   <string name="sum10">スルーしないで！</string>
   <string name="sum11">宿題は終わったのかな？</string>
   <string name="sum12">こんにちは。あなたの新しいアシスタントです。</string>
   <string name="sum13">UIを台無しにしないように！</string>
-  <string name="sum15">プロユーザー専用。</string>
+  <string name="sum14">何を期待したのかな？</string>
+  <string name="sum15">プロユーザー専用</string>
   <string name="sum16">退屈かい？俺を触るんだ！</string>
-  <string name="sum17">おめでとう！ボーナス機能 を てにいれた！</string>
+  <string name="sum17">おめでとう！ボーナス機能をてにいれた！</string>
   <string name="sum18">G+でスパムしてくるの勘弁して</string>
-  <string name="sum19">G+では投稿ルールを守ろう。</string>
-  <string name="sum20">素人の入場はお断りさせて頂きます。</string>
+  <string name="sum19">G+では投稿ルールを守ろう</string>
+  <string name="sum20">素人の入場はお断りさせて頂きます</string>
   <string name="sum21">#gotresurrected</string>
-  <string name="sum22">速報: 次期iPhoneはフラッシュライトなしに。</string>
+  <string name="sum22">速報 : 次期iPhoneはフラッシュライトなしに。</string>
   <string name="sum23">…幸せですか？</string>
   <string name="sum24">押すなよ！絶対に押すなよ！！！</string>
   <string name="sum25">#自慢</string>
   <string name="sum26">ツ</string>
   <!-- Hide Lockscreen clock, date, & alarm -->
+  <string name="hide_lockscreen_clock_title">時計ウィジェット</string>
+  <string name="hide_lockscreen_clock_summary">時計ウィジェットの表示を変更する</string>
+  <string name="hide_lockscreen_date_title">日付ウィジェット</string>
+  <string name="hide_lockscreen_date_summary">時計ウィジェットの下の日付の表示を変更する</string>
+  <string name="hide_lockscreen_alarm_title">アラームテキスト</string>
+  <string name="hide_lockscreen_alarm_summary">時計ウィジェットの下のアラームテキストの表示を変更する</string>
+  <string name="less_notification_sounds_title">スマート通知サウンド</string>
+  <string name="less_notification_sounds_summary">一定時間に一度だけ各アプリの通知音を再生する</string>
+  <string name="less_notification_sounds_default">アプリの既定</string>
+  <string name="less_notification_sounds_10s">10秒ごと</string>
+  <string name="less_notification_sounds_30s">30秒ごと</string>
+  <string name="less_notification_sounds_1m">1分ごと</string>
+  <string name="less_notification_sounds_2m">2分ごと</string>
   <!-- Screenshot -->
   <string name="screenshot_type_title">スクリーンショットの取得方法</string>
   <string name="screenshot_type_fullscreen">全画面を取得</string>
   <string name="screenshot_type_partial">ドラッグした任意の範囲を取得</string>
-  <string name="screenshot_options_category">スクリーン ショットのオプション</string>
-  <string name="screenshot_options_summary">時間、遅延、タイプ等のようなスクリーン ショットの属性をカスタマイズします。</string>
+  <string name="screenshot_options_category">スクリーンショットのオプション</string>
+  <string name="screenshot_options_summary">時間・遅延・タイプ等のようなスクリーンショットの属性をカスタマイズする</string>
   <string name="screenshot_delay_title">スクリーンショット遅延時間</string>
+  <string name="screenshot_edit_app">スクリーンショットエディター</string>
+  <string name="screenshot_edit_app_summary">スクリーンショット取得時の通知の編集ボタンをタップする時に起動するアプリを選択する</string>
+  <string name="screenshot_edit_app_no_editor">利用可能な画像エディターがありません</string>
   <!-- Face unlock auto -->
+  <string name="face_auto_unlock_title">フェイスアンロック</string>
+  <string name="face_auto_unlock_summary">フェイスロック解除後にロック画面を閉じます。これを行うには「フェイスロック解除 / 信頼できる顔」を有効にする必要があります。</string>
+  <string name="incall_notifications_vibrate">迷惑な着信通知を減らす</string>
+  <string name="incall_notifications_vibrate_summary">通話中は通知サウンドの代わりに振動する</string>
   <!-- Browser not found -->
+  <string name="browser_not_found_toast">既定のブラウザが見つかりません</string>
   <!-- Seekbar default text -->
+  <string name="custom_seekbar_default_text">既定</string>
   <!-- Notification guts kill app button -->
+  <string name="notification_guts_kill_app_button_title">アプリ終了ボタン</string>
+  <string name="notification_guts_kill_app_button_summary">通知の長押しメニューにアプリ終了ボタンを表示する</string>
   <!-- Smart Pixels -->
+  <string name="smart_pixels_title">スマートピクセル</string>
+  <string name="smart_pixels_summary">余分な画素を停止することでバッテリーを節約する</string>
+  <string name="smart_pixels_enable_title">スマートピクセルを有効にする</string>
+  <string name="smart_pixels_enable_summary">消費電力を削減するため画素を遮断する</string>
+  <string name="smart_pixels_on_power_save_title">バッテリーセーバー時は自動的に有効</string>
+  <string name="smart_pixels_on_power_save_summary">バッテリーセーバー起動時はスマートピクセルを自動的に有効にする</string>
+  <string name="smart_pixels_percent">無効にする画素の割合</string>
+  <string name="smart_pixels_shift">使う画素をたまにずらして有機ELのの焼き付きを避ける</string>
   <!-- QS footer icons -->
+  <string name="qs_footer_services_title">実行中のサービスアイコンを表示</string>
+  <string name="qs_footer_services_summary">クイック設定のフッターに実行中のサービスアイコンを表示する</string>
+  <string name="qs_footer_settings_title">設定アイコンを表示</string>
+  <string name="qs_footer_settings_summary">クイック設定のフッターに設定アイコンを表示する</string>
   <!-- Recents Grid -->
+  <string name="recents_grid_title">グリッド形式のアプリ履歴</string>
+  <string name="recents_grid_summary">ストックのアプリ履歴をグリッドスタイルで表示する</string>
   <!-- Recents Lock Icon -->
+  <string name="recents_lock_title">アプリ履歴のロック</string>
+  <string name="recents_lock_summary">アプリ履歴の上部にロックアイコンを表示する</string>
   <!-- Tiles animation style  -->
+  <string name="qs_tiles">クイック設定タイル</string>
+  <string name="qs_tile_animation_style_title">アニメーションスタイル</string>
+  <string name="qs_tile_animation_duration_title">アニメーション速度</string>
+  <string name="qs_tile_animation_interpolator_title">タイルのアニメーション補間</string>
+  <string name="qs_tile_animation_style_off">アニメーションなし</string>
+  <string name="qs_tile_animation_style_flip">左右に回転</string>
+  <string name="qs_tile_animation_style_rotate">上下に回転</string>
+  <string name="qs_tile_animation_duration_low">ゆっくり</string>
+  <string name="qs_tile_animation_duration_default">既定</string>
+  <string name="qs_tile_animation_duration_fast">速い</string>
+  <string name="qs_tile_animation_interpolator_linearInterpolator">等速</string>
+  <string name="qs_tile_animation_interpolator_accelerateInterpolator">加速</string>
+  <string name="qs_tile_animation_interpolator_decelerateInterpolator">減速</string>
+  <string name="qs_tile_animation_interpolator_accelerateDecelerateInterpolator">加速と減速</string>
+  <string name="qs_tile_animation_interpolator_bounceInterpolator">弾む</string>
+  <string name="qs_tile_animation_interpolator_overshootInterpolator">通過</string>
+  <string name="qs_tile_animation_interpolator_anticipateInterpolator">先取り</string>
+  <string name="qs_tile_animation_interpolator_anticipateOvershootInterpolator">先取りと通過</string>
   <!-- Running services -->
+  <string name="background_processes_settings_title">バックグラウンドプロセス</string>
   <!-- Force authorize substratum packages -->
+  <string name="force_authorize_substratum_packages_title">すべてのテーマアプリを強制的に承認する</string>
+  <string name="force_authorize_substratum_packages_summary">提供元不明のテーマアプリのインストールを許可する</string>
   <!-- Manage applications: show substratum overlays -->
+  <string name="filter_substratum_apps">下層のオーバーレイ</string>
+  <string name="menu_show_substratum">オーバーレイを表示</string>
+  <string name="menu_hide_substratum">オーバーレイを非表示</string>
   <!-- Edge gestures -->
+  <string name="edge_gestures_title">エッジジェスチャー</string>
+  <string name="edge_gestures_feedback_duration_title">入力時の振動の長さ</string>
+  <string name="edge_gestures_long_press_delay_title">長押し開始までの遅延時間</string>
+  <string name="edge_gestures_back_category_title">戻るジェスチャー</string>
+  <string name="edge_gestures_back_edges_title">戻るジェスチャーを始める場所</string>
+  <string name="edge_gestures_landscape_back_edges_title">横向きで戻るジェスチャーを始める場所</string>
+  <string name="edge_gestures_back_screen_percent_title">戻るジェスチャーは以下の画面の下からの割合から始めます</string>
+  <string name="edge_gestures_back_screen_percent_summary">画面の以下の割合より下から始める</string>
 </resources>

--- a/res/values-ko/rr_strings.xml
+++ b/res/values-ko/rr_strings.xml
@@ -200,7 +200,6 @@
   <string name="rr_statusbar_title">상태표시줄</string>
   <string name="rr_sb_gestures_title">상태표시줄 제스처</string>
   <string name="qs_advanced_title">고급 설정</string>
-  <string name="rr_notification_panel_title">패널</string>
   <string name="rr_tuner">시스템 UI 튜너</string>
   <string name="rr_tuner_summary">Android 기본 환경 설정</string>
   <string name="rr_battery">배터리</string>

--- a/res/values-nl/rr_strings.xml
+++ b/res/values-nl/rr_strings.xml
@@ -202,7 +202,6 @@
   <string name="rr_statusbar_title">Statusbalk</string>
   <string name="rr_sb_gestures_title">Statusbalk gebaren</string>
   <string name="qs_advanced_title">Geavanceerd</string>
-  <string name="rr_notification_panel_title">Panelen</string>
   <string name="rr_tuner">Systeem UI fijnafstelling</string>
   <string name="rr_tuner_summary">Onderdeel van standaard aanpassingen</string>
   <string name="rr_battery">Accu</string>

--- a/res/values-nl/rr_strings.xml
+++ b/res/values-nl/rr_strings.xml
@@ -101,6 +101,7 @@
   <string name="github_akhilnarang">https://github.com/akhilnarang</string>
   <string name="github_bdogg718k">https://github.com/bdogg718k</string>
   <string name="github_apascual89">https://github.com/apascual89</string>
+  <string name="github_mracar">https://github.com/mracar07</string>
   <string name="rr">Links</string>
   <string name="rr_website_title">Website</string>
   <string name="rr_website_summary">Meer informatie over Resurrection Remix OS</string>
@@ -132,6 +133,7 @@
   <string name="christopher_kardas_summary">● Moderator \n● Bewerker\n● Bijdrager</string>
   <string name="matt_summary">● Moderator \n● Bewerker\n● Bijdrager</string>
   <string name="justen_summary">● Moderator \n● Bewerker\n● Bijdrager</string>
+  <string name="mracar_summary">● Ontwikkelaar \n● Onderhoud</string>
   <string name="support_team_title">Moderator Tag</string>
   <string name="device_maintainers_title">Apparaten en Onderhouders</string>
   <string name="device_maintainers_title_summary">Lijst van apparaten en hun officiële RR-OS onderhouders</string>
@@ -1823,4 +1825,6 @@
   <!-- Edge gestures -->
   <string name="edge_gestures_title">Veeg gebaren</string>
   <string name="edge_gestures_feedback_duration_title">Duur trilsignaal</string>
+  <string name="edge_gestures_long_press_delay_title">Wachttijd tot langdruk-actie start</string>
+  <string name="edge_gestures_back_category_title">Terug-gebaar</string>
 </resources>

--- a/res/values-no-rNO/rr_strings.xml
+++ b/res/values-no-rNO/rr_strings.xml
@@ -135,7 +135,6 @@
   <string name="rr_title">Konfigurasjon</string>
   <string name="rr_statusbar_title">Statuslinje</string>
   <string name="qs_advanced_title">Avansert</string>
-  <string name="rr_notification_panel_title">Paneler</string>
   <string name="rr_tuner">Justere Systemgrensesnitt</string>
   <string name="rr_battery">Batteri</string>
   <string name="rr_sb_icons">System ikoner</string>

--- a/res/values-pl/rr_strings.xml
+++ b/res/values-pl/rr_strings.xml
@@ -101,6 +101,7 @@
   <string name="github_akhilnarang">https://github.com/akhilnaranag</string>
   <string name="github_bdogg718k">https://github.com/bdogg718k</string>
   <string name="github_apascual89">https://github.com/apascual89</string>
+  <string name="github_mracar">https://github.com/mracar07</string>
   <string name="rr">Linki</string>
   <string name="rr_website_title">Strona internetowa</string>
   <string name="rr_website_summary">Dowiedz się więcej o Resurrection Remix</string>
@@ -132,6 +133,7 @@
   <string name="christopher_kardas_summary">● Moderator\n● Redaktor\n● Pomocnik</string>
   <string name="matt_summary">● Moderator\n● Redaktor\n● Pomocnik</string>
   <string name="justen_summary">● Moderator\n● Redaktor\n● Pomocnik</string>
+  <string name="mracar_summary">● Deweloper\n● Maintainer</string>
   <string name="support_team_title">Tag Moderatora</string>
   <string name="device_maintainers_title">Urządzenia i ich opiekunowie</string>
   <string name="device_maintainers_title_summary">Lista urządzeń i ich oficjalnych opiekunów</string>
@@ -487,6 +489,7 @@
   <string name="rr_density_summary">Dostosuj gęstość ekranu, aby przeskalować ekran do jego limitu</string>
   <string name="rr_fonts_summary">Wybierz preferowany rozmiar czcionki</string>
   <string name="stock_recents_category">Zbiór niedawny</string>
+  <string name="edge_gestures_summary">Nawigacja używając gestów krawędzi</string>
   <!-- QS rows and columns -->
   <string name="qs_rows_portrait_title">Ilość kafelków w pionie</string>
   <string name="qs_rows_landscape_title">Ilość kafelków w poziomie</string>
@@ -821,6 +824,8 @@
   <string name="pulse_render_mode_solid_lines">Linie ciągłe</string>
   <string name="fling_pulse_color">Kolor Pulse</string>
   <string name="fling_pulse_color_summary">Używany również jako powrót do automatycznego koloru</string>
+  <string name="fling_smoothing_enabled_title">Włącz wygładzanie</string>
+  <string name="fling_smoothing_enabled_summary">Każdy pasek jest animowany bardziej łagodnie</string>
   <string name="eos_fling_lavalamp_title">Włącz lampę lawową</string>
   <string name="eos_fling_lavalamp_summary">Zmiana kolorów animacji Pulse w stylu lamp lawowych</string>
   <string name="pulse_advanced_category">Zaawansowane</string>
@@ -1821,4 +1826,12 @@
   <string name="menu_show_substratum">Pokaż nakładki</string>
   <string name="menu_hide_substratum">Ukryj nakładki</string>
   <!-- Edge gestures -->
+  <string name="edge_gestures_title">Gesty krawędzi</string>
+  <string name="edge_gestures_feedback_duration_title">Czas reakcji dotknięcia</string>
+  <string name="edge_gestures_long_press_delay_title">Opóźnienie startu akcji długiego naciśnięcia</string>
+  <string name="edge_gestures_back_category_title">Gest wstecz</string>
+  <string name="edge_gestures_back_edges_title">Miejsce gestu wstecz</string>
+  <string name="edge_gestures_landscape_back_edges_title">Miejsce gestu wstecz w trybie poziomym</string>
+  <string name="edge_gestures_back_screen_percent_title">Gest wstecz musi rozpocząć się poniżej tego procentu ekranu</string>
+  <string name="edge_gestures_back_screen_percent_summary">Przełącz poniżej % ekranu</string>
 </resources>

--- a/res/values-pl/rr_strings.xml
+++ b/res/values-pl/rr_strings.xml
@@ -202,7 +202,6 @@
   <string name="rr_statusbar_title">Pasek stanu</string>
   <string name="rr_sb_gestures_title">Gesty paska stanu</string>
   <string name="qs_advanced_title">Zaawansowane</string>
-  <string name="rr_notification_panel_title">Panele</string>
   <string name="rr_tuner">Kalibrator interfejsu systemu</string>
   <string name="rr_tuner_summary">Część podstawowych dostosowań</string>
   <string name="rr_battery">Bateria</string>

--- a/res/values-pt-rBR/rr_strings.xml
+++ b/res/values-pt-rBR/rr_strings.xml
@@ -101,6 +101,7 @@
   <string name="github_akhilnarang">https://github.com/akhilnaranag</string>
   <string name="github_bdogg718k">https://github.com/bdogg718k</string>
   <string name="github_apascual89">https://github.com/apascual89</string>
+  <string name="github_mracar">https://github.com/mracar07</string>
   <string name="rr">Links</string>
   <string name="rr_website_title">Website</string>
   <string name="rr_website_summary">Obter mais informações sobre a Resurrection Remix</string>
@@ -132,6 +133,7 @@
   <string name="christopher_kardas_summary">● Moderador \n● Editor\n● Colaborador</string>
   <string name="matt_summary">● Moderador \n● Editor\n● Colaborador</string>
   <string name="justen_summary">● Moderador \n● Editor\n● Colaborador</string>
+  <string name="mracar_summary">● Desenvolvedor\n● Mantenedor</string>
   <string name="support_team_title">Moderador</string>
   <string name="device_maintainers_title">Dispositivos e mantenedores</string>
   <string name="device_maintainers_title_summary">Lista de dispositivos e mantedores oficiais da RR</string>

--- a/res/values-pt-rBR/rr_strings.xml
+++ b/res/values-pt-rBR/rr_strings.xml
@@ -133,7 +133,7 @@
   <string name="christopher_kardas_summary">● Moderador \n● Editor\n● Colaborador</string>
   <string name="matt_summary">● Moderador \n● Editor\n● Colaborador</string>
   <string name="justen_summary">● Moderador \n● Editor\n● Colaborador</string>
-  <string name="mracar_summary">● Desenvolvedor\n● Mantenedor</string>
+  <string name="mracar_summary">● Desenvolvedor \n● Manutenção</string>
   <string name="support_team_title">Moderador</string>
   <string name="device_maintainers_title">Dispositivos e mantenedores</string>
   <string name="device_maintainers_title_summary">Lista de dispositivos e mantedores oficiais da RR</string>
@@ -202,7 +202,6 @@
   <string name="rr_statusbar_title">Barra de status</string>
   <string name="rr_sb_gestures_title">Gestos da barra de status</string>
   <string name="qs_advanced_title">Avançado</string>
-  <string name="rr_notification_panel_title">Painéis</string>
   <string name="rr_tuner">Sintonizador System UI</string>
   <string name="rr_tuner_summary">Customizações padrões do sistema</string>
   <string name="rr_battery">Bateria</string>
@@ -496,7 +495,7 @@ Densidade atual: <xliff:g name="count" example="520">%d</xliff:g> dpi</string>
   <string name="qs_columns_portrait_title">Número de colunas (retrato)</string>
   <string name="qs_columns_landscape_title">Número de colunas (paisagem)</string>
   <!-- QuickSettings Panel Transparency -->
-  <string name="qs_panel_alpha_title">Transparência do fundo do painel</string>
+  <string name="qs_panel_alpha_title">Transparência do fundo</string>
   <!-- Color Picker -->
   <string name="dialog_color_picker">Selecionador de cores</string>
   <string name="press_color_to_apply">Toque na cor abaixo para aplicar</string>

--- a/res/values-pt-rPT/cm_strings.xml
+++ b/res/values-pt-rPT/cm_strings.xml
@@ -301,6 +301,9 @@
   <string name="app_ops_reset_confirm_title">Confirmar reposição dos contadores</string>
   <string name="app_ops_reset_confirm_mesg">Tem a certeza que quer reiniciar os contadores?</string>
   <string name="ok">OK</string>
+
+  <string name="security_privacy_settings_title">Segurança e privacidade</string>
+
   <!-- LineageOS legal -->
   <string name="lineagelicense_title">Licença LineageOS</string>
 </resources>

--- a/res/values-pt-rPT/cm_strings.xml
+++ b/res/values-pt-rPT/cm_strings.xml
@@ -26,11 +26,14 @@
   <string name="show_dev_on_cm">Ativou as opções de programador!</string>
   <!-- [CHAR LIMIT=NONE] Device Info screen. Okay we get it, stop pressing, you already have it on -->
   <string name="show_dev_already_cm">Não é necessário, já ativou as opções de programador.</string>
+
   <!-- Launch Dev Tools -->
   <string name="development_tools_title">Ferramentas de desenvolvimento</string>
+
   <!-- Advanced restart options -->
   <string name="advanced_reboot_title">Reinicialização avançada</string>
   <string name="advanced_reboot_summary">Quando desbloqueado, incluir opções no menu ligar/desligar para reiniciar em modo de recuperação ou bootloader</string>
+
   <!-- Setting checkbox title for root access -->
   <string name="root_access">Acesso root</string>
   <string name="root_access_warning_title">Permitir acesso root?</string>
@@ -39,18 +42,23 @@
   <string name="root_access_apps">Só aplicações</string>
   <string name="root_access_adb">Só ADB</string>
   <string name="root_access_all">Aplicações e ADB</string>
+
   <!-- Preference link for root appops -->
   <string name="root_appops_title">Gerir os acessos root</string>
   <string name="root_appops_summary">Ver e controlar as regras de root</string>
+
   <!-- Double tap to sleep on status bar or lockscreen -->
   <string name="status_bar_double_tap_to_sleep_title">Toque duplo para desligar o ecrã</string>
-  <string name="status_bar_double_tap_to_sleep_summary">Toque duplo na barra de estado ou ecrã de bloqueio para desligar o ecrã</string>
+  <string name="status_bar_double_tap_to_sleep_summary">Dê um toque duplo na barra de estado ou ecrã de bloqueio para desligar o ecrã</string>
+
   <!-- Touchscreen gesture settings -->
   <string name="touchscreen_gesture_settings_title">Gestos do ecrã</string>
   <string name="touchscreen_gesture_settings_summary">Executar vários gestos no ecrã para ações rápidas</string>
+
   <!-- Proximity wake -->
   <string name="proximity_wake_title">Impedir o ecrã de se ligar acidentalmente</string>
   <string name="proximity_wake_summary">Verificar o sensor de proximidade antes de ligar o ecrã</string>
+
   <!-- Whether the keyguard will directly show the password entry -->
   <string name="lock_directly_show_password">Ir diretamente para a introdução da palavra-passe</string>
   <string name="lock_directly_show_password_summary">Ignorar o ecrã de deslizar para desbloquear e ir diretamente para a introdução da palavra-passe</string>
@@ -60,50 +68,65 @@
   <!-- Whether the keyguard will directly show the PIN entry -->
   <string name="lock_directly_show_pin">Ir diretamente para a introdução do código PIN</string>
   <string name="lock_directly_show_pin_summary">Ignorar o ecrã de deslizar para desbloquear e ir diretamente para a introdução do código PIN</string>
+
   <!-- PIN scramble -->
   <string name="unlock_scramble_pin_layout_title">Disposição aleatória</string>
   <string name="unlock_scramble_pin_layout_summary">Apresentar aleatoriamente a disposição do teclado numérico, quando desbloquear com PIN</string>
+
   <!-- Lock screen visualizer -->
   <string name="lockscreen_visualizer_title">Mostrar o visualizador de música</string>
+
   <!-- Lock screen cover art -->
   <string name="lockscreen_media_art_title">Mostrar capa do álbum</string>
+
   <!-- Sizes for pattern lockscreen -->
   <string name="lock_settings_picker_pattern_size_message">Escolha um tamanho para o padrão</string>
   <!-- Whether a visible red line will be drawn after the user has drawn the unlock pattern incorrectly -->
   <string name="lockpattern_settings_enable_error_path_title">Mostrar erro no padrão</string>
   <!-- Whether the dots will be drawn when using the lockscreen pattern -->
   <string name="lockpattern_settings_enable_dots_title">Mostrar os pontos do padrão</string>
+
   <!-- Lock screen vibrate settings -->
   <string name="lockscreen_vibrate_enabled_title">Vibrar</string>
   <string name="lockscreen_vibrate_enabled_head">Vibrar ao desbloquear</string>
+
   <!-- Android debugging -->
   <string name="adb_enable">Depuração Android</string>
   <string name="adb_enable_summary">Ativar a interface \"Android Debug Bridge\" (ADB)</string>
+
   <!-- Android debugging notification -->
   <string name="adb_notify">Notificação de depuração</string>
   <string name="adb_notify_summary">Mostrar uma notificação quando a depuração USB ou através da rede estiver ativada</string>
+
   <!-- Android debugging over network -->
   <string name="adb_over_network">ADB através da rede</string>
   <string name="adb_over_network_summary">Ativar a depuração TCP/IP sobre as interfaces de rede (Wi\u2011Fi, USB). Esta definição é restaurada ao reiniciar</string>
   <string name="adb_over_network_warning">Aviso: Quando o ADB sobre a rede está ativado, o seu telefone fica desprotegido e pode facilitar invasões em todas as redes conectadas! \n\nUsar esta funcionalidade apenas quando estiver conectado a redes de confiança.\n\nQuer mesmo ativar esta função?</string>
+
   <!-- Kill app long-press back -->
   <string name="kill_app_longpress_back">Fechar aplicação no botão Anterior</string>
   <string name="kill_app_longpress_back_summary">Fechar a aplicação em primeiro plano com pressão longa no botão Anterior</string>
+
   <!-- Format string for fingerprint location message -->
   <string name="security_settings_fingerprint_enroll_find_sensor_message_cm">Localize o sensor de impressões digitais na <xliff:g id="sensor_location">%1$s</xliff:g> do seu telefone.</string>
+
   <!-- Fingerprint sensor locations -->
   <string name="security_settings_fingerprint_sensor_location_back">traseira</string>
   <string name="security_settings_fingerprint_sensor_location_front">parte frontal</string>
   <string name="security_settings_fingerprint_sensor_location_left">lateral esquerda</string>
   <string name="security_settings_fingerprint_sensor_location_right">lateral direita</string>
+
   <!-- Increasing ring tone volume -->
   <string name="increasing_ring_volume_option_title">Toque crescente</string>
   <string name="increasing_ring_min_volume_title">Volume inicial</string>
   <string name="increasing_ring_ramp_up_time_title">Intervalo de aumento</string>
+
   <!-- Volume link notification -->
   <string name="volume_link_notification_title">Associar volumes de toque e notificação</string>
+
   <!-- Memory -->
   <string name="memory_startup_apps_title">Aplicações iniciadas no arranque</string>
+
   <!-- Manual provisioning support -->
   <string name="sim_enabler_summary"><xliff:g id="displayName">%1$s</xliff:g> está <xliff:g id="status" example="disabled">%2$s</xliff:g></string>
   <string name="sim_disabled">desativado</string>
@@ -120,6 +143,7 @@
   <string name="sub_activate_failed">A ativação falhou.</string>
   <string name="sub_deactivate_success">SIM desativado.</string>
   <string name="sub_deactivate_failed">A desativação falhou.</string>
+
   <!-- Names of categories of app ops tabs - extension of AOSP -->
   <string name="app_ops_categories_location">Localização</string>
   <string name="app_ops_categories_personal">Pessoal</string>
@@ -130,6 +154,7 @@
   <string name="app_ops_categories_bootup">Inicialização</string>
   <string name="app_ops_categories_su">Acesso root</string>
   <string name="app_ops_categories_other">Outro</string>
+
   <!-- User display names for app ops codes - extension of AOSP -->
   <string name="app_ops_summaries_coarse_location">Localização imprecisa</string>
   <string name="app_ops_summaries_fine_location">Localização precisa</string>
@@ -207,6 +232,7 @@
   <string name="app_ops_summaries_toggle_nfc">alternar o estado do NFC</string>
   <string name="app_ops_summaries_toggle_mobile_data">alternar o estado dos dados móveis</string>
   <string name="app_ops_summaries_superuser">acesso root</string>
+
   <!-- User display names for app ops codes - extension of AOSP -->
   <string name="app_ops_labels_coarse_location">Localização imprecisa</string>
   <string name="app_ops_labels_fine_location">Localização precisa</string>
@@ -284,26 +310,34 @@
   <string name="app_ops_labels_toggle_nfc">Alternar o estado do NFC</string>
   <string name="app_ops_labels_toggle_mobile_data">Alternar o estado dos dados móveis</string>
   <string name="app_ops_labels_superuser">Acesso root</string>
+
   <!-- App ops permissions -->
   <string name="app_ops_permissions_allowed">Permitido</string>
   <string name="app_ops_permissions_ignored">Ignorado</string>
   <string name="app_ops_permissions_always_ask">Perguntar sempre</string>
+
   <!-- App ops detail -->
   <string name="app_ops_entry_summary"><xliff:g id="op">%1$s</xliff:g> (utilizou <xliff:g id="count">%2$s</xliff:g>)</string>
   <string name="app_ops_allowed_count">Permitido <xliff:g id="count" example="2 times">%s</xliff:g></string>
   <string name="app_ops_ignored_count">Negado <xliff:g id="count" example="2 times">%s</xliff:g></string>
   <string name="app_ops_both_count">Permitido <xliff:g id="count">%1$s</xliff:g>, negado <xliff:g id="count">%2$s</xliff:g></string>
   <string name="app_ops_no_blockable_permissions">Não há permissões disponíveis para bloquear</string>
+
   <!-- App ops menu options -->
   <string name="app_ops_show_user_apps">Mostrar aplicações do utilizador</string>
   <string name="app_ops_show_system_apps">Mostrar aplicações de sistema</string>
   <string name="app_ops_reset_counters">Repor os contadores de permitir/negar</string>
   <string name="app_ops_reset_confirm_title">Confirmar reposição dos contadores</string>
   <string name="app_ops_reset_confirm_mesg">Tem a certeza que quer reiniciar os contadores?</string>
+
   <string name="ok">OK</string>
 
   <string name="security_privacy_settings_title">Segurança e privacidade</string>
 
-  <!-- LineageOS legal -->
-  <string name="lineagelicense_title">Licença LineageOS</string>
+  <!-- Volume settings - Volume adjustment sound -->
+  <string name="volume_adjust_sounds_title">Sons de ajuste do volume</string>
+
+  <!-- Full screen aspect ratio -->
+  <string name="full_screen_aspect_ratio_title">Proporção de apresentação do ecrã inteiro</string>
+  <string name="full_screen_aspect_ratio_summary">Forçar as aplicações a usarem a proporção de apresentação do ecrã inteiro. De notar que algumas aplicações podem não funcionar corretamente em ecrã inteiro</string>
 </resources>

--- a/res/values-pt-rPT/rr_strings.xml
+++ b/res/values-pt-rPT/rr_strings.xml
@@ -101,6 +101,7 @@
   <string name="github_akhilnarang">https://github.com/akhilnarang</string>
   <string name="github_bdogg718k">https://github.com/bdogg718k</string>
   <string name="github_apascual89">https://github.com/apascual89</string>
+  <string name="github_mracar">https://github.com/mracar07</string>
   <string name="rr">Ligações</string>
   <string name="rr_website_title">Página Web</string>
   <string name="rr_website_summary">Obter mais informações sobre a Resurrection Remix</string>
@@ -132,6 +133,7 @@
   <string name="christopher_kardas_summary">● Moderador \n● Editor\n● Colaborador</string>
   <string name="matt_summary">● Moderador \n● Editor\n● Colaborador</string>
   <string name="justen_summary">● Moderador \n● Editor\n● Colaborador</string>
+  <string name="mracar_summary">● Desenvolvedor\n● Mantenedor</string>
   <string name="support_team_title">Tag do Moderador</string>
   <string name="device_maintainers_title">Dispositivos e mantenedores</string>
   <string name="device_maintainers_title_summary">Lista de dispositivos e dos respetivos mantenedores da Resurrection Remix</string>

--- a/res/values-pt-rPT/rr_strings.xml
+++ b/res/values-pt-rPT/rr_strings.xml
@@ -329,7 +329,7 @@
   <string name="status_bar_quick_qs_pulldown_left">Esquerda</string>
   <string name="status_bar_quick_qs_pulldown_right">Direita</string>
   <string name="status_bar_double_tap_to_sleep_title">Toque duplo para desligar o ecrã</string>
-  <string name="status_bar_double_tap_to_sleep_summary">Toque duplo na barra de estado para desligar o ecrã</string>
+  <string name="status_bar_double_tap_to_sleep_summary">Toque duas vezes na barra de estado para desligar o ecrã</string>
   <string name="qs_tile_title_visibility_title">Mostrar título dos mosaicos</string>
   <string name="qs_tile_title_visibility_summary">Quando ativado, mostra os títulos por baixo dos mosaicos</string>
   <!-- QS Headers -->

--- a/res/values-pt-rPT/rr_strings.xml
+++ b/res/values-pt-rPT/rr_strings.xml
@@ -202,7 +202,6 @@
   <string name="rr_statusbar_title">Barra de estado</string>
   <string name="rr_sb_gestures_title">Gestos na barra de estado</string>
   <string name="qs_advanced_title">Avançadas</string>
-  <string name="rr_notification_panel_title">Painéis</string>
   <string name="rr_tuner">Sintonizador da interface do sistema</string>
   <string name="rr_tuner_summary">Algumas personalizações de origem</string>
   <string name="rr_battery">Bateria</string>
@@ -1830,8 +1829,8 @@
   <string name="edge_gestures_feedback_duration_title">Duração do retorno tátil</string>
   <string name="edge_gestures_long_press_delay_title">Atraso para iniciar a ação da pressão longa</string>
   <string name="edge_gestures_back_category_title">Gesto para Voltar</string>
-  <string name="edge_gestures_back_edges_title">Ativar o gesto para Voltar a partir de</string>
-  <string name="edge_gestures_landscape_back_edges_title">Ativar o gesto para Voltar no modo paisagem a partir de</string>
+  <string name="edge_gestures_back_edges_title">Ativar o gesto para Voltar a partir</string>
+  <string name="edge_gestures_landscape_back_edges_title">Ativar o gesto para Voltar no modo paisagem a partir</string>
   <string name="edge_gestures_back_screen_percent_title">Ativar o gesto para Voltar abaixo desta percentagem do ecrã</string>
   <string name="edge_gestures_back_screen_percent_summary">Ativar abaixo desta % do ecrã</string>
 </resources>

--- a/res/values-ro/rr_strings.xml
+++ b/res/values-ro/rr_strings.xml
@@ -101,6 +101,7 @@
   <string name="github_akhilnarang">https://github.com/akhilnarang</string>
   <string name="github_bdogg718k">https://github.com/bdogg718k</string>
   <string name="github_apascual89">https://github.com/apascual89</string>
+  <string name="github_mracar">https://github.com/apascual89</string>
   <string name="rr">Legături</string>
   <string name="rr_website_title">Pagină Web</string>
   <string name="rr_website_summary">Informații suplimentare despre Resurrection Remix OS</string>
@@ -132,6 +133,7 @@
   <string name="christopher_kardas_summary">● Moderator \n● Editor\n● Colaborator</string>
   <string name="matt_summary">● Moderator \n● Editor\n● Colaborator</string>
   <string name="justen_summary">● Moderator \n● Editor\n● Colaborator</string>
+  <string name="mracar_summary">● Dezvoltator \n● Maintainer</string>
   <string name="support_team_title">Tag Moderator</string>
   <string name="device_maintainers_title">Dispozitive și maintainers</string>
   <string name="device_maintainers_title_summary">Lista dispozitivelor şi persoanelor oficiale responsabile RR-OS</string>

--- a/res/values-ro/rr_strings.xml
+++ b/res/values-ro/rr_strings.xml
@@ -202,7 +202,6 @@
   <string name="rr_statusbar_title">Bara de stare</string>
   <string name="rr_sb_gestures_title">Gesturi bară de stare</string>
   <string name="qs_advanced_title">Avansat</string>
-  <string name="rr_notification_panel_title">Panouri</string>
   <string name="rr_tuner">System UI tuner</string>
   <string name="rr_tuner_summary">Parte din particularizări de stoc</string>
   <string name="rr_battery">Baterie</string>

--- a/res/values-ru/rr_strings.xml
+++ b/res/values-ru/rr_strings.xml
@@ -101,6 +101,7 @@
   <string name="github_akhilnarang">https://github.com/akhilnaranag</string>
   <string name="github_bdogg718k">https://github.com/bdogg718k</string>
   <string name="github_apascual89">https://github.com/apascual89</string>
+  <string name="github_mracar">https://github.com/mracar07</string>
   <string name="rr">Ссылки</string>
   <string name="rr_website_title">Сайт</string>
   <string name="rr_website_summary">Узнать больше о Resurrection Remix OS</string>
@@ -132,6 +133,7 @@
   <string name="christopher_kardas_summary">● Модератор\n● Редактор\n● Помощник</string>
   <string name="matt_summary">● Модератор\n● Редактор\n● Помощник</string>
   <string name="justen_summary">● Модератор\n● Редактор\n● Соучастник</string>
+  <string name="mracar_summary">● Разработчик\n● Поддерживающий</string>
   <string name="support_team_title">Тег модератора</string>
   <string name="device_maintainers_title">Устройства и разработчики</string>
   <string name="device_maintainers_title_summary">Список устройств, работающих на RR-OS, и людей, поддерживающих эти устройства</string>

--- a/res/values-ru/rr_strings.xml
+++ b/res/values-ru/rr_strings.xml
@@ -133,7 +133,7 @@
   <string name="christopher_kardas_summary">● Модератор\n● Редактор\n● Помощник</string>
   <string name="matt_summary">● Модератор\n● Редактор\n● Помощник</string>
   <string name="justen_summary">● Модератор\n● Редактор\n● Соучастник</string>
-  <string name="mracar_summary">● Разработчик\n● Поддерживающий</string>
+  <string name="mracar_summary">● Разработчик\n● Сопровождающий</string>
   <string name="support_team_title">Тег модератора</string>
   <string name="device_maintainers_title">Устройства и разработчики</string>
   <string name="device_maintainers_title_summary">Список устройств, работающих на RR-OS, и людей, поддерживающих эти устройства</string>
@@ -202,7 +202,6 @@
   <string name="rr_statusbar_title">Строка состояния</string>
   <string name="rr_sb_gestures_title">Жесты в строке состояния</string>
   <string name="qs_advanced_title">Дополнительные настройки</string>
-  <string name="rr_notification_panel_title">Панели</string>
   <string name="rr_tuner">Настройка системного интерфейса</string>
   <string name="rr_tuner_summary">Часть заводских настроек</string>
   <string name="rr_battery">Настройки отображения заряда в строке состояния</string>
@@ -838,7 +837,7 @@
   <string name="pulse_solid_dimen_category">Настройки режима сплошных линий</string>
   <string name="pulse_custom_buttons_opacity_title">Прозрачность Умной панели в режиме Пульс</string>
   <string name="pulse_auto_color_title">Автоматический цвет Pulse</string>
-  <string name="pulse_auto_color_summary">Цвет зависит от обложки трека. Переопределяет прозрачность \"Лава Лампы\" и сплошных линий.</string>
+  <string name="pulse_auto_color_summary">Синхронизация цвета с обложкой альбома. Переопределяет прозрачность \"Lava Lamp\" и сплошных линий.</string>
   <string name="fling_lavalamp_color_from">Цвет запуска Lava Lamp</string>
   <string name="fling_lavalamp_color_to">Цвет завершения Lava Lamp</string>
   <string name="pulse_colors_reset_title">Сбросить цвета Pulse</string>
@@ -1699,7 +1698,7 @@
   <string name="navbar_dynamic_summary">Изменять цвет панели навигации в зависимости от запущенного приложения</string>
   <string name="restart_app_required">Перезапустите соответствующее приложение, чтобы увидеть эффект</string>
   <!-- RR config options -->
-  <string name="rr_config_tabs_update_message">Вы собираетесь изменить макет на вкладки (как на nougat), который присутствовал в предыдущих версиях RR-OS и является стандартным. Вы уверен, что хотите продолжить?</string>
+  <string name="rr_config_tabs_update_message">Вы собираетесь изменить внешний вид настроек на вкладки (Nougat) как было в прошлой версии по умолчанию. Вы уверены, что хотите продолжить?</string>
   <string name="rr_config_classic_update_message">Вы собираетесь изменить внешний вид настроек  на классический (Marshmallow) как было в предыдущих версиях RR-OS по умолчанию. Вы уверены, что хотите продолжить?</string>
   <string name="rr_config_navigation_update_message">Вы собираетесь изменить внешний вид настроек RR-OS на панель с нижней навигацией (Oreo), который появился в текущей версии. Вы уверен, что хотите продолжить?</string>
   <string name="rr_config_navigation_color_enable_title">Свой цвет панели навигации</string>
@@ -1828,9 +1827,9 @@
   <string name="edge_gestures_title">Жесты</string>
   <string name="edge_gestures_feedback_duration_title">Длительность виброотклика</string>
   <string name="edge_gestures_long_press_delay_title">Задержка до тех пор, пока не начнется действие нажатия</string>
-  <string name="edge_gestures_back_category_title">Изменить жест разблокировки</string>
-  <string name="edge_gestures_back_edges_title">Trigger back gesture from</string>
-  <string name="edge_gestures_landscape_back_edges_title">Трек назад на фоне</string>
-  <string name="edge_gestures_back_screen_percent_title">Обратный жест должен начинаться ниже этого процента экрана</string>
-  <string name="edge_gestures_back_screen_percent_summary">Триггер ниже% экрана</string>
+  <string name="edge_gestures_back_category_title">Жест назад</string>
+  <string name="edge_gestures_back_edges_title">Запуск жеста назад из</string>
+  <string name="edge_gestures_landscape_back_edges_title">Запуск жеста назад в альбомной ориентации из</string>
+  <string name="edge_gestures_back_screen_percent_title">Жест назад будет выполняться в области экрана ниже этого показателя</string>
+  <string name="edge_gestures_back_screen_percent_summary">Область срабатывания жеста</string>
 </resources>

--- a/res/values-sk/rr_strings.xml
+++ b/res/values-sk/rr_strings.xml
@@ -202,7 +202,6 @@
   <string name="rr_statusbar_title">Stavový riadok</string>
   <string name="rr_sb_gestures_title">Gestá stavového riadku</string>
   <string name="qs_advanced_title">Rozšírené</string>
-  <string name="rr_notification_panel_title">Panely</string>
   <string name="rr_tuner">Ladenie rozhrania systému</string>
   <string name="rr_tuner_summary">Časť štandardných úprav</string>
   <string name="rr_battery">Batéria</string>

--- a/res/values-sk/rr_strings.xml
+++ b/res/values-sk/rr_strings.xml
@@ -101,6 +101,7 @@
   <string name="github_akhilnarang">https://github.com/akhilnarang</string>
   <string name="github_bdogg718k">https://github.com/bdogg718k</string>
   <string name="github_apascual89">https://github.com/apascual89</string>
+  <string name="github_mracar">https://github.com/mracar07</string>
   <string name="rr">Odkazy</string>
   <string name="rr_website_title">Web stránka</string>
   <string name="rr_website_summary">Získajte viac informácií o Resurrection Remix ROM</string>
@@ -132,6 +133,7 @@
   <string name="christopher_kardas_summary">● Moderátor\n● Editor\n● Prispievateľ</string>
   <string name="matt_summary">● Moderátor\n● Editor\n● Prispievateľ</string>
   <string name="justen_summary">● Moderátor\n● Editor\n● Prispievateľ</string>
+  <string name="mracar_summary">● Vývojár\n● Správca</string>
   <string name="support_team_title">Štítok moderátora</string>
   <string name="device_maintainers_title">Zariadenia a správcovia</string>
   <string name="device_maintainers_title_summary">Zoznam zariadení a ich správcovia v Resurrection ROM</string>

--- a/res/values-sr/rr_strings.xml
+++ b/res/values-sr/rr_strings.xml
@@ -114,7 +114,6 @@
   <string name="rr_statusbar_title">Статусна трака</string>
   <string name="rr_sb_gestures_title">Гестикулације статусне траке</string>
   <string name="qs_advanced_title">Напредно</string>
-  <string name="rr_notification_panel_title">Панели</string>
   <string name="rr_tuner">Уређење системског изгледа</string>
   <string name="rr_tuner_summary">Део подразумеваних прилагођавања</string>
   <string name="rr_battery">Батерија</string>

--- a/res/values-sv/rr_strings.xml
+++ b/res/values-sv/rr_strings.xml
@@ -196,7 +196,6 @@
   <string name="rr_statusbar_title">Statusfält</string>
   <string name="rr_sb_gestures_title">Gester i statusfält</string>
   <string name="qs_advanced_title">Avancerat</string>
-  <string name="rr_notification_panel_title">Paneler</string>
   <string name="rr_tuner">Inställningar för systemgränssnitt</string>
   <string name="rr_tuner_summary">En del av standardanpassningarna</string>
   <string name="rr_battery">Batteri</string>

--- a/res/values-sv/rr_strings.xml
+++ b/res/values-sv/rr_strings.xml
@@ -568,9 +568,13 @@
   <string name="slim_blacklist_apps_summary">Appar som inte ska visas i panelen</string>
   <string name="slim_blacklist_add_apps_title">Lägg till en app</string>
   <!-- Slim Recent App Sidebar  -->
+  <string name="recent_app_sidebar_label_color_title">Etikettfärg</string>
   <string name="recent_app_sidebar_bg_color_title">Bakgrundsfärg</string>
   <string name="recent_app_sidebar_scale_title">Storlek</string>
   <!-- Slim recents membar -->
+  <string name="slim_recents_mem_display_category_title">Minnesstapel</string>
+  <string name="slim_recents_mem_display_title">Visa minnesstapel</string>
+  <string name="slim_recents_mem_display_summaryOn">Minnesstapel aktiverad</string>
   <!-- Power Menu on Lock screen -->
   <string name="powermenu_category_other">Annat</string>
   <string name="powermenu_lockscreen_title">Låsskärmens synlighet</string>

--- a/res/values-th/rr_strings.xml
+++ b/res/values-th/rr_strings.xml
@@ -170,7 +170,6 @@
   <string name="rr_ota_fab_title">แสดงปุ่มลอย</string>
   <string name="rr_statusbar_title">แถบสถานะ</string>
   <string name="qs_advanced_title">ขั้นสูง</string>
-  <string name="rr_notification_panel_title">แผง</string>
   <string name="rr_tuner">ตัวปรับหน้าผู้ใช้งานของระบบ</string>
   <string name="rr_battery">แบตเตอรี่</string>
   <string name="rr_sb_icons">ไอคอนระบบ</string>

--- a/res/values-th/rr_strings.xml
+++ b/res/values-th/rr_strings.xml
@@ -122,6 +122,8 @@
   <string name="support_team_title">แท็กผู้ควบคุม</string>
   <string name="device_maintainers_title">อุปกรณ์และผู้ดูแล</string>
   <string name="maintainers_note_title">หมายเหตุ</string>
+  <string name="maintainers_note_title_summary">Make a pull request on Settings app with your name against your device if you want to apply to be a maintainer for a certain device</string>
+  <string name="device_summary"><xliff:g example="goldfish" id="codename">%1$s</xliff:g>\nMaintainer - <xliff:g example="deletescape" id="maintainer">%2$s</xliff:g></string>
   <!-- The Drill -->
   <!-- Changelog -->
   <string name="changelog_name">บันทึกการเปลี่ยนแปลง</string>

--- a/res/values-tr/cm_strings.xml
+++ b/res/values-tr/cm_strings.xml
@@ -301,6 +301,7 @@
   <string name="app_ops_reset_confirm_title">Sayaçları sıfırlamayı onayla</string>
   <string name="app_ops_reset_confirm_mesg">Sayaçları sıfırlamak istiyor musunuz?</string>
   <string name="ok">Tamam</string>
+  <string name="security_privacy_settings_title">Güvenlik ve gizlilik</string>
   <!-- LineageOS legal -->
   <string name="lineagelicense_title">LineageOS yasal</string>
 </resources>

--- a/res/values-tr/rr_strings.xml
+++ b/res/values-tr/rr_strings.xml
@@ -202,7 +202,6 @@
   <string name="rr_statusbar_title">Durum çubuğu</string>
   <string name="rr_sb_gestures_title">Durum çubuğu hareketleri</string>
   <string name="qs_advanced_title">Gelişmiş</string>
-  <string name="rr_notification_panel_title">Paneller</string>
   <string name="rr_tuner">Sistem arayüzü ayarlayıcı</string>
   <string name="rr_tuner_summary">Stok özelleştirmelerin bir kısmı</string>
   <string name="rr_battery">Pil</string>

--- a/res/values-tr/rr_strings.xml
+++ b/res/values-tr/rr_strings.xml
@@ -101,6 +101,7 @@
   <string name="github_akhilnarang">https://github.com/akhilnarang</string>
   <string name="github_bdogg718k">https://github.com/bdogg718k</string>
   <string name="github_apascual89">https://github.com/apascual89</string>
+  <string name="github_mracar">https://github.com/mracar07</string>
   <string name="rr">Bağlantılar</string>
   <string name="rr_website_title">Website</string>
   <string name="rr_website_summary">Resurrection Remix OS hakkında daha fazla bilgi edinin</string>
@@ -132,6 +133,7 @@
   <string name="christopher_kardas_summary">● Moderatör \n● Düzenleyici\n● Katılımcı</string>
   <string name="matt_summary">● Moderatör \n● Düzenleyici\n● Katılımcı</string>
   <string name="justen_summary">● Moderatör \n● Düzenleyici\n● Katılımcı</string>
+  <string name="mracar_summary">● Geliştirici \n● Cihaz Sorumlusu</string>
   <string name="support_team_title">Moderatör Etiketi</string>
   <string name="device_maintainers_title">Cihazlar ve sorumluları</string>
   <string name="device_maintainers_title_summary">RR-OS cihazlar ve sorumluları listesi</string>

--- a/res/values-uk/rr_strings.xml
+++ b/res/values-uk/rr_strings.xml
@@ -202,7 +202,6 @@
   <string name="rr_statusbar_title">Рядок стану</string>
   <string name="rr_sb_gestures_title">Жести в рядку стану</string>
   <string name="qs_advanced_title">Розширені налаштування</string>
-  <string name="rr_notification_panel_title">Панелі</string>
   <string name="rr_tuner">Налаштування системного інтерфейсу</string>
   <string name="rr_tuner_summary">Частина стандартних налаштувань</string>
   <string name="rr_battery">Батарея</string>
@@ -489,6 +488,7 @@
   <string name="rr_density_summary">Налаштуйте щільність екрана, щоб масштабувати екран до абсолютної межі</string>
   <string name="rr_fonts_summary">Виберіть ваш бажаний розмір шрифту</string>
   <string name="stock_recents_category">Стандартна панель недавніх додатків</string>
+  <string name="edge_gestures_summary">Навігація за допомогою жестів</string>
   <!-- QS rows and columns -->
   <string name="qs_rows_portrait_title">Кількість рядків (портрет)</string>
   <string name="qs_rows_landscape_title">Кількість рядків (ландшафт) </string>
@@ -823,6 +823,8 @@
   <string name="pulse_render_mode_solid_lines">Суцільні лінії</string>
   <string name="fling_pulse_color">Колір Pulse</string>
   <string name="fling_pulse_color_summary">Також використовується як резервний для автоматичного підбору кольору</string>
+  <string name="fling_smoothing_enabled_title">Включити згладжування</string>
+  <string name="fling_smoothing_enabled_summary">Більш плавна анімація Fling</string>
   <string name="eos_fling_lavalamp_title">Увімкнути \"Лава Лампу\"</string>
   <string name="eos_fling_lavalamp_summary">Випадкові кольори в стилі \"Лава Лампи\"</string>
   <string name="pulse_advanced_category">Розширені налаштування</string>
@@ -1781,9 +1783,16 @@
   <string name="smart_pixels_percent">Відсоток пікселів для відключення</string>
   <string name="smart_pixels_shift">Запобігання спалаху шляхом переміщення пікселів кожен</string>
   <!-- QS footer icons -->
+  <string name="qs_footer_services_title">Показувати значок запущених служб</string>
+  <string name="qs_footer_services_summary">Відображати значок запущених служб внизу швидких налаштувань</string>
+  <string name="qs_footer_settings_title">Показувати значок налаштувань</string>
+  <string name="qs_footer_settings_summary">Відображати значок налаштувань внизу швидких налаштувань</string>
   <!-- Recents Grid -->
   <string name="recents_grid_title">Сітка нещодавніх додатків</string>
+  <string name="recents_grid_summary">Відображати недавні додатки в стилі сітки</string>
   <!-- Recents Lock Icon -->
+  <string name="recents_lock_title">Блокування недавніх додатків</string>
+  <string name="recents_lock_summary">Відображати значок блокування в заголовку недавнього додатку</string>
   <!-- Tiles animation style  -->
   <string name="qs_tiles">Плитки панелі швидких налаштувань</string>
   <string name="qs_tile_animation_style_title">Стиль анімації</string>
@@ -1818,4 +1827,10 @@
   <!-- Edge gestures -->
   <string name="edge_gestures_title">Свайп-жести</string>
   <string name="edge_gestures_feedback_duration_title">Тривалість вібрації</string>
+  <string name="edge_gestures_long_press_delay_title">Затримка до тих пір, поки не почнеться дія натискання</string>
+  <string name="edge_gestures_back_category_title">Жест назад</string>
+  <string name="edge_gestures_back_edges_title">Запуск жесту назад з</string>
+  <string name="edge_gestures_landscape_back_edges_title">Запуск жесту назад альбомного формату з</string>
+  <string name="edge_gestures_back_screen_percent_title">Жест назад буде виконуватися в області екрана нижче цього показника</string>
+  <string name="edge_gestures_back_screen_percent_summary">Область спрацьовування жесту</string>
 </resources>

--- a/res/values-uk/rr_strings.xml
+++ b/res/values-uk/rr_strings.xml
@@ -101,6 +101,7 @@
   <string name="github_akhilnarang">https://github.com/akhilnarang</string>
   <string name="github_bdogg718k">https://github.com/bdogg718k</string>
   <string name="github_apascual89">https://GitHub.com/apascual89</string>
+  <string name="github_mracar">https://github.com/mracar07</string>
   <string name="rr">Посилання</string>
   <string name="rr_website_title">Веб-сторінка</string>
   <string name="rr_website_summary">Отримати більше інформації про Resurrection Remix OS</string>
@@ -132,6 +133,7 @@
   <string name="christopher_kardas_summary">● Модератор\n● Редактор\n● Співучасник</string>
   <string name="matt_summary">● Модератор\n● Редактор\n● Співучасник</string>
   <string name="justen_summary">● Модератор\n● Редактор\n● Співучасник</string>
+  <string name="mracar_summary">● Розробник\n● Підтримка моделі</string>
   <string name="support_team_title">Модератор тег</string>
   <string name="device_maintainers_title">Пристрої та розробники</string>
   <string name="device_maintainers_title_summary">Список пристроїв та їх супроводжуючих розробників</string>
@@ -1814,4 +1816,6 @@
   <string name="menu_show_substratum">Показувати шари</string>
   <string name="menu_hide_substratum">Сховати шари</string>
   <!-- Edge gestures -->
+  <string name="edge_gestures_title">Свайп-жести</string>
+  <string name="edge_gestures_feedback_duration_title">Тривалість вібрації</string>
 </resources>

--- a/res/values-vi/rr_strings.xml
+++ b/res/values-vi/rr_strings.xml
@@ -101,6 +101,7 @@
   <string name="github_akhilnarang">https://github.com/akhilnarang</string>
   <string name="github_bdogg718k">https://github.com/bdogg718k</string>
   <string name="github_apascual89">https://github.com/apascual89</string>
+  <string name="github_mracar">https://github.com/apascual89</string>
   <string name="rr">Liên kết</string>
   <string name="rr_website_title">Website</string>
   <string name="rr_website_summary">Xem thêm thông tin về Resurrection Remix OS</string>
@@ -132,6 +133,7 @@
   <string name="christopher_kardas_summary">● Người điều hành\n● Người biên tập\n● Người đóng góp</string>
   <string name="matt_summary">● Người điều hành\n● Người biên tập\n● Người đóng góp</string>
   <string name="justen_summary">● Người điều hành\n● Người biên tập\n● Người đóng góp</string>
+  <string name="mracar_summary">● Người phát triển\n● Người duy trì</string>
   <string name="support_team_title">Thẻ Người Điều Hành</string>
   <string name="device_maintainers_title">Các thiết bị và người duy trì</string>
   <string name="device_maintainers_title_summary">Danh sách các thiết bị và người duy trì RR-OS chính thức</string>
@@ -200,7 +202,6 @@
   <string name="rr_statusbar_title">Thanh trạng thái</string>
   <string name="rr_sb_gestures_title">Cử chỉ thanh trạng thái</string>
   <string name="qs_advanced_title">Nâng cao</string>
-  <string name="rr_notification_panel_title">Bảng điều khiển</string>
   <string name="rr_tuner">Bộ điều chỉnh giao diện người dùng hệ thống</string>
   <string name="rr_tuner_summary">Phần của các tùy chỉnh gốc</string>
   <string name="rr_battery">Pin</string>
@@ -488,6 +489,7 @@ Mật độ điểm ảnh
   <string name="rr_density_summary">Tùy chỉnh mật độ của màn hình để mở rộng màn hình tới giới hạn tuyệt đối của nó</string>
   <string name="rr_fonts_summary">Chọn kích thước phông chữ ưa thích của bạn</string>
   <string name="stock_recents_category">Gần đây gốc</string>
+  <string name="edge_gestures_summary">Điều hướng bằng cử chỉ viền</string>
   <!-- QS rows and columns -->
   <string name="qs_rows_portrait_title">Hàng gạch theo chiều dọc</string>
   <string name="qs_rows_landscape_title">Dãy ô theo chiều ngang</string>
@@ -822,6 +824,8 @@ Mật độ điểm ảnh
   <string name="pulse_render_mode_solid_lines">Đường liền nét</string>
   <string name="fling_pulse_color">Màu Pulse</string>
   <string name="fling_pulse_color_summary">Được sử dụng cũng như dự phòng cho màu tự động</string>
+  <string name="fling_smoothing_enabled_title">Bật làm mượt</string>
+  <string name="fling_smoothing_enabled_summary">Thanh hoạt cảnh mượt hơn</string>
   <string name="eos_fling_lavalamp_title">Bật đèn dung nham</string>
   <string name="eos_fling_lavalamp_summary">Các hoạt ảnh Pulse pha trộn kiểu màu đèn dung nham sống động</string>
   <string name="pulse_advanced_category">Nâng cao</string>
@@ -1497,7 +1501,7 @@ Mật độ điểm ảnh
   <string name="logo15">Tắt Thời tiết </string>
   <string name="logo16">Máy xay sinh tố</string>
   <string name="logo17">Bánh</string>
-  <string name="logo18">Đàn guitar điện</string>
+  <string name="logo18">Đàn Ghi-ta điện</string>
   <string name="logo19">Khuôn mặt cười</string>
   <string name="logo20">Chạy</string>
   <string name="logo21">Độc hại</string>
@@ -1819,4 +1823,12 @@ Mật độ điểm ảnh
   <string name="menu_show_substratum">Hiển thị các lớp phủ</string>
   <string name="menu_hide_substratum">Ẩn các lớp phủ</string>
   <!-- Edge gestures -->
+  <string name="edge_gestures_title">Cử chỉ toàn màn hình</string>
+  <string name="edge_gestures_feedback_duration_title">Thời gian chờ phản hồi</string>
+  <string name="edge_gestures_long_press_delay_title">Thời gian chờ cho chạm và giữ</string>
+  <string name="edge_gestures_back_category_title">Cử chỉ quay lại</string>
+  <string name="edge_gestures_back_edges_title">Kích hoạt cử chỉ quay lại</string>
+  <string name="edge_gestures_landscape_back_edges_title">Kích hoạt cử chỉ quay lại khi màn hình nằm ngang</string>
+  <string name="edge_gestures_back_screen_percent_title">Cử chỉ quay lại phải khởi động dưới từng này phần trăm của màn hình</string>
+  <string name="edge_gestures_back_screen_percent_summary">Kích hoạt dưới % của màn hình</string>
 </resources>

--- a/res/values-zh-rCN/rr_strings.xml
+++ b/res/values-zh-rCN/rr_strings.xml
@@ -101,6 +101,7 @@
   <string name="github_akhilnarang">https://github.com/akhilnarang</string>
   <string name="github_bdogg718k">https://github.com/bdogg718k</string>
   <string name="github_apascual89">https://github.com/apascual89</string>
+  <string name="github_mracar">https://github.com/mracar07</string>
   <string name="rr">链接</string>
   <string name="rr_website_title">网站</string>
   <string name="rr_website_summary">获取更多 Resurrection Remix OS 的相关信息</string>
@@ -132,6 +133,7 @@
   <string name="christopher_kardas_summary">● 版主\n● 编辑者\n● 贡献者</string>
   <string name="matt_summary">● 版主\n● 编辑者\n● 贡献者</string>
   <string name="justen_summary">● 版主\n● 编辑者\n● 贡献者</string>
+  <string name="mracar_summary">● 开发者\n● 维护者</string>
   <string name="support_team_title">版主标签</string>
   <string name="device_maintainers_title">设备和维护者</string>
   <string name="device_maintainers_title_summary">设备列表和官方 RR-OS 维护者</string>

--- a/res/values-zh-rCN/rr_strings.xml
+++ b/res/values-zh-rCN/rr_strings.xml
@@ -202,7 +202,6 @@
   <string name="rr_statusbar_title">状态栏</string>
   <string name="rr_sb_gestures_title">状态栏手势</string>
   <string name="qs_advanced_title">高级</string>
-  <string name="rr_notification_panel_title">面板</string>
   <string name="rr_tuner">系统界面调节</string>
   <string name="rr_tuner_summary">原生配置</string>
   <string name="rr_battery">电池</string>

--- a/res/values-zh-rHK/rr_strings.xml
+++ b/res/values-zh-rHK/rr_strings.xml
@@ -202,7 +202,6 @@
   <string name="rr_statusbar_title">狀態列</string>
   <string name="rr_sb_gestures_title">狀態欄手勢</string>
   <string name="qs_advanced_title">進階</string>
-  <string name="rr_notification_panel_title">面板</string>
   <string name="rr_tuner">系統使用者介面調整精靈</string>
   <string name="rr_tuner_summary">原始自訂部分</string>
   <string name="rr_battery">電池</string>
@@ -400,7 +399,7 @@
   <string name="status_bar_battery_percentage_text_inside">圖示內</string>
   <string name="status_bar_battery_percentage_text_next">圖示旁</string>
   <!-- Status bar - Brightness -->
-  <string name="status_bar_brightness_category">亮度</string>
+  <string name="status_bar_brightness_category">螢幕亮度</string>
   <string name="status_bar_brightness_slider_title">亮度滑動條</string>
   <string name="status_bar_brightness_slider_summary">在快速設定中調整亮度</string>
   <string name="status_bar_brightness_slider_auto_title">自動調整亮度</string>
@@ -410,7 +409,7 @@
   <!-- Carrier Label -->
   <string name="carrier_options">選擇顯示位置</string>
   <string name="custom_carrier_label_title">自訂電信商標籤</string>
-  <string name="custom_carrier_label_explain">輸入自訂標籤。保留為空以使用您的網路名稱</string>
+  <string name="custom_carrier_label_explain">輸入自訂標籤。留空以使用您的網路名稱</string>
   <string name="custom_carrier_label_notset">自訂標籤尚未設置</string>
   <string name="show_carrier_title">電信業者標籤</string>
   <string name="show_carrier_disabled">已停用</string>
@@ -420,7 +419,7 @@
   <string name="status_bar_carrier_size">電信商標籤文字大小</string>
   <string name="status_bar_carrier_font_style_title">電信商標籤字體</string>
   <!-- Battery bar -->
-  <string name="battery_bar_title">電量列</string>
+  <string name="battery_bar_title">電量條</string>
   <string name="battery_bar_position_title">位置</string>
   <string name="battery_bar_position_hidden">隱藏</string>
   <string name="battery_bar_position_statusbar">狀態列</string>

--- a/res/values-zh-rHK/rr_strings.xml
+++ b/res/values-zh-rHK/rr_strings.xml
@@ -101,6 +101,7 @@
   <string name="github_akhilnarang">https://github.com/akhilnarang</string>
   <string name="github_bdogg718k">https://github.com/bdogg718k</string>
   <string name="github_apascual89">https://github.com/apascual89</string>
+  <string name="github_mracar">https://github.com/mracar07</string>
   <string name="rr">鏈結</string>
   <string name="rr_website_title">網站</string>
   <string name="rr_website_summary">取得更多關於 Resurrection Remix OS 的相關資訊</string>
@@ -132,6 +133,7 @@
   <string name="christopher_kardas_summary">● 版主 \n● 編輯者 \n● 貢獻者</string>
   <string name="matt_summary">● 版主 \n● 編輯者 \n● 貢獻者</string>
   <string name="justen_summary">● 版主 \n● 編輯者 \n● 貢獻者</string>
+  <string name="mracar_summary">● 開發者 \n● 維護者</string>
   <string name="support_team_title">版主標籤</string>
   <string name="device_maintainers_title">裝置和維護人員</string>
   <string name="device_maintainers_title_summary">列出裝置及該裝置的官方 RR-OS 的維護人員</string>

--- a/res/values-zh-rTW/rr_strings.xml
+++ b/res/values-zh-rTW/rr_strings.xml
@@ -101,6 +101,7 @@
   <string name="github_akhilnarang">https://github.com/akhilnarang</string>
   <string name="github_bdogg718k">https://github.com/bdogg718k</string>
   <string name="github_apascual89">https://github.com/apascual89</string>
+  <string name="github_mracar">https://github.com/mracar07</string>
   <string name="rr">連結</string>
   <string name="rr_website_title">網站</string>
   <string name="rr_website_summary">取得更多關於 Resurrection Remix OS 的相關資訊</string>
@@ -132,6 +133,7 @@
   <string name="christopher_kardas_summary">● 版主 \n● 編輯者 \n● 貢獻者</string>
   <string name="matt_summary">● 版主 \n● 編輯者 \n● 貢獻者</string>
   <string name="justen_summary">● 版主 \n● 編輯者 \n● 貢獻者</string>
+  <string name="mracar_summary">● 開發者 \n● 維護者</string>
   <string name="support_team_title">版主標籤</string>
   <string name="device_maintainers_title">裝置和維護者</string>
   <string name="device_maintainers_title_summary">列出裝置及該裝置的官方 RR-OS 的維護人員</string>

--- a/res/values-zh-rTW/rr_strings.xml
+++ b/res/values-zh-rTW/rr_strings.xml
@@ -202,7 +202,6 @@
   <string name="rr_statusbar_title">狀態列</string>
   <string name="rr_sb_gestures_title">狀態列手勢</string>
   <string name="qs_advanced_title">進階</string>
-  <string name="rr_notification_panel_title">面板</string>
   <string name="rr_tuner">系統使用者介面調整精靈</string>
   <string name="rr_tuner_summary">原始自訂部分</string>
   <string name="rr_battery">電池</string>

--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -344,4 +344,10 @@
     <!-- Full screen aspect ratio -->
     <string name="full_screen_aspect_ratio_title">Full screen aspect ratio</string>
     <string name="full_screen_aspect_ratio_summary">Force apps to use full screen aspect ratio, note that some apps may not work properly in full screen</string>
+
+    <!-- Per-app data restrictions -->
+    <string name="data_usage_app_restrict_data">Cellular data</string>
+    <string name="data_usage_app_restrict_data_summary">Enable usage of cellular data</string>
+    <string name="data_usage_app_restrict_wifi">Wi\u2011Fi data</string>
+    <string name="data_usage_app_restrict_wifi_summary">Enable usage of Wi\u2011Fi data</string>
 </resources>

--- a/res/values/resurrection_device_maintainers_strings.xml
+++ b/res/values/resurrection_device_maintainers_strings.xml
@@ -97,7 +97,7 @@
 
   <string name="device_A6020" translatable="false">Lenovo Vibe K5/K5+</string>
   <string name="device_A6020_codename" translatable="false">A6020</string>
-  <string name="device_A6020_maintainer" translatable="false">Yash Garg</string>
+  <string name="device_A6020_maintainer" translatable="false"></string>
 
   <string name="device_a6000" translatable="false">Lenovo A6000</string>
   <string name="device_a6000_codename" translatable="false">a6000</string>

--- a/res/values/resurrection_device_maintainers_strings.xml
+++ b/res/values/resurrection_device_maintainers_strings.xml
@@ -942,6 +942,10 @@
   <string name="device_ville_codename" translatable="false">Ville</string>
   <string name="device_ville_maintainer" translatable="false">Moozon</string>
 
+  <string name="device_nubia_nx511j" translatable="false">Nubia Z9 mini</string>
+  <string name="device_nubia_nx511j_codename" translatable="false">nx511j</string>
+  <string name="device_nubia_nx511j_maintainer" translatable="false">TTTT555</string>
+
   <string name="device_nubia_nx512j" translatable="false">Nubia Z9 Max</string>
   <string name="device_nubia_nx512j_codename" translatable="false">nx512j</string>
   <string name="device_nubia_nx512j_maintainer" translatable="false">Atul Bansode</string>

--- a/res/values/resurrection_device_maintainers_strings.xml
+++ b/res/values/resurrection_device_maintainers_strings.xml
@@ -297,6 +297,10 @@
   <string name="device_fortuna3g" translatable="false">Galaxy Grand Prime</string>
   <string name="device_fortuna3g_codename" translatable="false">SM-G530H</string>
   <string name="device_fortuna3g_maintainer" translatable="false">Hassan Sardar</string>
+   
+  <string name="device_zenfone3" translatable="false">Zenfone 3</string>
+  <string name="device_zenfone3_codename" translatable="false">ZE520KL/ZE552KL</string>
+  <string name="device_zenfone3_maintainer" translatable="false">fosseperme</string> 
 
   <string name="device_fortunave3g" translatable="false">Galaxy Grand Prime</string>
   <string name="device_fortunave3g_codename" translatable="false">SM-G530H</string>

--- a/res/values/resurrection_device_maintainers_strings.xml
+++ b/res/values/resurrection_device_maintainers_strings.xml
@@ -713,7 +713,11 @@
   <string name="device_mido" translatable="false">Xiaomi Redmi Note 4</string>
   <string name="device_mido_codename" translatable="false">mido</string>
   <string name="device_mido_maintainer" translatable="false">Adesh (Adesh15)</string>
-      
+  
+  <string name="device_vince" translatable="false">Xiaomi Redmi 5 Plus/Redmi Note 5</string>
+  <string name="device_vince_codename" translatable="false">vince</string>
+  <string name="device_vince_maintainer" translatable="false">Ruturaj Kadam</string>
+    
   <string name="device_whyred" translatable="false">Xiaomi Redmi Note 5 Pro</string>
   <string name="device_whyred_codename" translatable="false">whyred</string>
   <string name="device_whyred_maintainer" translatable="false">Shahan_mik3</string>

--- a/res/values/resurrection_device_maintainers_strings.xml
+++ b/res/values/resurrection_device_maintainers_strings.xml
@@ -970,4 +970,8 @@
   <string name="device_oxygen_codename" translatable="false">oxygen</string>
   <string name="device_oxygen_maintainer" translatable="false">ROMFACTORY(SARTHAKMALLA)</string>
 
+  <string name="device_on7xelte" translatable="false">Galaxy J7 Prime</string>
+  <string name="device_on7xelte_codename" translatable="false">on7xelte</string>
+  <string name="device_on7xelte_maintainer" translatable="false">Douglas Gomes(Doug@s123)</string>
+   
 </resources>

--- a/res/values/resurrection_device_maintainers_strings.xml
+++ b/res/values/resurrection_device_maintainers_strings.xml
@@ -19,6 +19,7 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
+  <string name="device_category_generic_title">GENERIC</string>
   <string name="device_category_samsung_title">SAMSUNG</string>
   <string name="device_category_sony_title">SONY</string>
   <string name="device_category_lg_title">LG</string>
@@ -46,6 +47,18 @@
   <string name="device_category_jiayu_title">Jiayu</string>
   <string name="device_category_nextbit_title">Nextbit</string>
    
+  <string name="device_genericarm64aonly" translatable="false">Generic System Image</string>
+  <string name="device_genericarm64aonly_codename" translatable="false">ARM64 A-Only</string>
+  <string name="device_genericarm64aonly_maintainer" translatable="false">Mr. ACAR</string>
+
+  <string name="device_genericarm64ab" translatable="false">Generic System Image</string>
+  <string name="device_genericarm64ab_codename" translatable="false">ARM64 AB</string>
+  <string name="device_genericarm64ab_maintainer" translatable="false">Mr. ACAR</string>
+ 
+  <string name="device_genericarmaonly" translatable="false">Generic System Image</string>
+  <string name="device_genericarmaonly_codename" translatable="false">ARM A-Only</string>
+  <string name="device_genericarmaonly_maintainer" translatable="false">Mr. ACAR</string>
+
   <string name="device_a610" translatable="false">ZTE BLADE A610</string>
   <string name="device_a610_codename" translatable="false">a610</string>
   <string name="device_a610_maintainer" translatable="false">Roman Yukovsky (mosya234)</string>

--- a/res/values/resurrection_device_maintainers_strings.xml
+++ b/res/values/resurrection_device_maintainers_strings.xml
@@ -854,6 +854,10 @@
   <string name="device_Z00D_codename" translatable="false">Z00D</string>
   <string name="device_Z00D_maintainer" translatable="false">Nguyenhung9x </string>
 
+  <string name="device_X00TD" translatable="false">Asus Zenfone Max Pro M1 </string>
+  <string name="device_X00TD_codename" translatable="false">X00TD</string>
+  <string name="device_X00TD_maintainer" translatable="false">Shivam Kumar Jha </string>
+
   <string name="device_quark" translatable="false">Moto Maxx-Turbo, Droid Turbo </string>
   <string name="device_quark_codename" translatable="false">Quark</string>
   <string name="device_quark_maintainer" translatable="false">bhb27 - Felipe Leon</string>

--- a/res/values/resurrection_device_maintainers_strings.xml
+++ b/res/values/resurrection_device_maintainers_strings.xml
@@ -59,6 +59,10 @@
   <string name="device_genericarmaonly_codename" translatable="false">ARM A-Only</string>
   <string name="device_genericarmaonly_maintainer" translatable="false">Mr. ACAR</string>
 
+  <string name="device_generichkirin" translatable="false">Generic System Image</string>
+  <string name="device_generichkirin_codename" translatable="false">Huawei Kirin</string>
+  <string name="device_generichkirin_maintainer" translatable="false">Alexander Pohl </string>
+
   <string name="device_a610" translatable="false">ZTE BLADE A610</string>
   <string name="device_a610_codename" translatable="false">a610</string>
   <string name="device_a610_maintainer" translatable="false">Roman Yukovsky (mosya234)</string>

--- a/res/values/resurrection_device_maintainers_strings.xml
+++ b/res/values/resurrection_device_maintainers_strings.xml
@@ -318,6 +318,10 @@
   <string name="device_j5ltexx_codename" translatable="false">SM-J500F/FN/M/G/Y/H</string>
   <string name="device_j5ltexx_maintainer" translatable="false">Dyneteve </string>
 
+  <string name="device_a3xelte" translatable="false">Galaxy A3 2016</string>
+  <string name="device_a3xelte_codename" translatable="false">SM-A310F/M/NO/Y</string>
+  <string name="device_a3xelte_maintainer" translatable="false">McFy</string>
+
   <string name="device_a3y17lte" translatable="false">Galaxy A3 2017</string>
   <string name="device_a3y17lte_codename" translatable="false">SM-A320FL/F/Y</string>
   <string name="device_a3y17lte_maintainer" translatable="false">McFy</string>

--- a/res/values/resurrection_device_maintainers_strings.xml
+++ b/res/values/resurrection_device_maintainers_strings.xml
@@ -696,7 +696,7 @@
 
   <string name="device_natrium" translatable="false">Xiaomi MI 5s Plus</string>
   <string name="device_natrium_codename" translatable="false">Natrium</string>
-  <string name="device_natrium_maintainer" translatable="false">Ali İhsan Hatun (Asderdd)</string>
+  <string name="device_natrium_maintainer" translatable="false">hacker1024</string>
 
   <string name="device_sagit" translatable="false">Xiaomi MI 6</string>
   <string name="device_sagit_codename" translatable="false">Sagit</string>

--- a/res/values/resurrection_device_maintainers_strings.xml
+++ b/res/values/resurrection_device_maintainers_strings.xml
@@ -824,7 +824,7 @@
 
   <string name="device_redmi2" translatable="false">Xiaomi Redmi 2</string>
   <string name="device_redmi2_codename" translatable="false">wt88047</string>
-  <string name="device_redmi2_maintainer" translatable="false">nicknitewolf </string>
+  <string name="device_redmi2_maintainer" translatable="false">karthik km</string>
 
   <string name="device_redmi3" translatable="false">Xiaomi Redmi 3</string>
   <string name="device_redmi3_codename" translatable="false">ido</string>

--- a/res/values/resurrection_device_maintainers_strings.xml
+++ b/res/values/resurrection_device_maintainers_strings.xml
@@ -784,7 +784,7 @@
 
   <string name="device_angler" translatable="false">Huawei Nexus 6P</string>
   <string name="device_angler_codename" translatable="false">Angler</string>
-  <string name="device_angler_maintainer" translatable="false">BlackDeaths</string>
+  <string name="device_angler_maintainer" translatable="false">voidz</string>
 
   <string name="device_smp601" translatable="false">Samsung Galaxy Note 10.1 3G</string>
   <string name="device_smp601_codename" translatable="false">SM-P601</string>

--- a/res/values/resurrection_device_maintainers_strings.xml
+++ b/res/values/resurrection_device_maintainers_strings.xml
@@ -716,7 +716,7 @@
 
   <string name="device_kenzo" translatable="false">Xiaomi Redmi Note 3</string>
   <string name="device_kenzo_codename" translatable="false">Kenzo</string>
-  <string name="device_kenzo_maintainer" translatable="false">Akhil, Abhishek</string>
+  <string name="device_kenzo_maintainer" translatable="false">Alex9yust</string>
 
   <string name="device_mido" translatable="false">Xiaomi Redmi Note 4</string>
   <string name="device_mido_codename" translatable="false">mido</string>

--- a/res/values/resurrection_device_maintainers_strings.xml
+++ b/res/values/resurrection_device_maintainers_strings.xml
@@ -520,7 +520,7 @@
 
   <string name="device_titan" translatable="false">Moto G 2014</string>
   <string name="device_titan_codename" translatable="false">Titan</string>
-  <string name="device_titan_maintainer" translatable="false">Uvneshkumar</string>
+  <string name="device_titan_maintainer" translatable="false">thedeadfish59</string>
 
   <string name="device_osprey" translatable="false">Moto G 2015 </string>
   <string name="device_osprey_codename" translatable="false">Osprey</string>

--- a/res/values/resurrection_device_maintainers_strings.xml
+++ b/res/values/resurrection_device_maintainers_strings.xml
@@ -965,7 +965,7 @@
   <string name="device_z2_row" translatable="false">Zuk Z2 PRO</string>
   <string name="device_z2_row_codename" translatable="false"> z2_row</string>
   <string name="device_z2_row_maintainer" translatable="false">Mr.ACAR </string>   
-  
+
   <string name="device_oxygen" translatable="false">Xiaomi Mi Max 2</string>
   <string name="device_oxygen_codename" translatable="false">oxygen</string>
   <string name="device_oxygen_maintainer" translatable="false">ROMFACTORY(SARTHAKMALLA)</string>

--- a/res/values/resurrection_device_maintainers_strings.xml
+++ b/res/values/resurrection_device_maintainers_strings.xml
@@ -942,9 +942,9 @@
   <string name="device_lenovo_P1a42_codename" translatable="false">P1a42</string>
   <string name="device_lenovo_P1a42_maintainer" translatable="false">Subham (DerkLord)</string>
 
-  <string name="device_Zuk_Z2" translatable="false">Zuk_Z2</string>
-  <string name="device_Zuk_Z2_codename" translatable="false"> Zuk_Z2</string>
-  <string name="device_Zuk_Z2_maintainer" translatable="false">Keerten </string>
+  <string name="device_z2_plus" translatable="false">Zuk Z2 PLUS</string>
+  <string name="device_z2_plus_codename" translatable="false"> z2_plus</string>
+  <string name="device_z2_plus_maintainer" translatable="false">Mr.ACAR </string>
 
   <string name="device_ville" translatable="false">HTC One S</string>
   <string name="device_ville_codename" translatable="false">Ville</string>
@@ -962,9 +962,9 @@
   <string name="device_helium_codename" translatable="false">Helium</string>
   <string name="device_helium_maintainer" translatable="false">ROMFACTORY(SARTHAKMALLA)</string>
    
-  <string name="device_Zuk_Z2_row" translatable="false">Zuk Z2 PRO</string>
-  <string name="device_Zuk_Z2_row_codename" translatable="false"> Zuk_Z2_ROW</string>
-  <string name="device_Zuk_Z2_row_maintainer" translatable="false">Mr.ACAR </string>   
+  <string name="device_z2_row" translatable="false">Zuk Z2 PRO</string>
+  <string name="device_z2_row_codename" translatable="false"> z2_row</string>
+  <string name="device_z2_row_maintainer" translatable="false">Mr.ACAR </string>   
   
   <string name="device_oxygen" translatable="false">Xiaomi Mi Max 2</string>
   <string name="device_oxygen_codename" translatable="false">oxygen</string>

--- a/res/values/rr_arrays.xml
+++ b/res/values/rr_arrays.xml
@@ -569,8 +569,8 @@
     </string-array>
 
     <string-array name="slimsizer_profile_array">
-        <item >Load Profile</item>
-        <item >Save Profile</item>
+        <item>@string/load_profile</item>
+        <item>@string/save_profile</item>
     </string-array>
 
      <!-- Ambient Music Ticker -->
@@ -948,7 +948,7 @@
         <item>@*android:drawable/settings</item>
         <item>@*android:drawable/skype</item>
         <item>@*android:drawable/soundscloud</item>
-        <item>@*android:drawable/spotifiy</item>	
+        <item>@*android:drawable/spotifiy</item>    
         <item>@*android:drawable/tapatalk</item>
         <item>@*android:drawable/tunein</item>
         <item>@*android:drawable/twitter</item>
@@ -1042,70 +1042,70 @@
 
      <!-- Recents Clear All Button Style -->
      <string-array name="recents_button_style" translatable="false">
-		<item>@string/button1</item>
-		<item>@string/button2</item>
-		<item>@string/button3</item>
-		<item>@string/button4</item>
-		<item>@string/button5</item>
-		<item>@string/button6</item>
-		<item>@string/button7</item>
-		<item>@string/button8</item>
-		<item>@string/button9</item>
-		<item>@string/button10</item>
-		<item>@string/button11</item>
-		<item>@string/button12</item>
-		<item>@string/button13</item>
-		<item>@string/button14</item>
-		<item>@string/button15</item>
-		<item>@string/button16</item>
-		<item>@string/button17</item>
-		<item>@string/button18</item>
-		<item>@string/button19</item>
-		<item>@string/button20</item>
-		<item>@string/button21</item>
-		<item>@string/button22</item>
-		<item>@string/button23</item>
-		<item>@string/button24</item>
-		<item>@string/button25</item>
-		<item>@string/button26</item>
-		<item>@string/button27</item>
-		<item>@string/button28</item>
-		<item>@string/button29</item>
-		<item>@string/button30</item>
+        <item>@string/button1</item>
+        <item>@string/button2</item>
+        <item>@string/button3</item>
+        <item>@string/button4</item>
+        <item>@string/button5</item>
+        <item>@string/button6</item>
+        <item>@string/button7</item>
+        <item>@string/button8</item>
+        <item>@string/button9</item>
+        <item>@string/button10</item>
+        <item>@string/button11</item>
+        <item>@string/button12</item>
+        <item>@string/button13</item>
+        <item>@string/button14</item>
+        <item>@string/button15</item>
+        <item>@string/button16</item>
+        <item>@string/button17</item>
+        <item>@string/button18</item>
+        <item>@string/button19</item>
+        <item>@string/button20</item>
+        <item>@string/button21</item>
+        <item>@string/button22</item>
+        <item>@string/button23</item>
+        <item>@string/button24</item>
+        <item>@string/button25</item>
+        <item>@string/button26</item>
+        <item>@string/button27</item>
+        <item>@string/button28</item>
+        <item>@string/button29</item>
+        <item>@string/button30</item>
      </string-array>
  
      <string-array name="recents_button_style_values" translatable="false">
-		<item>0</item>
-		<item>1</item>
-		<item>2</item>
-		<item>3</item>
-		<item>4</item>
-		<item>5</item>
-		<item>6</item>
-		<item>7</item>
-		<item>8</item>
-		<item>9</item>
-		<item>10</item>
-		<item>11</item>
-		<item>12</item>
-		<item>13</item>
-		<item>14</item>
-		<item>15</item>
-		<item>16</item>
-		<item>17</item>
-		<item>18</item>
-		<item>19</item>
-		<item>20</item>
-		<item>21</item>
-		<item>22</item>
-		<item>23</item>
-		<item>24</item>
-		<item>25</item>
-		<item>26</item>
-		<item>27</item>
-		<item>28</item>
-		<item>29</item>
-		<item>30</item>
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
+        <item>6</item>
+        <item>7</item>
+        <item>8</item>
+        <item>9</item>
+        <item>10</item>
+        <item>11</item>
+        <item>12</item>
+        <item>13</item>
+        <item>14</item>
+        <item>15</item>
+        <item>16</item>
+        <item>17</item>
+        <item>18</item>
+        <item>19</item>
+        <item>20</item>
+        <item>21</item>
+        <item>22</item>
+        <item>23</item>
+        <item>24</item>
+        <item>25</item>
+        <item>26</item>
+        <item>27</item>
+        <item>28</item>
+        <item>29</item>
+        <item>30</item>
      </string-array>
 
 
@@ -1130,29 +1130,29 @@
     </string-array>
 
     <string-array name="fab_animation_style_values" translatable="false">
-		<item>0</item>
-		<item>1</item>
-		<item>2</item>
-		<item>3</item>
-		<item>4</item>
-		<item>5</item>
-		<item>6</item>
-		<item>7</item>
-		<item>8</item>
-		<item>9</item>
-		<item>10</item>
-		<item>11</item>
-		<item>12</item>
-		<item>13</item>
-		<item>14</item>
-		<item>15</item>
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
+        <item>6</item>
+        <item>7</item>
+        <item>8</item>
+        <item>9</item>
+        <item>10</item>
+        <item>11</item>
+        <item>12</item>
+        <item>13</item>
+        <item>14</item>
+        <item>15</item>
     </string-array>
 
     <!-- Status bar logo position-->
     <string-array name="custom_logo_position_entries" translatable="false">
         <item>@string/status_bar_logo_disabled</item>
-		<item>@string/status_bar_logo_position_left</item>
-		<item>@string/status_bar_logo_position_right</item>
+        <item>@string/status_bar_logo_position_left</item>
+        <item>@string/status_bar_logo_position_right</item>
     </string-array>
 
     <string-array name="custom_logo_position_values" translatable="false">
@@ -1205,7 +1205,7 @@
         <item>@string/logo39</item>
         <item>@string/logo40</item>
         <item>@string/logo41</item>
-        <item>@string/logo42</item>	
+        <item>@string/logo42</item> 
         <item>@string/logo43</item>
     </string-array>
 
@@ -1540,15 +1540,15 @@
     </string-array>
 
     <string-array name="smart_pixels_shift_times">
-        <item>15 seconds</item>
-        <item>30 seconds</item>
-        <item>1 minute</item>
-        <item>2 minutes</item>
-        <item>5 minutes</item>
-        <item>10 minutes</item>
-        <item>20 minutes</item>
-        <item>30 minutes</item>
-        <item>1 hour</item>
+        <item>@string/smart_pixels_shift_times_15s</item>
+        <item>@string/smart_pixels_shift_times_30s</item>
+        <item>@string/smart_pixels_shift_times_1min</item>
+        <item>@string/smart_pixels_shift_times_2min</item>
+        <item>@string/smart_pixels_shift_times_5min</item>
+        <item>@string/smart_pixels_shift_times_10min</item>
+        <item>@string/smart_pixels_shift_times_20min</item>
+        <item>@string/smart_pixels_shift_times_30min</item>
+        <item>@string/smart_pixels_shift_times_1h</item>
     </string-array>
 
     <string-array name="smart_pixels_shift_values">
@@ -1655,9 +1655,9 @@
     </string-array>
 
     <string-array name="edge_gestures_back_edges_labels">
-        <item>Left</item>
-        <item>Right</item>
-        <item>Both sides</item>
+        <item>@string/edge_gestures_back_edges_left_side</item>
+        <item>@string/edge_gestures_back_edges_right_side</item>
+        <item>@string/edge_gestures_back_edges_both_sides</item>
     </string-array>
 
 </resources>

--- a/res/values/rr_strings.xml
+++ b/res/values/rr_strings.xml
@@ -106,6 +106,7 @@
     <string name="github_akhilnarang">https://github.com/akhilnarang</string>
     <string name="github_bdogg718k">https://github.com/bdogg718k</string>
     <string name="github_apascual89">https://github.com/apascual89</string> 
+    <string name="github_mracar">https://github.com/mracar07</string> 
     <string name="rr">Links</string>
     <string name="rr_website_title">Website</string>
     <string name="rr_website_summary">Get more information about Resurrection Remix OS</string>
@@ -138,7 +139,7 @@
     <string name="christopher_kardas_summary">● Moderator\n● Editor\n● Contributor</string>
     <string name="matt_summary">● Moderator\n● Editor\n● Contributor</string>
     <string name="justen_summary">● Moderator\n● Editor\n● Contributor</string>
-
+    <string name="mracar_summary">● Developer\n● Maintainer</string>
 
     <string name="support_team_title">Moderator Tag</string>
 

--- a/res/values/rr_strings.xml
+++ b/res/values/rr_strings.xml
@@ -217,7 +217,8 @@
     <string name="rr_statusbar_title">Status bar</string>
     <string name="rr_sb_gestures_title">Status bar gestures</string>
     <string name="qs_advanced_title">Advanced</string>
-    <string name="rr_notification_panel_title">Panels</string>
+    <string name="rr_notification_panel_title">Notification panel</string>
+    <string name="rr_panels_title">Panels</string>
     <string name="rr_tuner">System UI tuner</string>
     <string name="rr_tuner_summary">Part of stock customizations</string>
     <string name="rr_battery">Battery</string>
@@ -1207,6 +1208,8 @@
     <string name="delete_success">Deleted</string>
     <string name="delete_fail">Unable to delete</string>
     <string name="btn_profile">Profile</string>
+    <string name="load_profile">Load Profile</string>
+    <string name="save_profile">Save Profile</string>
     <string name="sizer_message_sdnowrite">Cannot write to SD Card.</string>
     <string name="sizer_message_sdnoread">Cannot read SD Card.</string>
     <string name="sizer_message_filesuccess">Created profile.</string>
@@ -1930,12 +1933,21 @@
     <string name="smart_pixels_on_power_save_summary">Enable Smart Pixels when battery saver is enabled</string>
     <string name="smart_pixels_percent">Percent of pixels to disable</string>
     <string name="smart_pixels_shift">Prevent burn-in by shifting pixels every</string>
+    <string name="smart_pixels_shift_times_15s">15 seconds</string>
+    <string name="smart_pixels_shift_times_30s">30 seconds</string>
+    <string name="smart_pixels_shift_times_1min">1 minute</string>
+    <string name="smart_pixels_shift_times_2min">2 minutes</string>
+    <string name="smart_pixels_shift_times_5min">5 minutes</string>
+    <string name="smart_pixels_shift_times_10min">10 minutes</string>
+    <string name="smart_pixels_shift_times_20min">20 minutes</string>
+    <string name="smart_pixels_shift_times_30min">30 minutes</string>
+    <string name="smart_pixels_shift_times_1h">1 hour</string>
 
     <!-- QS footer icons -->
     <string name="qs_footer_services_title">Show Running Services icon</string>
     <string name="qs_footer_services_summary">Display Running Services icon in quick settings footer</string>
     <string name="qs_footer_settings_title">Show Settings icon</string>
-    <string name="qs_footer_settings_summary">Display Settings icon in quick settings footer</string>	
+    <string name="qs_footer_settings_summary">Display Settings icon in quick settings footer</string>   
 
     <!-- Recents Grid -->
     <string name="recents_grid_title">Recents grid</string>
@@ -1982,10 +1994,14 @@
 
     <!-- Edge gestures -->
     <string name="edge_gestures_title">Edge gestures</string>
+    <string name="edge_gestures_description">Swipe from bottom to trigger Home gesture. Keep it pressed to open recents. Swipe from bottom left or bottom right to go back.</string>
     <string name="edge_gestures_feedback_duration_title">Haptic feedback duration</string>
     <string name="edge_gestures_long_press_delay_title">Delay until long press action starts</string>
     <string name="edge_gestures_back_category_title">Back gesture</string>
     <string name="edge_gestures_back_edges_title">Trigger back gesture from</string>
+    <string name="edge_gestures_back_edges_left_side">Left</string>
+    <string name="edge_gestures_back_edges_right_side">Right</string>
+    <string name="edge_gestures_back_edges_both_sides">Both sides</string>
     <string name="edge_gestures_landscape_back_edges_title">Trigger back gesture on landscape from</string>
     <string name="edge_gestures_back_screen_percent_title">Back gesture must start below this percentage of the screen</string>
     <string name="edge_gestures_back_screen_percent_summary">Trigger below % of screen</string>

--- a/res/xml/about_rom.xml
+++ b/res/xml/about_rom.xml
@@ -194,17 +194,17 @@
     </PreferenceCategory>        
     
        <PreferenceCategory
-            android:key="support_team_three"
-            android:title="@string/support_team_title">
+            android:key="dev_categorie_six"
+            android:title="@string/dev_categorie_title">
 
        <com.android.settings.widgets.DeveloperPreference
-            android:title="Christopher Kardas"
+            android:title="Mr. Acar"
             android:icon="@drawable/rr_dev_one_icon"
-            android:summary="@string/christopher_kardas_summary"
-            resurrection:nameDev="Christopher Kardas"
-            resurrection:gplusHandle="ChristopherKardas"
-            resurrection:donateLink="@string/github_bdogg718k"
-            resurrection:emailDev="noname@gmail.com"/>
+            android:summary="@string/mracar_summary"
+            resurrection:nameDev="Mr. Acar"
+            resurrection:gplusHandle="101125726535583243694"
+            resurrection:donateLink="@string/github_mracar"
+            resurrection:emailDev="mracar07@gmail.com"/>
     </PreferenceCategory>             
             
        <PreferenceCategory

--- a/res/xml/app_data_usage.xml
+++ b/res/xml/app_data_usage.xml
@@ -50,6 +50,16 @@
             android:title="@string/data_usage_app_settings" />
 
         <SwitchPreference
+            android:key="restrict_wlan"
+            android:title="@string/data_usage_app_restrict_wifi"
+            android:summary="@string/data_usage_app_restrict_wifi_summary" />
+
+        <SwitchPreference
+            android:key="restrict_data"
+            android:title="@string/data_usage_app_restrict_data"
+            android:summary="@string/data_usage_app_restrict_data_summary" />
+
+        <SwitchPreference
             android:key="restrict_background"
             android:title="@string/data_usage_app_restrict_background"
             android:summary="@string/data_usage_app_restrict_background_summary" />

--- a/res/xml/device_maintainers_fragment.xml
+++ b/res/xml/device_maintainers_fragment.xml
@@ -33,6 +33,13 @@
             app:codename="@string/device_genericarmaonly_codename"
             app:maintainer="@string/device_genericarmaonly_maintainer"
             app:type="phone" />
+
+        <com.android.settings.rr.Preferences.DevicePreference
+            android:id="@+id/device_generichkirin"
+            android:title="@string/device_generichkirin"
+            app:codename="@string/device_generichkirin_codename"
+            app:maintainer="@string/device_generichkirin_maintainer"
+            app:type="phone" />
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/res/xml/device_maintainers_fragment.xml
+++ b/res/xml/device_maintainers_fragment.xml
@@ -10,6 +10,32 @@
          android:selectable="false" />
 
     <PreferenceCategory
+        android:id="@+id/device_category_generic"
+	android:title="@string/device_category_generic_title">
+
+        <com.android.settings.rr.Preferences.DevicePreference
+            android:id="@+id/device_genericarm64aonly"
+            android:title="@string/device_genericarm64aonly"
+            app:codename="@string/device_genericarm64aonly_codename"
+            app:maintainer="@string/device_genericarm64aonly_maintainer"
+	    app:type="phone" />
+
+        <com.android.settings.rr.Preferences.DevicePreference
+            android:id="@+id/device_genericarm64ab"
+            android:title="@string/device_genericarm64ab"
+            app:codename="@string/device_genericarm64ab_codename"
+            app:maintainer="@string/device_genericarm64ab_maintainer"
+            app:type="phone" />
+
+        <com.android.settings.rr.Preferences.DevicePreference
+            android:id="@+id/device_genericarmaonly"
+            android:title="@string/device_genericarmaonly"
+            app:codename="@string/device_genericarmaonly_codename"
+            app:maintainer="@string/device_genericarmaonly_maintainer"
+            app:type="phone" />
+    </PreferenceCategory>
+
+    <PreferenceCategory
         android:id="@+id/device_category_lg"
         android:title="@string/device_category_lg_title">
 

--- a/res/xml/device_maintainers_fragment.xml
+++ b/res/xml/device_maintainers_fragment.xml
@@ -730,6 +730,13 @@
             app:codename="@string/device_ms013g_codename"
             app:maintainer="@string/device_ms013g_maintainer"
             app:type="phone" />
+        
+        <com.android.settings.rr.Preferences.DevicePreference
+            android:id="@+id/device_on7xelte"
+            android:title="@string/device_on7xelte"
+            app:codename="@string/device_on7xelte_codename"
+            app:maintainer="@string/device_on7xelte_maintainer"
+            app:type="phone" />
 
     </PreferenceCategory>
 

--- a/res/xml/device_maintainers_fragment.xml
+++ b/res/xml/device_maintainers_fragment.xml
@@ -1423,6 +1423,13 @@
             app:type="phone" />
 
         <com.android.settings.rr.Preferences.DevicePreference
+            android:id="@+id/device_nubia_nx511j"
+            android:title="@string/device_nubia_nx511j"
+            app:codename="@string/device_nubia_nx511j_codename"
+            app:maintainer="@string/device_nubia_nx511j_maintainer"
+            app:type="phone" />
+
+        <com.android.settings.rr.Preferences.DevicePreference
             android:id="@+id/device_nubia_nx512j"
             android:title="@string/device_nubia_nx512j"
             app:codename="@string/device_nubia_nx512j_codename"

--- a/res/xml/device_maintainers_fragment.xml
+++ b/res/xml/device_maintainers_fragment.xml
@@ -1109,6 +1109,12 @@
             app:maintainer="@string/device_mido_maintainer"
             app:type="phone" />
         <com.android.settings.rr.Preferences.DevicePreference
+            android:id="@+id/device_vince"
+            android:title="@string/device_vince"
+            app:codename="@string/device_vince_codename"
+            app:maintainer="@string/device_vince_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preferences.DevicePreference
             android:id="@+id/device_whyred"
             android:title="@string/device_whyred"
             app:codename="@string/device_whyred_codename"

--- a/res/xml/device_maintainers_fragment.xml
+++ b/res/xml/device_maintainers_fragment.xml
@@ -1418,17 +1418,17 @@
             app:type="phone" />
 
         <com.android.settings.rr.Preferences.DevicePreference
-            android:id="@+id/device_Zuk_Z2"
-            android:title="@string/device_Zuk_Z2"
-            app:codename="@string/device_Zuk_Z2_codename"
-            app:maintainer="@string/device_Zuk_Z2_maintainer"
+            android:id="@+id/device_z2_plus"
+            android:title="@string/device_z2_plus"
+            app:codename="@string/device_z2_plus_codename"
+            app:maintainer="@string/device_z2_plus_maintainer"
             app:type="phone" />
         
         <com.android.settings.rr.Preferences.DevicePreference
-            android:id="@+id/device_Zuk_Z2_row"
-            android:title="@string/device_Zuk_Z2_row"
-            app:codename="@string/device_Zuk_Z2_row_codename"
-            app:maintainer="@string/device_Zuk_Z2_row_maintainer"
+            android:id="@+id/device_z2_row"
+            android:title="@string/device_z2_row"
+            app:codename="@string/device_z2_row_codename"
+            app:maintainer="@string/device_z2_row_maintainer"
             app:type="phone" />
     </PreferenceCategory>
 

--- a/res/xml/device_maintainers_fragment.xml
+++ b/res/xml/device_maintainers_fragment.xml
@@ -526,6 +526,12 @@
             app:maintainer="@string/device_j5ltexx_maintainer"
             app:type="phone" />
         <com.android.settings.rr.Preferences.DevicePreference
+            android:id="@+id/device_a3xelte"
+            android:title="@string/device_a3xelte"
+            app:codename="@string/device_a3xelte_codename"
+            app:maintainer="@string/device_a3xelte_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preferences.DevicePreference
             android:id="@+id/device_a3y17lte"
             android:title="@string/device_a3y17lte"
             app:codename="@string/device_a3y17lte_codename"

--- a/res/xml/device_maintainers_fragment.xml
+++ b/res/xml/device_maintainers_fragment.xml
@@ -1341,7 +1341,14 @@
             app:codename="@string/device_Z00D_codename"
             app:maintainer="@string/device_Z00D_maintainer"
             app:type="phone" />
-        
+
+        <com.android.settings.rr.Preferences.DevicePreference
+            android:id="@+id/device_X00TD"
+            android:title="@string/device_X00TD"
+            app:codename="@string/device_X00TD_codename"
+            app:maintainer="@string/device_X00TD_maintainer"
+            app:type="phone" />
+
         <com.android.settings.rr.Preferences.DevicePreference
             android:id="@+id/device_zenfone3"
             android:title="@string/device_zenfone3"

--- a/res/xml/device_maintainers_fragment.xml
+++ b/res/xml/device_maintainers_fragment.xml
@@ -1341,6 +1341,13 @@
             app:codename="@string/device_Z00D_codename"
             app:maintainer="@string/device_Z00D_maintainer"
             app:type="phone" />
+        
+        <com.android.settings.rr.Preferences.DevicePreference
+            android:id="@+id/device_zenfone3"
+            android:title="@string/device_zenfone3"
+            app:codename="@string/device_zenfone3_codename"
+            app:maintainer="@string/device_zenfone3_maintainer"
+            app:type="phone" />
 
     </PreferenceCategory>
 

--- a/res/xml/device_maintainers_fragment.xml
+++ b/res/xml/device_maintainers_fragment.xml
@@ -1158,12 +1158,6 @@
             app:maintainer="@string/device_land_maintainer"
             app:type="phone" />
         <com.android.settings.rr.Preferences.DevicePreference
-            android:id="@+id/device_piccolo"
-            android:title="@string/device_piccolo"
-            app:codename="@string/device_piccolo_codename"
-            app:maintainer="@string/device_piccolo_maintainer"
-            app:type="phone" />
-        <com.android.settings.rr.Preferences.DevicePreference
             android:id="@+id/device_santoni"
             android:title="@string/device_santoni"
             app:codename="@string/device_santoni_codename"
@@ -1403,6 +1397,12 @@
             android:title="@string/device_paella"
             app:codename="@string/device_paella_codename"
             app:maintainer="@string/device_paella_maintainer"
+            app:type="phone" />
+        <com.android.settings.rr.Preferences.DevicePreference
+            android:id="@+id/device_piccolo"
+            android:title="@string/device_piccolo"
+            app:codename="@string/device_piccolo_codename"
+            app:maintainer="@string/device_piccolo_maintainer"
             app:type="phone" />
     </PreferenceCategory>
 

--- a/res/xml/expanded_desktop_prefs.xml
+++ b/res/xml/expanded_desktop_prefs.xml
@@ -14,13 +14,13 @@
      limitations under the License.
 -->
 
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-    <PreferenceCategory
-            android:title="@string/expanded_desktop_title" >
-        <ListPreference
-                android:key="expanded_desktop_style"
-                android:title="@string/expanded_desktop_style"
-                android:entries="@array/expanded_desktop_entries"
-                android:entryValues="@array/expanded_desktop_values"/>
-    </PreferenceCategory>
+<PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:settings="http://schemas.android.com/apk/res/com.android.settings"
+    android:title="@string/expanded_desktop_title">
+    <ListPreference
+        android:key="expanded_desktop_style"
+        android:title="@string/expanded_desktop_style"
+        android:entries="@array/expanded_desktop_entries"
+        android:entryValues="@array/expanded_desktop_values"/>
 </PreferenceScreen>

--- a/res/xml/rr_edge_gestures.xml
+++ b/res/xml/rr_edge_gestures.xml
@@ -26,7 +26,7 @@
         android:defaultValue="500" />
 
     <Preference android:key="edge_gestures_description"
-        android:summary="Swipe from bottom to trigger Home gesture, keep it pressed to open recents. Swipe from bottom left or bottom right to go back." />
+        android:summary="@string/edge_gestures_description" />
 
     <PreferenceCategory
         android:key="edge_gestures_category_back"

--- a/res/xml/rr_main_settings.xml
+++ b/res/xml/rr_main_settings.xml
@@ -28,7 +28,7 @@
 
     <PreferenceScreen
             android:id="@+id/rr_panels"
-            android:title="@string/rr_notification_panel_title"
+            android:title="@string/rr_panels_title"
             android:fragment="com.android.settings.rr.PanelSettings" 
 	    	android:icon="@drawable/rr_panel_icon" />
 

--- a/res/xml/security_settings_misc.xml
+++ b/res/xml/security_settings_misc.xml
@@ -21,9 +21,9 @@
     <PreferenceCategory android:title="@string/security_passwords_title"
             android:persistent="false">
 
-        <!-- Privacy Guard -->
+        <!-- Trust interface -->
         <org.lineageos.internal.lineageparts.LineagePartsPreference
-            android:key="privacy_guard_manager" />
+            android:key="trust_interface" />
 
         <Preference
             android:key="location"

--- a/src/com/android/settings/applications/AppOpsDetails.java
+++ b/src/com/android/settings/applications/AppOpsDetails.java
@@ -100,6 +100,7 @@ public class AppOpsDetails extends SettingsPreferenceFragment {
     private static HashMap<Integer, Integer> OP_ICONS = new HashMap<>();
 
     static {
+        OP_ICONS.put(AppOpsManager.OP_ACTIVATE_VPN, R.drawable.ic_perm_vpn);
         OP_ICONS.put(AppOpsManager.OP_AUDIO_ALARM_VOLUME, R.drawable.ic_perm_alarm);
         OP_ICONS.put(AppOpsManager.OP_BLUETOOTH_CHANGE, R.drawable.ic_perm_bluetooth);
         OP_ICONS.put(AppOpsManager.OP_BOOT_COMPLETED, R.drawable.ic_perm_boot);

--- a/src/com/android/settings/applications/AppOpsDetails.java
+++ b/src/com/android/settings/applications/AppOpsDetails.java
@@ -202,7 +202,12 @@ public class AppOpsDetails extends SettingsPreferenceFragment {
                 if (icon == null && op != 0 && OP_ICONS.containsKey(op)) {
                     icon = getActivity().getDrawable(OP_ICONS.get(op));
                 }
-                icon.setTint(Utils.getColorAttr(getActivity(), android.R.attr.colorControlNormal));
+                if (icon == null) {
+                    Log.e(TAG, "Failed to retrieve icon for permission: " + perm);
+                } else {
+                    icon.setTint(Utils.getColorAttr(getActivity(),
+                            android.R.attr.colorControlNormal));
+                }
 
                 final AppOpsManager.OpEntry firstOp = entry.getOpEntry(0);
                 final int switchOp = AppOpsManager.opToSwitch(firstOp.getOp());

--- a/src/com/android/settings/datausage/AppDataUsage.java
+++ b/src/com/android/settings/datausage/AppDataUsage.java
@@ -15,6 +15,8 @@
 package com.android.settings.datausage;
 
 import static android.net.NetworkPolicyManager.POLICY_REJECT_METERED_BACKGROUND;
+import static android.net.NetworkPolicyManager.POLICY_REJECT_ON_DATA;
+import static android.net.NetworkPolicyManager.POLICY_REJECT_ON_WLAN;
 
 import android.app.Activity;
 import android.app.LoaderManager;
@@ -26,6 +28,7 @@ import android.content.pm.PackageManager;
 import android.graphics.drawable.Drawable;
 import android.net.INetworkStatsSession;
 import android.net.NetworkPolicy;
+import android.net.NetworkPolicyManager;
 import android.net.NetworkStatsHistory;
 import android.net.NetworkTemplate;
 import android.net.TrafficStats;
@@ -68,6 +71,8 @@ public class AppDataUsage extends DataUsageBase implements Preference.OnPreferen
     private static final String KEY_BACKGROUND_USAGE = "background_usage";
     private static final String KEY_APP_SETTINGS = "app_settings";
     private static final String KEY_RESTRICT_BACKGROUND = "restrict_background";
+    private static final String KEY_RESTRICT_DATA = "restrict_data";
+    private static final String KEY_RESTRICT_WLAN = "restrict_wlan";
     private static final String KEY_APP_LIST = "app_list";
     private static final String KEY_CYCLE = "cycle";
     private static final String KEY_UNRESTRICTED_DATA = "unrestricted_data_saver";
@@ -82,6 +87,8 @@ public class AppDataUsage extends DataUsageBase implements Preference.OnPreferen
     private Preference mBackgroundUsage;
     private Preference mAppSettings;
     private SwitchPreference mRestrictBackground;
+    private SwitchPreference mRestrictData;
+    private SwitchPreference mRestrictWlan;
     private PreferenceCategory mAppList;
 
     private Drawable mIcon;
@@ -95,6 +102,7 @@ public class AppDataUsage extends DataUsageBase implements Preference.OnPreferen
     private ChartData mChartData;
     private NetworkTemplate mTemplate;
     private NetworkPolicy mPolicy;
+    private NetworkPolicyManager mPolicyManager;
     private AppItem mAppItem;
     private Intent mAppSettingsIntent;
     private SpinnerPreference mCycle;
@@ -113,6 +121,7 @@ public class AppDataUsage extends DataUsageBase implements Preference.OnPreferen
             throw new RuntimeException(e);
         }
 
+        mPolicyManager = NetworkPolicyManager.from(getContext());
         mAppItem = (args != null) ? (AppItem) args.getParcelable(ARG_APP_ITEM) : null;
         mTemplate = (args != null) ? (NetworkTemplate) args.getParcelable(ARG_NETWORK_TEMPLATE)
                 : null;
@@ -160,9 +169,15 @@ public class AppDataUsage extends DataUsageBase implements Preference.OnPreferen
             if (!UserHandle.isApp(mAppItem.key)) {
                 removePreference(KEY_UNRESTRICTED_DATA);
                 removePreference(KEY_RESTRICT_BACKGROUND);
+                removePreference(KEY_RESTRICT_DATA);
+                removePreference(KEY_RESTRICT_WLAN);
             } else {
                 mRestrictBackground = (SwitchPreference) findPreference(KEY_RESTRICT_BACKGROUND);
                 mRestrictBackground.setOnPreferenceChangeListener(this);
+                mRestrictData = (SwitchPreference) findPreference(KEY_RESTRICT_DATA);
+                mRestrictData.setOnPreferenceChangeListener(this);
+                mRestrictWlan = (SwitchPreference) findPreference(KEY_RESTRICT_WLAN);
+                mRestrictWlan.setOnPreferenceChangeListener(this);
                 mUnrestrictedData = (SwitchPreference) findPreference(KEY_UNRESTRICTED_DATA);
                 mUnrestrictedData.setOnPreferenceChangeListener(this);
             }
@@ -202,6 +217,8 @@ public class AppDataUsage extends DataUsageBase implements Preference.OnPreferen
             removePreference(KEY_UNRESTRICTED_DATA);
             removePreference(KEY_APP_SETTINGS);
             removePreference(KEY_RESTRICT_BACKGROUND);
+            removePreference(KEY_RESTRICT_DATA);
+            removePreference(KEY_RESTRICT_WLAN);
             removePreference(KEY_APP_LIST);
         }
     }
@@ -238,6 +255,14 @@ public class AppDataUsage extends DataUsageBase implements Preference.OnPreferen
             mDataSaverBackend.setIsBlacklisted(mAppItem.key, mPackageName, !(Boolean) newValue);
             updatePrefs();
             return true;
+        } else if (preference == mRestrictData) {
+            setAppRestrictData(!(Boolean) newValue);
+            updatePrefs();
+            return true;
+        } else if (preference == mRestrictWlan) {
+            setAppRestrictWlan(!(Boolean) newValue);
+            updatePrefs();
+            return true;
         } else if (preference == mUnrestrictedData) {
             mDataSaverBackend.setIsWhitelisted(mAppItem.key, mPackageName, (Boolean) newValue);
             return true;
@@ -258,18 +283,33 @@ public class AppDataUsage extends DataUsageBase implements Preference.OnPreferen
 
     @VisibleForTesting
     void updatePrefs() {
-        updatePrefs(getAppRestrictBackground(), getUnrestrictData());
+        updatePrefs(getAppRestrictBackground(), getUnrestrictData(),
+                getAppRestrictData(), getAppRestrictWlan());
     }
 
-    private void updatePrefs(boolean restrictBackground, boolean unrestrictData) {
+    private void updatePrefs(boolean restrictBackground, boolean unrestrictData,
+            boolean restrictData, boolean restrictWlan) {
         if (mRestrictBackground != null) {
-            mRestrictBackground.setChecked(!restrictBackground);
+            if (restrictData) {
+                mRestrictBackground.setEnabled(false);
+                mRestrictBackground.setChecked(false);
+            } else {
+                mRestrictBackground.setEnabled(true);
+                mRestrictBackground.setChecked(!restrictBackground);
+            }
+        }
+        if (mRestrictData != null) {
+            mRestrictData.setChecked(!restrictData);
+        }
+        if (mRestrictWlan != null) {
+            mRestrictWlan.setChecked(!restrictWlan);
         }
         if (mUnrestrictedData != null) {
-            if (restrictBackground) {
-                mUnrestrictedData.setVisible(false);
+            if (restrictData || restrictBackground) {
+                mUnrestrictedData.setEnabled(false);
+                mUnrestrictedData.setChecked(false);
             } else {
-                mUnrestrictedData.setVisible(true);
+                mUnrestrictedData.setEnabled(true);
                 mUnrestrictedData.setChecked(unrestrictData);
             }
         }
@@ -307,9 +347,15 @@ public class AppDataUsage extends DataUsageBase implements Preference.OnPreferen
     }
 
     private boolean getAppRestrictBackground() {
-        final int uid = mAppItem.key;
-        final int uidPolicy = services.mPolicyManager.getUidPolicy(uid);
-        return (uidPolicy & POLICY_REJECT_METERED_BACKGROUND) != 0;
+        return getAppRestriction(POLICY_REJECT_METERED_BACKGROUND);
+    }
+
+    private boolean getAppRestrictData() {
+        return getAppRestriction(POLICY_REJECT_ON_DATA);
+    }
+
+    private boolean getAppRestrictWlan() {
+        return getAppRestriction(POLICY_REJECT_ON_WLAN);
     }
 
     private boolean getUnrestrictData() {
@@ -317,6 +363,29 @@ public class AppDataUsage extends DataUsageBase implements Preference.OnPreferen
             return mDataSaverBackend.isWhitelisted(mAppItem.key);
         }
         return false;
+    }
+
+    private boolean getAppRestriction(int policy) {
+        final int uid = mAppItem.key;
+        final int uidPolicy = services.mPolicyManager.getUidPolicy(uid);
+        return (uidPolicy & policy) != 0;
+    }
+
+    private void setAppRestrictData(boolean restrict) {
+        setAppRestriction(POLICY_REJECT_ON_DATA, restrict);
+    }
+
+    private void setAppRestrictWlan(boolean restrict) {
+        setAppRestriction(POLICY_REJECT_ON_WLAN, restrict);
+    }
+
+    private void setAppRestriction(int policy, boolean restrict) {
+        final int uid = mAppItem.key;
+        if (restrict) {
+            mPolicyManager.addUidPolicy(uid, policy);
+        } else {
+            mPolicyManager.removeUidPolicy(uid, policy);
+        }
     }
 
     @Override
@@ -422,14 +491,16 @@ public class AppDataUsage extends DataUsageBase implements Preference.OnPreferen
     @Override
     public void onWhitelistStatusChanged(int uid, boolean isWhitelisted) {
         if (mAppItem.uids.get(uid, false)) {
-            updatePrefs(getAppRestrictBackground(), isWhitelisted);
+            updatePrefs(getAppRestrictBackground(), isWhitelisted,
+                    getAppRestrictData(), getAppRestrictWlan());
         }
     }
 
     @Override
     public void onBlacklistStatusChanged(int uid, boolean isBlacklisted) {
         if (mAppItem.uids.get(uid, false)) {
-            updatePrefs(isBlacklisted, getUnrestrictData());
+            updatePrefs(isBlacklisted, getUnrestrictData(),
+                    getAppRestrictData(), getAppRestrictWlan());
         }
     }
 }

--- a/src/com/android/settings/rr/MainSettingsLayout.java
+++ b/src/com/android/settings/rr/MainSettingsLayout.java
@@ -404,7 +404,7 @@ public class MainSettingsLayout extends SettingsPreferenceFragment {
         if (mStyle == 0) {
         titleString = new String[]{
                 getString(R.string.rr_statusbar_title),
-                getString(R.string.rr_notification_panel_title),
+                getString(R.string.rr_panels_title),
                 getString(R.string.rr_qs_title),
                 getString(R.string.rr_recents_title),
                 getString(R.string.rr_ui_title),

--- a/src/com/android/settings/rr/MainSettingsLayout.java
+++ b/src/com/android/settings/rr/MainSettingsLayout.java
@@ -456,7 +456,7 @@ public class MainSettingsLayout extends SettingsPreferenceFragment {
         String titleString[];
         titleString = new String[]{
                 getString(R.string.rr_statusbar_title),
-                getString(R.string.rr_notification_panel_title),
+                getString(R.string.rr_panels_title),
                 getString(R.string.rr_buttons_title),
                 getString(R.string.rr_ui_title),
                 getString(R.string.rr_misc_title)};

--- a/src/com/android/settings/rr/ScreenShotSettings.java
+++ b/src/com/android/settings/rr/ScreenShotSettings.java
@@ -22,6 +22,7 @@ import android.content.Intent;
 import android.content.res.Resources;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Handler;
 import android.os.SystemProperties;
 import android.os.UserHandle;
 import android.support.v7.preference.ListPreference;

--- a/src/com/android/settings/rr/ScreenshotEditPackageListAdapter.java
+++ b/src/com/android/settings/rr/ScreenshotEditPackageListAdapter.java
@@ -108,10 +108,10 @@ public class ScreenshotEditPackageListAdapter extends BaseAdapter implements Run
         if (convertView != null) {
             holder = (ViewHolder) convertView.getTag();
         } else {
-            convertView = mInflater.inflate(R.layout.preference_icon, null, false);
+            convertView = mInflater.inflate(R.layout.applist_preference_icon, null, false);
             holder = new ViewHolder();
             convertView.setTag(holder);
-            holder.title = (TextView) convertView.findViewById(R.id.title);
+            holder.title = (TextView) convertView.findViewById(com.android.internal.R.id.title);
             holder.icon = (ImageView) convertView.findViewById(R.id.icon);
         }
 


### PR DESCRIPTION
RR Oreo 6.1.0 doesn't have night light available. But if you create a widget on launcher using widgets>settings shortcut>night light, you can open it and a night light page will open. Its not functional though and nothing crashes even if you toggle it. Requires cleanup.
Thanks you.