### PR TITLE
Added GSI support for 6 variations

### DIFF
--- a/res/values/resurrection_device_maintainers_strings.xml
+++ b/res/values/resurrection_device_maintainers_strings.xml
@@ -49,15 +49,27 @@
    
   <string name="device_genericarm64aonly" translatable="false">Generic System Image</string>
   <string name="device_genericarm64aonly_codename" translatable="false">ARM64 A-Only</string>
-  <string name="device_genericarm64aonly_maintainer" translatable="false"></string>
+  <string name="device_genericarm64aonly_maintainer" translatable="false">RobotHanzo</string>
 
   <string name="device_genericarm64ab" translatable="false">Generic System Image</string>
   <string name="device_genericarm64ab_codename" translatable="false">ARM64 AB</string>
-  <string name="device_genericarm64ab_maintainer" translatable="false"></string>
+  <string name="device_genericarm64ab_maintainer" translatable="false">RobotHanzo</string>
  
   <string name="device_genericarmaonly" translatable="false">Generic System Image</string>
   <string name="device_genericarmaonly_codename" translatable="false">ARM A-Only</string>
-  <string name="device_genericarmaonly_maintainer" translatable="false"></string>
+  <string name="device_genericarmaonly_maintainer" translatable="false">RobotHanzo</string>
+   
+  <string name="device_genericarmab" translatable="false">Generic System Image</string>
+  <string name="device_genericarmab_codename" translatable="false">ARM AB</string>
+  <string name="device_genericarmab_maintainer" translatable="false">RobotHanzo</string>
+   
+  <string name="device_generica64aonly" translatable="false">Generic System Image</string>
+  <string name="device_generica64aonly_codename" translatable="false">ARM32 with 64-bit Binder A-Only</string>
+  <string name="device_generica64aonly_maintainer" translatable="false">RobotHanzo</string>
+
+  <string name="device_generica64ab" translatable="false">Generic System Image</string>
+  <string name="device_generica64ab_codename" translatable="false">ARM32 with 64-bit Binder AB</string>
+  <string name="device_generica64ab_maintainer" translatable="false">RobotHanzo</string>
 
   <string name="device_generichkirin" translatable="false">Generic System Image</string>
   <string name="device_generichkirin_codename" translatable="false">Huawei Kirin</string>

--- a/res/xml/device_maintainers_fragment.xml
+++ b/res/xml/device_maintainers_fragment.xml
@@ -30,6 +30,24 @@
             app:codename="@string/device_genericarmaonly_codename"
             app:maintainer="@string/device_genericarmaonly_maintainer"
             app:type="phone" />
+	<com.android.settings.rr.Preferences.DevicePreference
+            android:id="@+id/device_genericarmab"
+            android:title="@string/device_genericarmab"
+            app:codename="@string/device_genericarmab_codename"
+            app:maintainer="@string/device_genericarmab_maintainer"
+            app:type="phone" />
+	<com.android.settings.rr.Preferences.DevicePreference
+            android:id="@+id/device_generica64aonly"
+            android:title="@string/device_generica64aonly"
+            app:codename="@string/device_genericar64only_codename"
+            app:maintainer="@string/device_generica64aonly_maintainer"
+            app:type="phone" />
+	<com.android.settings.rr.Preferences.DevicePreference
+            android:id="@+id/device_generica64ab"
+            android:title="@string/device_generica64ab"
+            app:codename="@string/device_generica64ab_codename"
+            app:maintainer="@string/device_generica64ab_maintainer"
+            app:type="phone" />
         <com.android.settings.rr.Preferences.DevicePreference
             android:id="@+id/device_generichkirin"
             android:title="@string/device_generichkirin"


### PR DESCRIPTION
Variations: armaonly, armab, a64aonly, a64ab, arm64aonly, arm64ab

XDA post: https://forum.xda-developers.com/t/10-0-unofficial-resurrection-remix-v8-6-5-gsi-arm-a64-arm64-aonly-ab.4219067/

Custom build script: https://github.com/RobotHanzo/treble_experimentations

Custom treble manifest: https://github.com/RobotHanzo/treble_manifest/tree/android-10.0

Custom device tree: https://github.com/RobotHanzo/device_phh_treble/tree/android-10.0

Telegram: https://t.me/RobotHanzo

Note: a64ab is tested on my gta3xlwifi device
Additional tests: arm64 ab is tested on my classmate's X01AD device