### PR TITLE
Settings: ButtonBacklightBrightness add missing dialog buttons

### DIFF
--- a/src/com/android/settings/rr/input/ButtonBacklightBrightness.java
+++ b/src/com/android/settings/rr/input/ButtonBacklightBrightness.java
@@ -104,6 +104,18 @@ public class ButtonBacklightBrightness extends CustomDgPreference<AlertDialog> i
             public void onClick(DialogInterface dialog, int which) {
             }
         });
+        builder.setPositiveButton(R.string.save,
+                new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+            }
+        });
+        builder.setNegativeButton(R.string.cancel,
+                new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: Felipe Leon <fglfgl27@gmail.com>