### PR TITLE
fix typo for left_learn_layout

### DIFF
--- a/res/values/rr_strings.xml
+++ b/res/values/rr_strings.xml
@@ -480,7 +480,7 @@
     <string name="connected_devices_category_title">Connected Devices</string>
     <string name="normal_layout">Normal</string>
     <string name="compact_layout">Compact</string>
-    <string name="left_learn_layout">Left-learing</string>
+    <string name="left_learn_layout">Left-learning</string>
     <string name="right_learn_layout">Right-learning</string>
 
    <!--RR Configurations Summaries-->


### PR DESCRIPTION
missing "n"
Left-learing->Left-learning

Typo found by "tigaSAING | 6" 