### PR TITLE
add back onclite to official list and update the maintainer.

### DIFF
--- a/res/values/resurrection_device_maintainers_strings.xml
+++ b/res/values/resurrection_device_maintainers_strings.xml
@@ -913,7 +913,7 @@
  
   <string name="device_onclite" translatable="false">Redmi 7</string>
   <string name="device_onclite_codename" translatable="false">onclite</string>
-  <string name="device_onclite_maintainer" translatable="false">Revanth_24</string>
+  <string name="device_onclite_maintainer" translatable="false">Hadad</string>
 
   <string name="device_phoenix" translatable="false">Redmi K30/Poco X2</string>
   <string name="device_phoenix_codename" translatable="false">phoenix</string>


### PR DESCRIPTION
Device tree: https://github.com/hadad/device_xiaomi_onclite
Vendor blobs: https://github.com/hadad/vendor_xiaomi_onclite
Kernel sources: https://github.com/hadad/android_kernel_xiaomi_onc/tree/ten

XDA Thread: https://forum.xda-developers.com/t/rom-10-resurrection-remix-onc-unofficial.4297725/
Telegram: https://t.me/hdrjt

Thanks to @ Dhina17 for LineageOS based trees
Thanks to @ crevanth for previous RR official maintainer.