### PR TITLE
set title after switching fragment

### DIFF
--- a/src/com/android/settings/network/telephony/MobileNetworkActivity.java
+++ b/src/com/android/settings/network/telephony/MobileNetworkActivity.java
@@ -222,6 +222,7 @@ public class MobileNetworkActivity extends SettingsBaseActivity {
             }
             navigation.setOnNavigationItemSelectedListener(item -> {
                 switchFragment(new MobileNetworkSettings(), item.getItemId());
+                getActionBar().setTitle(item.getTitle());
                 return true;
             });
         }


### PR DESCRIPTION
Bottom navigation bar shows two items while device is dual-sim supported, and the title should update while selected item of bottom navigation bar changed.