### PR TITLE
Add Samsung Galaxy J6+ to Official list

### DIFF
--- a/res/values/resurrection_device_maintainers_strings.xml
+++ b/res/values/resurrection_device_maintainers_strings.xml
@@ -1206,7 +1206,11 @@
   <string name="device_j4primelte" translatable="false">Galaxy J4+</string>
   <string name="device_j4primelte_codename" translatable="false">j4primelte</string>
   <string name="device_j4primelte_maintainer" translatable="false">George Voudourhs</string>
-   
+
+  <string name="device_j6primelte" translatable="false">Galaxy J6+</string>
+  <string name="device_j6primelte_codename" translatable="false">j6primelte</string>
+  <string name="device_j6primelte_maintainer" translatable="false">Tiago Silva</string>
+
   <string name="device_a10" translatable="false">Samsung Galaxy a10</string>
   <string name="device_a10_codename" translatable="false">a10</string>
   <string name="device_a10_maintainer" translatable="false">Geckyn</string>

--- a/res/xml/device_maintainers_fragment.xml
+++ b/res/xml/device_maintainers_fragment.xml
@@ -785,7 +785,13 @@
             android:title="@string/device_j4primelte"
             app:codename="@string/device_j4primelte_codename"
             app:maintainer="@string/device_j4primelte_maintainer"
-            app:type="phone" />	
+            app:type="phone" />
+        <com.android.settings.rr.Preferences.DevicePreference
+            android:id="@+id/device_j6primelte"
+            android:title="@string/device_j6primelte"
+            app:codename="@string/device_j6primelte_codename"
+            app:maintainer="@string/device_j6primelte_maintainer"
+            app:type="phone" />
         <com.android.settings.rr.Preferences.DevicePreference
             android:id="@+id/device_a10"
             android:title="@string/device_a10"


### PR DESCRIPTION
Device Tree (Common): https://github.com/samsung-msm8917/android_device_samsung_msm8917-common
Device Tree J6+: https://github.com/samsung-msm8917/android_device_samsung_j6primelte
Vendor Tree: https://github.com/samsung-msm8917/android_vendor_samsung-common
Kernel: https://github.com/samsung-msm8917/android_kernel_samsung_msm8917

* We use common trees for j4+ and j6+. J4+ already has a maintainer but George only has j4+ and I can maintain the rom for j6+