### PR TITLE
Settings: Fix SystemSettingSeekBarPreference default value

### DIFF
--- a/src/com/android/settings/rr/Preferences/SystemSettingSeekBarPreference.java
+++ b/src/com/android/settings/rr/Preferences/SystemSettingSeekBarPreference.java
@@ -35,4 +35,9 @@ public class SystemSettingSeekBarPreference extends CustomSeekBarPreference {
         super(context, null);
         setPreferenceDataStore(new SystemSettingsStore(context.getContentResolver()));
     }
+
+    @Override
+    protected void onSetInitialValue(boolean restoreValue, Object defaultValue) {
+        setValue(restoreValue ? getPersistedInt((Integer) defaultValue) : (Integer) defaultValue);
+    }
 }


### PR DESCRIPTION
The SeekBarPreference show 0 as default value before the user do any change to the preference, after a clean install for example.

This fixes to show the default value of the preference.

Signed-off-by: Felipe Leon <fglfgl27@gmail.com>