### PR TITLE
port bluetooth timeout setting [2/2]

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -3020,6 +3020,12 @@
             </intent-filter>
         </receiver>
 
+        <receiver android:name="com.android.settingslib.bluetooth.BluetoothTimeoutReceiver">
+            <intent-filter>
+                <action android:name="android.bluetooth.intent.TIMEOUT" />
+            </intent-filter>
+        </receiver>
+
         <!-- Watch for ContactsContract.Profile changes and update the user's photo.  -->
         <receiver android:name=".users.ProfileUpdateReceiver">
             <intent-filter>

--- a/res/values/rr_arrays.xml
+++ b/res/values/rr_arrays.xml
@@ -12,6 +12,50 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
+    <!-- Bluetooth settings.  The delay in inactivity before bluetooth is turned off. These are shown in a list dialog. -->
+    <string-array name="bluetooth_timeout_entries">
+        <item>@string/bluetooth_timeout_summary_never</item>
+        <item>@string/bluetooth_timeout_summary_15secs</item>
+        <item>@string/bluetooth_timeout_summary_30secs</item>
+        <item>@string/bluetooth_timeout_summary_1min</item>
+        <item>@string/bluetooth_timeout_summary_2mins</item>
+        <item>@string/bluetooth_timeout_summary_5mins</item>
+        <item>@string/bluetooth_timeout_summary_10mins</item>
+        <item>@string/bluetooth_timeout_summary_30mins</item>
+        <item>@string/bluetooth_timeout_summary_1hour</item>
+        <item>@string/bluetooth_timeout_summary_2hours</item>
+        <item>@string/bluetooth_timeout_summary_4hours</item>
+        <item>@string/bluetooth_timeout_summary_8hours</item>
+    </string-array>
+
+    <!-- Do not translate. -->
+    <string-array name="bluetooth_timeout_values" translatable="false">
+        <!-- Do not translate. -->
+        <item>0</item>
+        <!-- Do not translate. -->
+        <item>15000</item>
+        <!-- Do not translate. -->
+        <item>30000</item>
+        <!-- Do not translate. -->
+        <item>60000</item>
+        <!-- Do not translate. -->
+        <item>120000</item>
+        <!-- Do not translate. -->
+        <item>300000</item>
+        <!-- Do not translate. -->
+        <item>600000</item>
+        <!-- Do not translate. -->
+        <item>1800000</item>
+        <!-- Do not translate. -->
+        <item>3600000</item>
+        <!-- Do not translate. -->
+        <item>7200000</item>
+        <!-- Do not translate. -->
+        <item>14400000</item>
+        <!-- Do not translate. -->
+        <item>28800000</item>
+    </string-array>
+
     <!-- Refresh rate -->
     <string-array name="refresh_rate_entries">
         <item>@string/auto_refresh_rate</item>

--- a/res/values/rr_strings.xml
+++ b/res/values/rr_strings.xml
@@ -1994,6 +1994,26 @@
     <!-- Bluetooth status -->
     <string name="bluetooth_battery_title">Bluetooth battery status</string>
     <string name="bluetooth_battery_summary">Display battery status for the connected bluetooth device, if available</string>
+
+    <!-- Connected devices screen, setting option name to change bluetooth timeout -->
+    <string name="bluetooth_timeout">Bluetooth timeout</string>
+
+    <!-- Connected devices screen, setting option summary to change bluetooth timeout -->
+    <string name="bluetooth_timeout_summary">Bluetooth will turn off after <xliff:g id="timeout_description">%1$s</xliff:g> if no devices connected</string>
+    <string name="bluetooth_timeout_summary2">Do not automatically turn off Bluetooth</string>
+    <string name="bluetooth_timeout_summary_never">Never</string>
+    <string name="bluetooth_timeout_summary_15secs">15 seconds</string>
+    <string name="bluetooth_timeout_summary_30secs">30 seconds</string>
+    <string name="bluetooth_timeout_summary_1min">1 minute</string>
+    <string name="bluetooth_timeout_summary_2mins">2 minutes</string>
+    <string name="bluetooth_timeout_summary_5mins">5 minutes</string>
+    <string name="bluetooth_timeout_summary_10mins">10 minutes</string>
+    <string name="bluetooth_timeout_summary_30mins">30 minutes</string>
+    <string name="bluetooth_timeout_summary_1hour">1 hour</string>
+    <string name="bluetooth_timeout_summary_2hours">2 hours</string>
+    <string name="bluetooth_timeout_summary_4hours">4 hours</string>
+    <string name="bluetooth_timeout_summary_8hours">8 hours</string>
+
     <!-- QS battery -->
     <string name="qs_battery_location_title">Battery location</string>
     <string name="qs_battery_location_qs_panel">QS Panel</string>

