### PR TITLE
Add Redmi K20 Pro/Mi 9T Pro Maintainer String

### DIFF
--- a/res/values/resurrection_device_maintainers_strings.xml
+++ b/res/values/resurrection_device_maintainers_strings.xml
@@ -1068,4 +1068,8 @@
   <string name="device_X01BD" translatable="false">Asus Zenfone Max Pro M2</string>
   <string name="device_X01BD_codename" translatable="false">X01BD</string>
   <string name="device_X01BD_maintainer" translatable="false"></string>
+
+  <string name="device_raphael" translatable="false">Redmi K20 Pro/Mi 9T Pro</string>
+  <string name="device_raphael_codename" translatable="false">raphael</string>
+  <string name="device_raphael_maintainer" translatable="false">Pavan Parmeshwar</string>
 </resources>

--- a/res/xml/device_maintainers_fragment.xml
+++ b/res/xml/device_maintainers_fragment.xml
@@ -1330,6 +1330,12 @@
             app:codename="@string/device_willow_codename"
             app:maintainer="@string/device_willow_maintainer"
             app:type="phone" />
+        <com.android.settings.rr.Preferences.DevicePreference
+            android:id="@+id/device_raphael"
+            android:title="@string/device_raphael"
+            app:codename="@string/device_raphael_codename"
+            app:maintainer="@string/device_raphael_maintainer"
+            app:type="phone" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
DT - https://github.com/pavanpaps/device_xiaomi_raphael/tree/Q
VT - https://github.com/pavanpaps/proprietary_vendor_xiaomi/tree/Q
Kernel: Prebuilt, Reason: Due to FOD being buggy on custom kernel and issues with DC dimming