### PR TITLE
Settings: re-add device Osprey

### DIFF
--- a/res/values/resurrection_device_maintainers_strings.xml
+++ b/res/values/resurrection_device_maintainers_strings.xml
@@ -548,6 +548,10 @@
   <string name="device_titan_codename" translatable="false">Titan</string>
   <string name="device_titan_maintainer" translatable="false">thedeadfish59</string>
 
+  <string name="device_osprey" translatable="false">Moto G 2015 </string>
+  <string name="device_osprey_codename" translatable="false">Osprey</string>
+  <string name="device_osprey_maintainer" translatable="false"></string>
+
   <string name="device_athene" translatable="false">Moto G4 Plus</string>
   <string name="device_athene_codename" translatable="false">athene</string>
   <string name="device_athene_maintainer" translatable="false">Joshua (jleeblanch)</string>


### PR DESCRIPTION
removed here
https://github.com/ResurrectionRemix/Resurrection_packages_apps_Settings/commit/20dc8bb5b3676f296f09a59f1ad4ccba006a26dc
but not from here
https://github.com/ResurrectionRemix/Resurrection_packages_apps_Settings/blob/pie/res/xml/device_maintainers_fragment.xml#L273-L277

Change-Id: I53b9bd6ace49e5aac665b41b618a234488539f34
Signed-off-by: Felipe Leon <fglfgl27@gmail.com>