--- a/res/xml/connected_devices.xml
+++ b/res/xml/connected_devices.xml
@@ -56,6 +56,14 @@
         settings:useAdminDisabledSummary="true"
         settings:controller="com.android.settings.connecteddevice.AddDevicePreferenceController"/>
 
+    <androidx.preference.ListPreference
+        android:key="bluetooth_timeout"
+        android:title="@string/bluetooth_timeout"
+        android:summary="@string/summary_placeholder"
+        android:entries="@array/bluetooth_timeout_entries"
+        android:entryValues="@array/bluetooth_timeout_values"
+        settings:controller="com.android.settings.bluetooth.BluetoothTimeoutPreferenceController"/>
+
     <PreferenceCategory
         android:key="previously_connected_devices"
         android:title="@string/connected_device_previously_connected_title"

--- a/src/com/android/settings/bluetooth/BluetoothTimeoutPreferenceController.java
+++ b/src/com/android/settings/bluetooth/BluetoothTimeoutPreferenceController.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2020 The Calyx Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.bluetooth;
+
+import android.bluetooth.BluetoothAdapter;
+import android.content.Context;
+import android.provider.Settings;
+import android.util.Log;
+
+import androidx.preference.ListPreference;
+import androidx.preference.Preference;
+
+import com.android.settings.R;
+import com.android.settings.core.BasePreferenceController;
+import com.android.settings.core.PreferenceControllerMixin;
+
+public class BluetoothTimeoutPreferenceController extends BasePreferenceController implements
+        PreferenceControllerMixin, Preference.OnPreferenceChangeListener {
+    private static final String TAG = "BluetoothTimeoutPrefCtrl";
+
+    public static final int FALLBACK_BLUETOOTH_TIMEOUT_VALUE = 0;
+
+    private final String mBluetoothTimeoutKey;
+
+    protected BluetoothAdapter mBluetoothAdapter;
+
+    public BluetoothTimeoutPreferenceController(Context context, String key) {
+        super(context, key);
+        mBluetoothTimeoutKey = key;
+
+        mBluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
+        if (mBluetoothAdapter == null) {
+            Log.e(TAG, "Bluetooth is not supported on this device");
+            return;
+        }
+    }
+
+    @Override
+    public int getAvailabilityStatus() {
+        return mBluetoothAdapter != null ? AVAILABLE : UNSUPPORTED_ON_DEVICE;
+    }
+
+    @Override
+    public String getPreferenceKey() {
+        return mBluetoothTimeoutKey;
+    }
+
+    @Override
+    public void updateState(Preference preference) {
+        final ListPreference timeoutListPreference = (ListPreference) preference;
+        final long currentTimeout = Settings.Global.getLong(mContext.getContentResolver(),
+                Settings.Global.BLUETOOTH_OFF_TIMEOUT, FALLBACK_BLUETOOTH_TIMEOUT_VALUE);
+        timeoutListPreference.setValue(String.valueOf(currentTimeout));
+        updateTimeoutPreferenceDescription(timeoutListPreference,
+                Long.parseLong(timeoutListPreference.getValue()));
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object newValue) {
+        try {
+            int value = Integer.parseInt((String) newValue);
+            Settings.Global.putInt(mContext.getContentResolver(), Settings.Global.BLUETOOTH_OFF_TIMEOUT, value);
+            updateTimeoutPreferenceDescription((ListPreference) preference, value);
+        } catch (NumberFormatException e) {
+            Log.e(TAG, "could not persist bluetooth timeout setting", e);
+        }
+        return true;
+    }
+
+    public static CharSequence getTimeoutDescription(
+            long currentTimeout, CharSequence[] entries, CharSequence[] values) {
+        if (currentTimeout < 0 || entries == null || values == null
+                || values.length != entries.length) {
+            return null;
+        }
+
+        for (int i = 0; i < values.length; i++) {
+            long timeout = Long.parseLong(values[i].toString());
+            if (currentTimeout == timeout) {
+                return entries[i];
+            }
+        }
+        return null;
+    }
+
+    private void updateTimeoutPreferenceDescription(ListPreference preference,
+                                                    long currentTimeout) {
+        final CharSequence[] entries = preference.getEntries();
+        final CharSequence[] values = preference.getEntryValues();
+        final CharSequence timeoutDescription = getTimeoutDescription(
+                currentTimeout, entries, values);
+        String summary = "";
+        if (timeoutDescription != null) {
+            if (currentTimeout != 0)
+                summary = mContext.getString(R.string.bluetooth_timeout_summary, timeoutDescription);
+            else
+                summary = mContext.getString(R.string.bluetooth_timeout_summary2);
+        }
+        preference.setSummary(summary);
+    }
+}


### PR DESCRIPTION
This feature has been tested on resurrection remix 8.6.7 fajita and enchilada for a week, there were no issues since the first test.

Original:
https://review.calyxos.org/c/CalyxOS/platform_packages_apps_Settings/+/145