### PR TITLE
port dashboard multicolumn layout from Omni

### DIFF
--- a/res/layout/dashboard_tile.xml
+++ b/res/layout/dashboard_tile.xml
@@ -21,7 +21,6 @@
     android:layout_height="wrap_content"
     android:background="?android:attr/selectableItemBackground"
     android:gravity="center_vertical"
-    android:minHeight="@dimen/dashboard_tile_minimum_height"
     android:clickable="true"
     android:focusable="true">
 
@@ -41,7 +40,7 @@
         <TextView android:id="@android:id/title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:singleLine="true"
+            android:maxLines="2"
             android:textAppearance="@style/TextAppearance.TileTitle"
             android:ellipsize="marquee"
             android:fadingEdge="horizontal" />
@@ -51,7 +50,7 @@
             android:layout_height="wrap_content"
             android:textAppearance="@style/TextAppearance.Small"
             android:textColor="?android:attr/textColorSecondary"
-            android:maxLines="1"
+            android:maxLines="2"
             android:ellipsize="end"
             android:paddingEnd="@dimen/dashboard_tile_image_margin" />
 

--- a/res/menu/options_menu.xml
+++ b/res/menu/options_menu.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2014 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/columns_menu"
+        android:title="@string/columns_menu"
+        android:showAsAction="never"
+        android:checkable="true"/>
+    <item
+        android:id="@+id/hide_summary_menu"
+        android:title="@string/hide_summary_menu"
+        android:showAsAction="never"
+        android:checkable="true" />
+</menu>

--- a/res/values/config.xml
+++ b/res/values/config.xml
@@ -30,7 +30,10 @@
     <integer name="maximum_user_dictionary_word_length" translatable="false">48</integer>
 
     <!-- Dashboard number of columns -->
-    <integer name="dashboard_num_columns">1</integer>
+    <integer name="dashboard_num_columns">2</integer>
+    
+    <!-- Dashboard hide summary of the tiles -->
+    <bool name="dashboard_hide_tile_summary">false</bool>
 
     <!-- Carrier_enabled editable -->
     <bool name="config_allow_edit_carrier_enabled" translatable="false">false</bool>

--- a/res/values/rr_dimens.xml
+++ b/res/values/rr_dimens.xml
@@ -197,4 +197,7 @@
     <dimen name="changelog_app_bar_height">200dp</dimen>
     <dimen name="changelog_header_big">22sp</dimen>
     <dimen name="changelog_header_small">16sp</dimen>
+    
+    <dimen name="dashboard_category_height">48dp</dimen>
+    <dimen name="dashboard_text_margin_end">10dp</dimen>
 </resources>

--- a/res/values/rr_strings.xml
+++ b/res/values/rr_strings.xml
@@ -2006,4 +2006,6 @@
     <string name="edge_gestures_back_screen_percent_title">Back gesture must start below this percentage of the screen</string>
     <string name="edge_gestures_back_screen_percent_summary">Trigger below % of screen</string>
  
+    <string name="columns_menu">Columns layout</string>
+    <string name="hide_summary_menu">Hide summary</string>
 </resources>

--- a/src/com/android/settings/dashboard/DashboardAdapter.java
+++ b/src/com/android/settings/dashboard/DashboardAdapter.java
@@ -85,6 +85,10 @@ public class DashboardAdapter extends RecyclerView.Adapter<DashboardAdapter.Dash
     private SuggestionDismissController mSuggestionDismissHandler;
     private SuggestionDismissController.Callback mCallback;
 
+    // omni additions start
+    private int mNumColumns = 1;
+    private boolean mHideSummary;
+
     @VisibleForTesting
     DashboardData mDashboardData;
 
@@ -469,12 +473,16 @@ public class DashboardAdapter extends RecyclerView.Adapter<DashboardAdapter.Dash
         } else {
             holder.icon.setImageDrawable(mCache.getIcon(tile.icon));
             holder.title.setText(tile.title);
-            if (!TextUtils.isEmpty(tile.summary)) {
+            if (!TextUtils.isEmpty(tile.summary) && !mHideSummary) {
                 holder.summary.setText(tile.summary);
                 holder.summary.setVisibility(View.VISIBLE);
             } else {
                 holder.summary.setVisibility(View.GONE);
             }
+            int minHeight = mContext.getResources().getDimensionPixelSize(mHideSummary ?
+                R.dimen.dashboard_category_height :
+                R.dimen.dashboard_tile_minimum_height);
+            holder.itemView.setMinimumHeight(minHeight);
         }
     }
 
@@ -539,6 +547,17 @@ public class DashboardAdapter extends RecyclerView.Adapter<DashboardAdapter.Dash
                 mSuggestionFeatureProvider.isSmartSuggestionEnabled(mContext));
     }
 
+    public boolean isPositionFullSpan(int position) {
+        final int type = mDashboardData.getItemTypeByPosition(position);
+        return type != R.layout.dashboard_tile;
+    }
+     public void setNumColumns(int numColumns) {
+        mNumColumns = numColumns;
+    }
+     public void setHideSummary(boolean hideSummary) {
+        mHideSummary = hideSummary;
+    }
+    
     public static class IconCache {
         private final Context mContext;
         private final ArrayMap<Icon, Drawable> mMap = new ArrayMap<>();


### PR DESCRIPTION
activated by default, can be overidden at build time by setting

    <!-- Dashboard number of columns -->
    <integer name="dashboard_num_columns">2</integer>
    <!-- Dashboard hide summary of the tiles -->
    <bool name="dashboard_hide_tile_summary">false</bool>

in 'res/values/config.xml'

courtesy of
https://gerrit.omnirom.org/#/c/android_packages_apps_Settings/+/21392/

Change-Id: I2c33229f76cc5e15627ae7389c69daf90a7eabdb