### PR TITLE
Settings: update LockscreenCharging preference key

### DIFF
--- a/res/xml/rr_lock.xml
+++ b/res/xml/rr_lock.xml
@@ -31,7 +31,7 @@
         android:defaultValue="false" />
 
     <com.rr.settings.preferences.SystemSettingSwitchPreference
-        android:key="lockscreen_charging_current"
+        android:key="lockscreen_battery_info"
         android:title="@string/lockscreen_charging_current_title"
         android:summary="@string/lockscreen_charging_current_summary"
         android:defaultValue="false" />


### PR DESCRIPTION
base commit is lockscreen_battery_info
https://github.com/ResurrectionRemix/android_frameworks_base/commit/045fe31514aa46db789ff0adb1a4f5a2a04a2151#diff-f940f15458a2b4627fa1252bd43b5facR4210

Change-Id: Ifc975cd0e76ccbe742d46ed84165e27cd5269254
Signed-off-by: Felipe Leon <fglfgl27@gmail.com>