### PR TITLE
Fix last date entry formatting, and added compact date format

### DIFF
--- a/res/values/rr_arrays.xml
+++ b/res/values/rr_arrays.xml
@@ -233,6 +233,7 @@
         <item>EEE MMM dd</item>
         <item>EEE MMMM dd</item>
         <item>EEEE dd/MM</item>
+        <item>EEEEE M/d</item>
     </string-array>
 
     <string-array name="clock_date_position_entries" translatable="false">

--- a/src/com/android/settings/rr/ClockSettings.java
+++ b/src/com/android/settings/rr/ClockSettings.java
@@ -232,20 +232,16 @@ public class ClockSettings extends SettingsPreferenceFragment implements
         int dateFormat = Settings.Secure.getInt(getActivity()
                 .getContentResolver(), Settings.Secure.STATUSBAR_CLOCK_DATE_STYLE, 0);
         for (int i = 0; i < dateEntries.length; i++) {
-            if (i == lastEntry) {
-                parsedDateEntries[i] = dateEntries[i];
+            String newDate;
+            CharSequence dateString = DateFormat.format(dateEntries[i], now);
+            if (dateFormat == CLOCK_DATE_STYLE_LOWERCASE) {
+                newDate = dateString.toString().toLowerCase();
+            } else if (dateFormat == CLOCK_DATE_STYLE_UPPERCASE) {
+                newDate = dateString.toString().toUpperCase();
             } else {
-                String newDate;
-                CharSequence dateString = DateFormat.format(dateEntries[i], now);
-                if (dateFormat == CLOCK_DATE_STYLE_LOWERCASE) {
-                    newDate = dateString.toString().toLowerCase();
-                } else if (dateFormat == CLOCK_DATE_STYLE_UPPERCASE) {
-                    newDate = dateString.toString().toUpperCase();
-                } else {
-                    newDate = dateString.toString();
-                }
-                 parsedDateEntries[i] = newDate;
+                newDate = dateString.toString();
             }
+            parsedDateEntries[i] = newDate;
         }
         mClockDateFormat.setEntries(parsedDateEntries);
     }


### PR DESCRIPTION
It looks like a bit of testing code forcing the display of the formatting code was left in.  
Removing that if statement makes the list appear correctly.  

Also added a compact date format which is useful on notched devices.  